### PR TITLE
fix: Update I/O validation methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Stages 3 and 4 run in parallel. Each stage should eventually be independently sw
 | Stage I/O specs                         | [`docs/stage{N}-{name}/spec.md`](docs/)                        |
 | MVP I/O reference & Pixi commands       | [`docs/mvp-pipeline.md`](docs/mvp-pipeline.md)                 |
 | Physics equations & I/O contracts (TeX) | [`stellarator_workflow/`](stellarator_workflow/)               |
+| I/O validation methodology              | [`docs/guide.md#io-validation`](docs/guide.md#io-validation)          |
 | Coding standards                        | [`docs/guide.md#coding-conventions`](docs/guide.md#coding-conventions) |
 
 ## Pipeline Stages

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -261,6 +261,16 @@ When integrating a new stage or implementation:
 
 Output files should be inspected to verify that shapes, types (float32 vs float64), units, and coordinate conventions match between the output and the next stage's expected input.
 
+## I/O Validation
+
+Each stage validates its inputs and outputs in two steps:
+
+1. **Schema validation.** Verify that files match the spec -- all required fields present, correct types, shapes, and file format (NetCDF/HDF5/TOML). The spec tables were initially derived from upstream documentation, not direct inspection of code output. If actual files differ from the spec, update the spec to match the actual input/output data.
+
+2. **Physics validation.** Check that values are physically sensible and compatible with downstream stages: finiteness, non-negativity where expected, conservation laws, cross-stage consistency (e.g., iota in `boozmn_*.nc` matches `wout_*.nc`), convergence criteria met, etc.. The goal is to catch bad data at stage boundaries before it silently propagates through the pipeline.
+
+Each stage's `spec.md` lists the specific schema and physics checks under its Input Validation and Output Validation sections. Validation methods should be implemented as testable functions so they can run as part of the test suite (see [Writing Tests](#writing-tests)).
+
 ## Known Risks
 
 **1. Source-build fragility.** Some upstream codes have no release versions and must be built from source. Pin to a tested git commit SHA in `pixi.toml`. Test builds in CI and maintain fallback known-good revisions.

--- a/docs/stage1-equilibrium/spec.md
+++ b/docs/stage1-equilibrium/spec.md
@@ -81,7 +81,7 @@ Reference: `stellarator_io_reference.tex`, Section 3.1.
 ### Input Validation
 
 > [!TODO]
-> Validate input tables against actual code behavior.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 
@@ -161,7 +161,7 @@ Stage 2 (`BOOZ_XFORM` / `booz_xform_jax`) needs the **full** equilibrium spectru
 ### Output Validation
 
 > [!TODO]
-> Verify output fields against actual `wout_*.nc` files.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 

--- a/docs/stage2-boozer/spec.md
+++ b/docs/stage2-boozer/spec.md
@@ -54,7 +54,7 @@ The JAX version (`booz_xform_jax`) does not use a separate `in_booz.*` control f
 ### Input Validation
 
 > [!TODO]
-> Document input validation checks for wout fields, mboz/nboz bounds, surface indices, and equilibrium quality thresholds.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 
@@ -96,7 +96,7 @@ Non-target Boozer harmonics in `bmnc_b` or symmetry-breaking measures built from
 ### Output Validation
 
 > [!TODO]
-> Document output validation checks: field completeness, spectral convergence, iota consistency, and |B| cross-checks against VMEC.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 

--- a/docs/stage3-neoclassical/spec.md
+++ b/docs/stage3-neoclassical/spec.md
@@ -36,7 +36,7 @@ Reference: `stellarator_io_reference.tex`, Section 3.4.
 #### Input Validation
 
 > [!TODO]
-> Document input validation checks for NEO / NEO_JAX (required boozmn fields, resolution parameter ranges, surface index bounds, Fourier cutoff limits, CALC_CUR guidance, error codes, JAX vs. legacy differences).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Output Specification
 
@@ -67,7 +67,7 @@ Optional outputs (if CALC_CUR=1): `neo_cur.*`, `current.dat`, `conver.dat`, `dia
 #### Output Validation
 
 > [!TODO]
-> Document output validation checks for NEO / NEO_JAX (field presence and shapes, epstot finiteness and physical range, iota cross-check vs. Stage 2, per-class sum consistency, convergence criteria, cross-code agreement, logging strategy).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Governing Equations
 
@@ -113,7 +113,7 @@ Key namelist parameters: species charges/masses, $\hat{n}_s$, $\hat{T}_s$, their
 #### Input Validation
 
 > [!TODO]
-> Document input validation checks for SFINCS / sfincs_jax (required namelist groups, species parameter consistency, gradient sign conventions, resolution parameter ranges, geometry source verification, E_r initial guess guidance, Phi1 switch implications, error codes, JAX vs. legacy differences).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Output Specification
 
@@ -139,7 +139,7 @@ Also: matching momentum-flux arrays, classical fluxes, optional full-f/delta-f e
 #### Output Validation
 
 > [!TODO]
-> Document output validation checks for SFINCS / sfincs_jax (field presence and shapes, flux finiteness, ambipolarity check, bootstrap current sanity, Onsager symmetry of transport matrix, physical range checks, convergence criteria, cross-code agreement, Phi1 output presence, logging strategy).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Governing Equations
 
@@ -180,7 +180,7 @@ In database-building mode: the solve is repeated over collisionality (nu_v) and 
 #### Input Validation
 
 > [!TODO]
-> Document input validation checks for monkes (field object attributes, species parameter validation, E_r and nu_v grid spacing for database building, pitch-angle resolution bounds, surface selection, error codes, DESC vs. boozmn geometry handling).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Output Specification
 
@@ -207,7 +207,7 @@ Reference: `stellarator_io_reference.tex`, Section 3.6.
 #### Output Validation
 
 > [!TODO]
-> Document output validation checks for monkes (field presence and shapes, D_ij finiteness across full grid, D11/D33 positivity, Onsager symmetry, 1/nu and plateau limiting behavior, grid coverage for NEOPAX, database completeness, Legendre convergence, logging strategy).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ### Governing Equations
 

--- a/docs/stage4-turbulence/spec.md
+++ b/docs/stage4-turbulence/spec.md
@@ -76,7 +76,7 @@ Installation-dependent. Key physics contract: geometry from VMEC/Boozer, species
 ### Input Validation
 
 > [!TODO]
-> Validate input tables against actual code behavior (required vs. optional fields, defaults, normalization conventions).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 
@@ -146,7 +146,7 @@ For transport coupling, the critical handoff is the **turbulent flux vector** (s
 ### Output Validation
 
 > [!TODO]
-> Verify output fields against actual gyrokinetic runs (formats, units, normalization, steady-state extraction).
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 

--- a/docs/stage5-transport/spec.md
+++ b/docs/stage5-transport/spec.md
@@ -106,7 +106,7 @@ Reference: `stellarator_io_reference.tex`, Sections 3.11-3.12.
 ### Input Validation
 
 > [!TODO]
-> Define input validation rules for the D_ij database, wout/boozmn consistency, and Trinity3D TOML schema.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 
@@ -222,7 +222,7 @@ $P_\text{fus}$, $Q$, $\beta$, transport-consistent profiles.
 ### Output Validation
 
 > [!TODO]
-> Define output validation: physical sanity checks, conservation balances, shape consistency, and regression comparisons.
+> See [I/O Validation section](../guide.md#io-validation).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add new "I/O Validation" section to `docs/guide.md` defining a two-step methodology: schema validation (verify files match spec, update spec if they differ) and physics validation (catch bad data at stage boundaries)
- Update all stage `spec.md` validation TODOs to reference the guide instead of duplicating the methodology
- Add I/O validation entry to README quick reference table

I'm going to merge immediately, but I'm opening a PR to establish best practice and in case anyone has comments or suggestions for the I/O validation.