### PR TITLE
ci: Only deploy Linux container images on main project

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,7 @@ jobs:
           environment: ${{ matrix.environment }}
           image-tag: ${{ matrix.image-tag }}
           cuda-version: ${{ matrix.cuda-version || '' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # Only deploy on the main project
+          push: ${{ github.event_name != 'pull_request' && github.repository == 'rkhashmani/stellaforge' }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* To avoid deploying Linux container builds to the container registry of every fork restrict deployment to the main project.
   - Amends PR https://github.com/RKHashmani/StellaForge/pull/9

---

Aside / reminder: Note that the CI doesn't run on this PR given that these changes don't touch any of the following files: 

https://github.com/RKHashmani/StellaForge/blob/c98fbf6e9348b9086ae0b262af2c9673f91df9aa/.github/workflows/docker.yml#L14-L19