### PR TITLE
fix: Update naming schema to support alternative solvers

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -3,10 +3,10 @@ description: Build and optionally push a Docker image for a Pixi environment
 
 inputs:
   environment:
-    description: Pixi environment name (e.g., stage-1, stage-1-gpu)
+    description: Pixi environment name (e.g., stage-1-vmec, stage-1-vmec-gpu)
     required: true
   image-tag:
-    description: Docker image tag suffix (e.g., stage-1-cpu, stage-1-gpu)
+    description: Docker image tag suffix (e.g., stage-1-vmec-cpu, stage-1-vmec-gpu)
     required: true
   cuda-version:
     description: CUDA version for GPU builds (leave empty for CPU builds)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,36 +39,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # stage-1
-          - environment: stage-1
-            image-tag: stage-1-cpu
-          - environment: stage-1-gpu
+          # Stage 1: Equilibrium
+          - environment: stage-1-vmec
+            image-tag: stage-1-vmec-cpu
+          - environment: stage-1-vmec-gpu
             cuda-version: "12"
-            image-tag: stage-1-gpu
-          # stage-2
-          - environment: stage-2
-            image-tag: stage-2-cpu
-          - environment: stage-2-gpu
+            image-tag: stage-1-vmec-gpu
+          # Stage 2: Boozer Transform
+          - environment: stage-2-booz
+            image-tag: stage-2-booz-cpu
+          - environment: stage-2-booz-gpu
             cuda-version: "12"
-            image-tag: stage-2-gpu
-          # stage-3
-          - environment: stage-3
-            image-tag: stage-3-cpu
-          - environment: stage-3-gpu
+            image-tag: stage-2-booz-gpu
+          # Stage 3: Neoclassical Transport
+          - environment: stage-3-sfincs
+            image-tag: stage-3-sfincs-cpu
+          - environment: stage-3-sfincs-gpu
             cuda-version: "12"
-            image-tag: stage-3-gpu
-          # stage-4
-          - environment: stage-4
-            image-tag: stage-4-cpu
-          - environment: stage-4-gpu
+            image-tag: stage-3-sfincs-gpu
+          # Stage 4: Turbulence
+          - environment: stage-4-spectrax
+            image-tag: stage-4-spectrax-cpu
+          - environment: stage-4-spectrax-gpu
             cuda-version: "12"
-            image-tag: stage-4-gpu
-          # stage-5
-          - environment: stage-5
-            image-tag: stage-5-cpu
-          - environment: stage-5-gpu
+            image-tag: stage-4-spectrax-gpu
+          # Stage 5: Transport
+          - environment: stage-5-neopax
+            image-tag: stage-5-neopax-cpu
+          - environment: stage-5-neopax-gpu
             cuda-version: "12"
-            image-tag: stage-5-gpu
+            image-tag: stage-5-neopax-gpu
 
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Forward-pass chain: `vmec_jax` -> `booz_xform_jax` -> (`sfincs_jax` / `monkes`) 
 ### Naming Conventions
 
 - Stage directories: `stage{N}-{name}` (e.g., `stage1-equilibrium`)
-- Container images: `ghcr.io/rkhashmani/stellaforge:stage-{N}-cpu` / `stage-{N}-gpu` (on GHCR)
+- Container images: `ghcr.io/rkhashmani/stellaforge:stage-{N}-{code}-cpu` / `stage-{N}-{code}-gpu` (e.g., `stage-1-vmec-cpu`) (on GHCR)
 - W&B projects: `stellaforge-stage{N}-{name}`
 - Output directories: `{run_dir}/stage{N}_{name}/`
 - Test files: mirror source structure in `tests/`
@@ -225,7 +225,7 @@ Snakemake rules define which files connect which stages. Each stage's `spec.md` 
 **StellaForge container architecture** (see `docs/guide.md#container-architecture` for full details):
 - All dependencies are managed through Pixi (e.g., `mvp/pixi.toml` + `mvp/pixi.lock`).
 - A single templated Dockerfile (e.g., `mvp/Dockerfile`) builds all stages using `ghcr.io/prefix-dev/pixi:noble` as the base image. Build arguments (`ENVIRONMENT`, `CUDA_VERSION`) select the target stage and GPU support.
-- Container images are published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-{N}-cpu` / `stage-{N}-gpu`. CI builds all stage variants from the single Dockerfile using a GitHub Actions matrix.
+- Container images are published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-{N}-{code}-cpu` / `stage-{N}-{code}-gpu` (e.g., `stage-1-vmec-cpu`). CI builds all stage variants from the single Dockerfile using a GitHub Actions matrix.
 - Source-built upstream packages are pinned to exact git commit SHAs in `pixi.toml`.
 
 ### Performance & Memory Management

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ git clone https://github.com/RKHashmani/StellaForge.git
 cd StellaForge
 git submodule update --init --recursive
 snakemake --sdm docker --configfile config.yaml
-docker pull ghcr.io/rkhashmani/stellaforge:stage-1-cpu
+docker pull ghcr.io/rkhashmani/stellaforge:stage-1-vmec-cpu
 -->
 
 ## License

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -161,15 +161,15 @@ After Phase 1 is complete for a stage, move to containerization and testing.
 
 StellaForge is a **recipe repo**: it contains everything needed to build and run the containerized pipeline, but does not contain the upstream solver code itself.
 
-**Pixi-based environments.** Dependencies are managed through `pixi.toml` files, e.g., `mvp/pixi.toml` and locked in `pixi.lock` files, e.g., `mvp/pixi.lock`. Stages with Pixi environments defined have named environments (e.g., `stage-1`, `stage-1-gpu`) that fully specify the dependency stack.
+**Pixi-based environments.** Dependencies are managed through `pixi.toml` files, e.g., `mvp/pixi.toml` and locked in `pixi.lock` files, e.g., `mvp/pixi.lock`. Stages with Pixi environments defined have named environments (e.g., `stage-1-vmec`, `stage-1-vmec-gpu`) that fully specify the dependency stack.
 
 **Single templated Dockerfile.** There is one shared `Dockerfile`, e.g. `mvp/Dockerfile` that uses build arguments to select the target environment at build time:
-- `ENVIRONMENT` -- the Pixi environment name (e.g., `stage-1`, `stage-2-gpu`). Must be passed explicitly when building locally: `docker build --build-arg ENVIRONMENT=stage-1 mvp/`
+- `ENVIRONMENT` -- the Pixi environment name (e.g., `stage-1-vmec`, `stage-2-booz-gpu`). Must be passed explicitly when building locally: `docker build --build-arg ENVIRONMENT=stage-1-vmec mvp/`
 - `CUDA_VERSION` -- set for GPU builds (e.g., `12`), left empty for CPU builds
 
 The Dockerfile uses a multi-stage build on a `ghcr.io/prefix-dev/pixi:noble` base image. See `mvp/Dockerfile` for implementation details.
 
-**Container images** are published to GHCR at `ghcr.io/rkhashmani/stellaforge`. For MVP, the tags follow the pattern `stage-{N}-cpu` / `stage-{N}-gpu` (e.g., `stage-1-cpu`). CI builds all stage variants from the single Dockerfile using a GitHub Actions matrix. See `.github/workflows/docker.yml` and `.github/actions/build-docker/action.yml` for the CI setup.
+**Container images** are published to GHCR at `ghcr.io/rkhashmani/stellaforge`. For MVP, the tags follow the pattern `stage-{N}-{code}-cpu` / `stage-{N}-{code}-gpu` (e.g., `stage-1-vmec-cpu`). CI builds all stage variants from the single Dockerfile using a GitHub Actions matrix. See `.github/workflows/docker.yml` and `.github/actions/build-docker/action.yml` for the CI setup.
 
 **Adding or updating a dependency:**
 1. Update the relevant `pixi.toml` (add/change the dependency or git rev)

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -70,13 +70,13 @@ Each `input/` directory contains config files for that code. Each `expected_outp
 From inside the `mvp/` directory
 
 ```
-pixi install --environment stage-1
+pixi install --environment stage-1-vmec
 ```
 
 ### How to Run
 
 ```
-pixi run stage-1-equilibrium
+pixi run stage-1-vmec
 ```
 
 ---
@@ -96,13 +96,13 @@ pixi run stage-1-equilibrium
 ### How to Install
 
 ```
-pixi install --environment stage-2
+pixi install --environment stage-2-booz
 ```
 
 ### How to Run
 
 ```
-pixi run stage-2-boozer
+pixi run stage-2-booz
 ```
 
 which is morally similar to
@@ -133,7 +133,7 @@ b.write_boozmn("boozmn_HSX_QHS_vacuum_ns201.nc")
 #### How to Install
 
 ```
-pixi install --environment stage-3
+pixi install --environment stage-3-sfincs
 ```
 
 #### How to Run
@@ -141,7 +141,7 @@ pixi install --environment stage-3
 **After** manually editing the value of `equilibriumFile` in `mvp/stage3-neoclassical/sfincs_jax/input/input.HSX_QHS_vacuum_ns201`, run
 
 ```
-pixi run stage-3-neoclassical
+pixi run stage-3-sfincs
 ```
 
 
@@ -188,13 +188,13 @@ We basically call it inside a python loop to use Monkes to generate a database a
 ### How to Install
 
 ```
-pixi install --environment stage-4
+pixi install --environment stage-4-spectrax
 ```
 
 ### How to Run
 
 ```
-pixi run stage-4-turbulence
+pixi run stage-4-spectrax
 ```
 
 which executes something morally equivalent to
@@ -221,7 +221,7 @@ spectrax-gk run --config runtime_hsx_nonlinear_vmec_geometry.toml --out tools_ou
 ### How to Install
 
 ```
-pixi install --environment stage-5
+pixi install --environment stage-5-neopax
 ```
 
 ### How to Run

--- a/docs/stage1-equilibrium/spec.md
+++ b/docs/stage1-equilibrium/spec.md
@@ -35,7 +35,7 @@ Reference: `stellarator_workflow/stellarator_workflow.tex`, Section 4.1 (`VMEC++
 **`vmec_jax`:** Install via the Pixi environment. From inside `mvp/`:
 
 ```
-pixi install --environment stage-1
+pixi install --environment stage-1-vmec
 ```
 
 See `docs/mvp-pipeline.md` for run commands and I/O details.
@@ -212,7 +212,7 @@ Reference: `stellarator_workflow.tex`, Sections 4.1-4.2.
 **`vmec_jax` (via Pixi):** From inside `mvp/`:
 
 ```
-pixi run stage-1-equilibrium
+pixi run stage-1-vmec
 ```
 
 **Input:** `mvp/stage1-equilibrium/vmec_jax/input/input.HSX_QHS_vacuum_ns201`
@@ -239,11 +239,11 @@ See `docs/mvp-pipeline.md` for full I/O details.
 **`vmec_jax`:** Built from the single templated `mvp/Dockerfile` using a build process morally equivalent to:
 
 ```
-docker build --file mvp/Dockerfile --build-arg ENVIRONMENT=stage-1 --platform linux/amd64 --tag ghcr.io/rkhashmani/stellaforge:stage-1-cpu mvp/  # CPU
-docker build --file mvp/Dockerfile --build-arg CUDA_VERSION=12 --build-arg ENVIRONMENT=stage-1-gpu --platform linux/amd64 --tag ghcr.io/rkhashmani/stellaforge:stage-1-gpu mvp/  # GPU
+docker build --file mvp/Dockerfile --build-arg ENVIRONMENT=stage-1-vmec --platform linux/amd64 --tag ghcr.io/rkhashmani/stellaforge:stage-1-vmec-cpu mvp/  # CPU
+docker build --file mvp/Dockerfile --build-arg CUDA_VERSION=12 --build-arg ENVIRONMENT=stage-1-vmec-gpu --platform linux/amd64 --tag ghcr.io/rkhashmani/stellaforge:stage-1-vmec-gpu mvp/  # GPU
 ```
 
-Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-1-cpu` and `stage-1-gpu`. CI builds via `.github/workflows/docker.yml`.
+Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-1-vmec-cpu` and `stage-1-vmec-gpu`. CI builds via `.github/workflows/docker.yml`.
 
 See [guide](../guide.md#container-architecture) for full architecture details.
 

--- a/docs/stage2-boozer/spec.md
+++ b/docs/stage2-boozer/spec.md
@@ -29,7 +29,7 @@ Transforms a VMEC-style equilibrium into Boozer coordinates. Boozer coordinates 
 **`booz_xform_jax`:** Install via the Pixi environment. From inside `mvp/`:
 
 ```
-pixi install --environment stage-2
+pixi install --environment stage-2-booz
 ```
 
 See `docs/mvp-pipeline.md` for run commands and I/O details.
@@ -149,7 +149,7 @@ where $w$ is reconstructed from the original covariant field harmonics.
 **`booz_xform_jax` (via Pixi):** From inside `mvp/`:
 
 ```
-pixi run stage-2-boozer
+pixi run stage-2-booz
 ```
 
 **Input:** `mvp/stage1-equilibrium/vmec_jax/expected_output/wout_HSX_QHS_vacuum_ns201.nc` (from Stage 1)
@@ -176,11 +176,11 @@ See `docs/mvp-pipeline.md` for full I/O details.
 **`booz_xform_jax`:** Built from the single templated `mvp/Dockerfile` using build arguments:
 
 ```
-docker build --build-arg ENVIRONMENT=stage-2 mvp/        # CPU
-docker build --build-arg ENVIRONMENT=stage-2-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
+docker build --build-arg ENVIRONMENT=stage-2-booz mvp/        # CPU
+docker build --build-arg ENVIRONMENT=stage-2-booz-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
 ```
 
-Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-2-cpu` and `stage-2-gpu`. CI builds via `.github/workflows/docker.yml`.
+Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-2-booz-cpu` and `stage-2-booz-gpu`. CI builds via `.github/workflows/docker.yml`.
 
 See [guide](../guide.md#container-architecture) for full architecture details.
 

--- a/docs/stage3-neoclassical/spec.md
+++ b/docs/stage3-neoclassical/spec.md
@@ -232,7 +232,7 @@ $$D_{ij} = \begin{pmatrix} D_{11} & D_{12} & D_{13} \\ D_{21} & D_{22} & D_{23} 
 **`sfincs_jax`:** Install via the Pixi environment. From inside `mvp/`:
 
 ```
-pixi install --environment stage-3
+pixi install --environment stage-3-sfincs
 ```
 
 See `docs/mvp-pipeline.md` for run commands and I/O details.
@@ -271,7 +271,7 @@ pip install .
 After editing `equilibriumFile` in `mvp/stage3-neoclassical/sfincs_jax/input/input.HSX_QHS_vacuum_ns201` to point to the Stage 1 output:
 
 ```
-pixi run stage-3-neoclassical
+pixi run stage-3-sfincs
 ```
 
 **Input:** `mvp/stage1-equilibrium/vmec_jax/expected_output/wout_HSX_QHS_vacuum_ns201.nc` + `mvp/stage3-neoclassical/sfincs_jax/input/input.HSX_QHS_vacuum_ns201`
@@ -303,11 +303,11 @@ See `docs/mvp-pipeline.md` for full I/O details.
 **`sfincs_jax`:** Built from the single templated `mvp/Dockerfile` using build arguments:
 
 ```
-docker build --build-arg ENVIRONMENT=stage-3 mvp/        # CPU
-docker build --build-arg ENVIRONMENT=stage-3-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
+docker build --build-arg ENVIRONMENT=stage-3-sfincs mvp/        # CPU
+docker build --build-arg ENVIRONMENT=stage-3-sfincs-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
 ```
 
-Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-3-cpu` and `stage-3-gpu`. CI builds via `.github/workflows/docker.yml`.
+Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-3-sfincs-cpu` and `stage-3-sfincs-gpu`. CI builds via `.github/workflows/docker.yml`.
 
 See [guide](../guide.md#container-architecture) for full architecture details.
 

--- a/docs/stage4-turbulence/spec.md
+++ b/docs/stage4-turbulence/spec.md
@@ -36,7 +36,7 @@ Reference: `stellarator_workflow.tex`, Section 4.7; `stellarator_io_reference.te
 **`SPECTRAX-GK`:** Install via the Pixi environment. From inside `mvp/`:
 
 ```
-pixi install --environment stage-4
+pixi install --environment stage-4-spectrax
 ```
 
 See `docs/mvp-pipeline.md` for run commands and I/O details.
@@ -181,7 +181,7 @@ Reference: `stellarator_workflow.tex`, Section 4.7.
 **`SPECTRAX-GK` (via Pixi):** From inside `mvp/`:
 
 ```
-pixi run stage-4-turbulence
+pixi run stage-4-spectrax
 ```
 
 which executes something morally equivalent to:
@@ -217,11 +217,11 @@ See `docs/mvp-pipeline.md` for full I/O details.
 **`SPECTRAX-GK`:** Built from the single templated `mvp/Dockerfile` using build arguments:
 
 ```
-docker build --build-arg ENVIRONMENT=stage-4 mvp/        # CPU
-docker build --build-arg ENVIRONMENT=stage-4-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
+docker build --build-arg ENVIRONMENT=stage-4-spectrax mvp/        # CPU
+docker build --build-arg ENVIRONMENT=stage-4-spectrax-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
 ```
 
-Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-4-cpu` and `stage-4-gpu`. CI builds via `.github/workflows/docker.yml`.
+Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-4-spectrax-cpu` and `stage-4-spectrax-gpu`. CI builds via `.github/workflows/docker.yml`.
 
 See [guide](../guide.md#container-architecture) for full architecture details.
 

--- a/docs/stage5-transport/spec.md
+++ b/docs/stage5-transport/spec.md
@@ -55,7 +55,7 @@ Reference: `stellarator_workflow.tex`, Sections 4.8--4.9;
 **`NEOPAX`:** Install via the Pixi environment. From inside `mvp/`:
 
 ```
-pixi install --environment stage-5
+pixi install --environment stage-5-neopax
 ```
 
 See `docs/mvp-pipeline.md` for run commands and I/O details.
@@ -312,11 +312,11 @@ See `docs/mvp-pipeline.md` for full I/O details.
 **`NEOPAX`:** Built from the single templated `mvp/Dockerfile` using build arguments:
 
 ```
-docker build --build-arg ENVIRONMENT=stage-5 mvp/        # CPU
-docker build --build-arg ENVIRONMENT=stage-5-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
+docker build --build-arg ENVIRONMENT=stage-5-neopax mvp/        # CPU
+docker build --build-arg ENVIRONMENT=stage-5-neopax-gpu --build-arg CUDA_VERSION=12 mvp/  # GPU
 ```
 
-Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-5-cpu` and `stage-5-gpu`. CI builds via `.github/workflows/docker.yml`.
+Published to GHCR as `ghcr.io/rkhashmani/stellaforge:stage-5-neopax-cpu` and `stage-5-neopax-gpu`. CI builds via `.github/workflows/docker.yml`.
 
 See [guide](../guide.md#container-architecture) for full architecture details.
 

--- a/mvp/pixi.lock
+++ b/mvp/pixi.lock
@@ -6,7 +6,7 @@ environments:
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages: {}
-  stage-1:
+  stage-1-vmec:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -35,7 +35,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -72,7 +72,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
@@ -121,7 +121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -178,7 +178,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
-  stage-1-gpu:
+  stage-1-vmec-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -222,7 +222,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -272,7 +272,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
@@ -301,7 +301,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
-  stage-2:
+  stage-2-booz:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -350,7 +350,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -413,7 +413,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
@@ -441,12 +441,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py314h8ec4b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
@@ -517,7 +517,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -580,7 +580,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py314hab283cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -604,7 +604,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: git+https://github.com/uwplasma/booz_xform_jax.git?rev=1f206597f2f28436e0e2124160c13de9ae63b2ea#1f206597f2f28436e0e2124160c13de9ae63b2ea
-  stage-2-gpu:
+  stage-2-booz-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -668,7 +668,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -744,7 +744,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
@@ -773,12 +773,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py314h8ec4b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
@@ -822,7 +822,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: git+https://github.com/uwplasma/booz_xform_jax.git?rev=1f206597f2f28436e0e2124160c13de9ae63b2ea#1f206597f2f28436e0e2124160c13de9ae63b2ea
-  stage-3:
+  stage-3-sfincs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -848,7 +848,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -881,7 +881,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py314h6477eea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
@@ -919,7 +919,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -965,7 +965,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: git+https://github.com/uwplasma/sfincs_jax?rev=de50abd2ee9063176728805288e8bafe8e83cbc3#de50abd2ee9063176728805288e8bafe8e83cbc3
-  stage-3-gpu:
+  stage-3-sfincs-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -1006,7 +1006,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.9.1-pyhd8ed1ab_0.conda
@@ -1052,7 +1052,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py314h6477eea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.29.3.1-h4d09622_0.conda
@@ -1073,7 +1073,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: git+https://github.com/uwplasma/sfincs_jax?rev=de50abd2ee9063176728805288e8bafe8e83cbc3#de50abd2ee9063176728805288e8bafe8e83cbc3
-  stage-4:
+  stage-4-spectrax:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -1123,7 +1123,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.8.2-pyhd8ed1ab_0.conda
@@ -1296,7 +1296,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.8.2-pyhd8ed1ab_0.conda
@@ -1390,7 +1390,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: git+https://github.com/uwplasma/booz_xform_jax.git?rev=1f206597f2f28436e0e2124160c13de9ae63b2ea#1f206597f2f28436e0e2124160c13de9ae63b2ea
       - pypi: git+https://github.com/uwplasma/SPECTRAX-GK.git?rev=61aac059166e30f937fa0ad6163b4d857c132622#61aac059166e30f937fa0ad6163b4d857c132622
-  stage-4-gpu:
+  stage-4-spectrax-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -1455,7 +1455,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.8.2-pyhd8ed1ab_0.conda
@@ -1614,7 +1614,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: git+https://github.com/uwplasma/booz_xform_jax.git?rev=1f206597f2f28436e0e2124160c13de9ae63b2ea#1f206597f2f28436e0e2124160c13de9ae63b2ea
       - pypi: git+https://github.com/uwplasma/SPECTRAX-GK.git?rev=61aac059166e30f937fa0ad6163b4d857c132622#61aac059166e30f937fa0ad6163b4d857c132622
-  stage-5:
+  stage-5-neopax:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -1668,7 +1668,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/interpax-0.3.13-pyhd8ed1ab_0.conda
@@ -1883,7 +1883,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/interpax-0.3.13-pyhd8ed1ab_0.conda
@@ -2013,7 +2013,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl
-  stage-5-gpu:
+  stage-5-neopax-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
@@ -2082,7 +2082,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/interpax-0.3.13-pyhd8ed1ab_0.conda
@@ -2863,7 +2863,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=hash-mapping
+  - pkg:pypi/certifi?source=compressed-mapping
   size: 151445
   timestamp: 1772001170301
 - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -3680,9 +3680,9 @@ packages:
   purls: []
   size: 762257
   timestamp: 1695661864625
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_103.conda
-  sha256: 79c3592e00ce9974e3d08e4bd28bfbe9f86c03064880efe3cfcff807a633abd1
-  md5: dcb50cd5fed839129afb25f1061f6b7f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+  sha256: c6ff674a4a5a237fcf748fed8f64e79df54b42189986e705f35ba64dc6603235
+  md5: 1d92558abd05cea0577f83a5eca38733
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-c-auth >=0.10.1,<0.10.2.0a0
@@ -3702,11 +3702,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 4408274
-  timestamp: 1774661981887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_103.conda
-  sha256: f236f50377869ba9561e4f50df6240f544d2755b7c7b5867a9b99d41f814e5da
-  md5: 03316cdd768f449e9293d4284a13adb3
+  size: 4138489
+  timestamp: 1775243967708
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
+  sha256: 5b96accf983be97718fbfaddd6706591d7ef6511b4ccdac8a09f6b9899d1b284
+  md5: e5390fd4a3b964a3ed619480df918294
   depends:
   - __osx >=11.0
   - aws-c-auth >=0.10.1,<0.10.2.0a0
@@ -3725,8 +3725,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3418107
-  timestamp: 1774662175390
+  size: 3418702
+  timestamp: 1775244340092
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -5646,17 +5646,6 @@ packages:
   purls: []
   size: 373892
   timestamp: 1762022345545
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
-  sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
-  md5: db409b7c1720428638e7c0d509d3e1b5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 40311
-  timestamp: 1766271528534
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
   sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
   md5: 38ffe67b78c9d4de527be8315e5ada2c
@@ -5914,6 +5903,7 @@ packages:
   - intel-openmp <0.0a0
   - openmp 22.1.2|22.1.2.*
   license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
   purls: []
   size: 285695
   timestamp: 1774733561929
@@ -6137,7 +6127,7 @@ packages:
   timestamp: 1738196177597
 - pypi: git+https://github.com/uwplasma/NEOPAX.git?rev=5ec4cc3c5583121c5c454358defa7ab1af40c211#5ec4cc3c5583121c5c454358defa7ab1af40c211
   name: neopax
-  version: 0.1.dev53+g5ec4cc3c5.d20260403
+  version: 0.1.dev53+g5ec4cc3c5.d20260404
   requires_dist:
   - jax
   - jaxlib
@@ -6246,7 +6236,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=hash-mapping
+  - pkg:pypi/numpy?source=compressed-mapping
   size: 8927860
   timestamp: 1773839233468
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.3.5-py314hae46ccb_1.conda
@@ -6429,7 +6419,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/packaging?source=hash-mapping
+  - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
@@ -6445,29 +6435,6 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
-  sha256: 9e6ec8f3213e8b7d64b0ad45f84c51a2c9eba4398efda31e196c9a56186133ee
-  md5: 79678378ae235e24b3aa83cee1b38207
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - python_abi 3.14.* *_cp314
-  - tk >=8.6.13,<8.7.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - lcms2 >=2.18,<3.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  license: HPND
-  purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 1073026
-  timestamp: 1770794002408
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py314h8ec4b1a_0.conda
   sha256: 123d8a7c16c88658b4f29e9f115a047598c941708dade74fbaff373a32dbec5e
   md5: 76c4757c0ec9d11f969e8eb44899307b
@@ -6491,29 +6458,6 @@ packages:
   - pkg:pypi/pillow?source=compressed-mapping
   size: 1082797
   timestamp: 1775060059882
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
-  sha256: 1659ff6e8ea6170a90fb8eb7291990d12bba270aab18176defa0717ed34ce186
-  md5: bcb38a8005e93a3b240a0dbcf28df87a
-  depends:
-  - python
-  - python 3.14.* *_cp314
-  - __osx >=11.0
-  - libxcb >=1.17.0,<2.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - python_abi 3.14.* *_cp314
-  - lcms2 >=2.18,<3.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  license: HPND
-  purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 996187
-  timestamp: 1770794152243
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py314hab283cf_0.conda
   sha256: 3d8a86c8cf69ea4bdfeaa3e89e7218bcdc1522e58c9c6298263bfede8ab48cee
   md5: adf49537da0e0c34cf735e71fe579506
@@ -6697,32 +6641,6 @@ packages:
   - pkg:pypi/pyparsing?source=hash-mapping
   size: 110893
   timestamp: 1769003998136
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_0.conda
-  sha256: c73a46d100f29d058d941304fa7454edfafe9a1bb09ed3cada061260b135e0b2
-  md5: 1bd12dc69c3632f1d7ee9fbfd68c0186
-  depends:
-  - python
-  - qt6-main 6.11.0.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - qt6-main >=6.11.0,<6.12.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libopengl >=1.7.0,<2.0a0
-  - libclang13 >=21.1.8
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - python_abi 3.14.* *_cp314
-  - libxslt >=1.1.43,<2.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libgl >=1.7.0,<2.0a0
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls:
-  - pkg:pypi/pyside6?source=hash-mapping
-  - pkg:pypi/shiboken6?source=hash-mapping
-  size: 13209437
-  timestamp: 1774714568851
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_1.conda
   sha256: 70e2bedac4505bacf317371406c3246023536ec2337a8eb2310dab5afa90dbad
   md5: 5abdb958cf8cc0b43cf078d0559f7969
@@ -6743,6 +6661,7 @@ packages:
   - libvulkan-loader >=1.4.341.0,<2.0a0
   - qt6-main >=6.11.0,<6.12.0a0
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=compressed-mapping
   size: 13209677
@@ -7066,7 +6985,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=hash-mapping
+  - pkg:pypi/scipy?source=compressed-mapping
   size: 13986990
   timestamp: 1771881110844
 - pypi: git+https://github.com/uwplasma/sfincs_jax?rev=de50abd2ee9063176728805288e8bafe8e83cbc3#de50abd2ee9063176728805288e8bafe8e83cbc3
@@ -7200,7 +7119,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=hash-mapping
+  - pkg:pypi/tornado?source=compressed-mapping
   size: 910845
   timestamp: 1774358965067
 - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
@@ -7229,7 +7148,7 @@ packages:
   - python
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=hash-mapping
+  - pkg:pypi/tqdm?source=compressed-mapping
   size: 94132
   timestamp: 1770153424136
 - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl

--- a/mvp/pixi.toml
+++ b/mvp/pixi.toml
@@ -9,8 +9,6 @@ depends-on = [ "stage-1-vmec", "stage-2-booz", "stage-3-sfincs"]
 
 [dependencies]
 
-# --- Stage 1: Equilibrium ---
-
 [feature.vmec-jax.dependencies]
 numpy = ">=2.4.3,<3"
 jax = ">=0.9.1,<0.10"
@@ -21,8 +19,6 @@ vmec-jax = { git = "https://github.com/uwplasma/vmec_jax", rev = "cfdf674b0ca213
 
 [feature.vmec-jax.tasks.stage-1-vmec]
 cmd = "vmec_jax stage1-equilibrium/vmec_jax/input/input.HSX_QHS_vacuum_ns201"
-
-# --- Stage 2: Boozer Transform ---
 
 [feature.booz-xform-jax.dependencies]
 numpy = ">=2.4.3,<3"
@@ -38,8 +34,6 @@ booz-xform-jax = { git = "https://github.com/uwplasma/booz_xform_jax.git", rev =
 [feature.booz-xform-jax.tasks.stage-2-booz]
 cmd = "python stage2-boozer/example.py"
 
-# --- Stage 3: Neoclassical Transport ---
-
 [feature.sfincs-jax.dependencies]
 numpy = ">=2.4.3,<3"
 scipy = ">=1.17.1,<2"
@@ -51,8 +45,6 @@ sfincs-jax = { git = "https://github.com/uwplasma/sfincs_jax", rev = "de50abd2ee
 
 [feature.sfincs-jax.tasks.stage-3-sfincs]
 cmd = "sfincs_jax stage3-neoclassical/sfincs_jax/input/input.HSX_QHS_vacuum_ns201"
-
-# --- Stage 4: Turbulence ---
 
 [feature.spectrax-gk.dependencies]
 numpy = ">=2.3,<2.4"
@@ -71,8 +63,6 @@ booz-xform-jax = { git = "https://github.com/uwplasma/booz_xform_jax.git", rev =
 
 [feature.spectrax-gk.tasks.stage-4-spectrax]
 cmd = "spectrax-gk run --config ./stage4-turbulence/spectrax_gk/input/runtime_hsx_nonlinear_vmec_geometry.toml --out stage4-turbulence/spectrax_gk/tools_out/hsx_run"
-
-# --- Stage 5: Transport ---
 
 [feature.neopax.dependencies]
 scipy = ">=1.17.1,<2"
@@ -97,18 +87,13 @@ platforms = ["linux-64"]
 cuda = "12"
 
 [environments]
-# Stage 1: Equilibrium
 stage-1-vmec = {features = ["vmec-jax"], no-default-feature = true }
 stage-1-vmec-gpu = {features = ["vmec-jax", "cuda"], no-default-feature = true }
-# Stage 2: Boozer Transform
 stage-2-booz = {features = ["booz-xform-jax"], no-default-feature = true }
 stage-2-booz-gpu = {features = ["booz-xform-jax", "cuda"], no-default-feature = true }
-# Stage 3: Neoclassical Transport
 stage-3-sfincs = {features = ["sfincs-jax"], no-default-feature = true}
 stage-3-sfincs-gpu = {features = ["sfincs-jax", "cuda"], no-default-feature = true }
-# Stage 4: Turbulence
 stage-4-spectrax = {features = ["spectrax-gk"], no-default-feature = true}
 stage-4-spectrax-gpu = {features = ["spectrax-gk", "cuda"], no-default-feature = true }
-# Stage 5: Transport
 stage-5-neopax = {features = ["neopax"], no-default-feature = true}
 stage-5-neopax-gpu = {features = ["neopax", "cuda"], no-default-feature = true }

--- a/mvp/pixi.toml
+++ b/mvp/pixi.toml
@@ -5,22 +5,26 @@ platforms = ["linux-64", "osx-arm64"]
 version = "0.1.0"
 
 [tasks.start]
-depends-on = [ "stage-1-equilibrium", "stage-2-boozer", "stage-3-neoclassical"]
+depends-on = [ "stage-1-vmec", "stage-2-booz", "stage-3-sfincs"]
 
 [dependencies]
 
-[feature.stage-1.dependencies]
+# --- Stage 1: Equilibrium ---
+
+[feature.vmec-jax.dependencies]
 numpy = ">=2.4.3,<3"
 jax = ">=0.9.1,<0.10"
 netcdf4 = ">=1.7.4,<2"
 
-[feature.stage-1.pypi-dependencies]
+[feature.vmec-jax.pypi-dependencies]
 vmec-jax = { git = "https://github.com/uwplasma/vmec_jax", rev = "cfdf674b0ca213b3b97244b0cf0273d481ec37fd" }
 
-[feature.stage-1.tasks.stage-1-equilibrium]
+[feature.vmec-jax.tasks.stage-1-vmec]
 cmd = "vmec_jax stage1-equilibrium/vmec_jax/input/input.HSX_QHS_vacuum_ns201"
 
-[feature.stage-2.dependencies]
+# --- Stage 2: Boozer Transform ---
+
+[feature.booz-xform-jax.dependencies]
 numpy = ">=2.4.3,<3"
 scipy = ">=1.17.1,<2"
 jax = ">=0.9.1,<0.10"
@@ -28,25 +32,29 @@ netcdf4 = ">=1.7.4,<2"
 matplotlib = ">=3.10.8,<4"
 plotly = ">=6.6.0,<7"
 
-[feature.stage-2.pypi-dependencies]
+[feature.booz-xform-jax.pypi-dependencies]
 booz-xform-jax = { git = "https://github.com/uwplasma/booz_xform_jax.git", rev = "1f206597f2f28436e0e2124160c13de9ae63b2ea" }
 
-[feature.stage-2.tasks.stage-2-boozer]
+[feature.booz-xform-jax.tasks.stage-2-booz]
 cmd = "python stage2-boozer/example.py"
 
-[feature.stage-3.dependencies]
+# --- Stage 3: Neoclassical Transport ---
+
+[feature.sfincs-jax.dependencies]
 numpy = ">=2.4.3,<3"
 scipy = ">=1.17.1,<2"
 jax = ">=0.9.1,<0.10"
 h5py = ">=3.16.0,<4"
 
-[feature.stage-3.pypi-dependencies]
+[feature.sfincs-jax.pypi-dependencies]
 sfincs-jax = { git = "https://github.com/uwplasma/sfincs_jax", rev = "de50abd2ee9063176728805288e8bafe8e83cbc3" }
 
-[feature.stage-3.tasks.stage-3-neoclassical]
+[feature.sfincs-jax.tasks.stage-3-sfincs]
 cmd = "sfincs_jax stage3-neoclassical/sfincs_jax/input/input.HSX_QHS_vacuum_ns201"
 
-[feature.stage-4.dependencies]
+# --- Stage 4: Turbulence ---
+
+[feature.spectrax-gk.dependencies]
 numpy = ">=2.3,<2.4"
 jax = ">=0.8,<0.9"
 diffrax = ">=0.7.2,<0.8"
@@ -57,14 +65,16 @@ matplotlib = ">=3.10.8,<4"
 netcdf4 = ">=1.7.4,<2"
 plotly = ">=6.6.0,<7"
 
-[feature.stage-4.pypi-dependencies]
+[feature.spectrax-gk.pypi-dependencies]
 spectrax-gk = { git = "https://github.com/uwplasma/SPECTRAX-GK.git", rev = "61aac059166e30f937fa0ad6163b4d857c132622" }
 booz-xform-jax = { git = "https://github.com/uwplasma/booz_xform_jax.git", rev = "1f206597f2f28436e0e2124160c13de9ae63b2ea" }
 
-[feature.stage-4.tasks.stage-4-turbulence]
+[feature.spectrax-gk.tasks.stage-4-spectrax]
 cmd = "spectrax-gk run --config ./stage4-turbulence/spectrax_gk/input/runtime_hsx_nonlinear_vmec_geometry.toml --out stage4-turbulence/spectrax_gk/tools_out/hsx_run"
 
-[feature.stage-5.dependencies]
+# --- Stage 5: Transport ---
+
+[feature.neopax.dependencies]
 scipy = ">=1.17.1,<2"
 jax = ">=0.9.1,<0.10"
 equinox = ">=0.13.6,<0.14"
@@ -76,7 +86,7 @@ matplotlib = ">=3.10.8,<4"
 h5py = ">=3.16.0,<4"
 netcdf4 = ">=1.7.4,<2"
 
-[feature.stage-5.pypi-dependencies]
+[feature.neopax.pypi-dependencies]
 orthax = ">=0.2.8, <0.3"
 inductiva = ">=0.18.12, <0.19"
 neopax = { git = "https://github.com/uwplasma/NEOPAX.git", rev = "5ec4cc3c5583121c5c454358defa7ab1af40c211" }
@@ -87,13 +97,18 @@ platforms = ["linux-64"]
 cuda = "12"
 
 [environments]
-stage-1 = {features = ["stage-1"], no-default-feature = true }
-stage-1-gpu = {features = ["stage-1", "cuda"], no-default-feature = true }
-stage-2 = {features = ["stage-2"], no-default-feature = true }
-stage-2-gpu = {features = ["stage-2", "cuda"], no-default-feature = true }
-stage-3 = {features = ["stage-3"], no-default-feature = true}
-stage-3-gpu = {features = ["stage-3", "cuda"], no-default-feature = true }
-stage-4 = {features = ["stage-4"], no-default-feature = true}
-stage-4-gpu = {features = ["stage-4", "cuda"], no-default-feature = true }
-stage-5 = {features = ["stage-5"], no-default-feature = true}
-stage-5-gpu = {features = ["stage-5", "cuda"], no-default-feature = true }
+# Stage 1: Equilibrium
+stage-1-vmec = {features = ["vmec-jax"], no-default-feature = true }
+stage-1-vmec-gpu = {features = ["vmec-jax", "cuda"], no-default-feature = true }
+# Stage 2: Boozer Transform
+stage-2-booz = {features = ["booz-xform-jax"], no-default-feature = true }
+stage-2-booz-gpu = {features = ["booz-xform-jax", "cuda"], no-default-feature = true }
+# Stage 3: Neoclassical Transport
+stage-3-sfincs = {features = ["sfincs-jax"], no-default-feature = true}
+stage-3-sfincs-gpu = {features = ["sfincs-jax", "cuda"], no-default-feature = true }
+# Stage 4: Turbulence
+stage-4-spectrax = {features = ["spectrax-gk"], no-default-feature = true}
+stage-4-spectrax-gpu = {features = ["spectrax-gk", "cuda"], no-default-feature = true }
+# Stage 5: Transport
+stage-5-neopax = {features = ["neopax"], no-default-feature = true}
+stage-5-neopax-gpu = {features = ["neopax", "cuda"], no-default-feature = true }


### PR DESCRIPTION
## Summary

- Rename Pixi features from stage-based names (`stage-1`, `stage-2`, ...) to code-based names (`vmec-jax`, `booz-xform-jax`, `sfincs-jax`, `spectrax-gk`, `neopax`)
- Rename environments from `stage-{N}` to `stage-{N}-{code}` (e.g., `stage-3-sfincs`)
- Update CI matrix and mvp-pipeline docs to match

This separates what's installed (feature = code) from where it's used (environment = pipeline stage), enabling future alternative solvers per stage (e.g., `stage-3-monkes` alongside `stage-3-sfincs`).

## Verification

- `pixi install` succeeds for all CPU environments (`stage-1-vmec`, `stage-2-booz`, `stage-3-sfincs`, `stage-4-spectrax`, `stage-5-neopax`)
- `pixi run` invokes tasks correctly for renamed stages
- Resolved packages in `pixi.lock` are identical to `main` (only minor conda-forge build-number bumps from lock file regeneration)
- No behavioral changes, same dependency versions, and same git SHAs for all solver codes
