### PR TITLE
fix: bump vmec_jax pin to include mnmax/mnmax_nyq wout scalars

### DIFF
--- a/mvp/pixi.lock
+++ b/mvp/pixi.lock
@@ -3,16 +3,12 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages: {}
   stage-1-vmec:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -99,7 +95,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
+      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=fbe829c33f3bfcac5e2adc49b343cf43db280196#fbe829c33f3bfcac5e2adc49b343cf43db280196
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -177,14 +173,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
+      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=fbe829c33f3bfcac5e2adc49b343cf43db280196#fbe829c33f3bfcac5e2adc49b343cf43db280196
   stage-1-vmec-gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -300,12 +294,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
+      - pypi: git+https://github.com/uwplasma/vmec_jax?rev=fbe829c33f3bfcac5e2adc49b343cf43db280196#fbe829c33f3bfcac5e2adc49b343cf43db280196
   stage-2-booz:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -434,8 +426,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -737,8 +727,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -955,8 +943,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1098,8 +1084,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1206,8 +1190,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1527,8 +1509,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1754,8 +1734,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -2153,8 +2131,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -7473,7 +7449,7 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
-- pypi: git+https://github.com/uwplasma/vmec_jax?rev=cfdf674b0ca213b3b97244b0cf0273d481ec37fd#cfdf674b0ca213b3b97244b0cf0273d481ec37fd
+- pypi: git+https://github.com/uwplasma/vmec_jax?rev=fbe829c33f3bfcac5e2adc49b343cf43db280196#fbe829c33f3bfcac5e2adc49b343cf43db280196
   name: vmec-jax
   version: 0.0.1
   requires_dist:
@@ -7489,6 +7465,7 @@ packages:
   - pytest>=7.0 ; extra == 'dev'
   - ruff>=0.1 ; extra == 'dev'
   - mypy>=1.6 ; extra == 'dev'
+  - types-setuptools ; extra == 'dev'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
   sha256: af400decd8578d521c752594bb9380eb4d1e1e53e919c18dd2d65429f032e36c

--- a/mvp/pixi.toml
+++ b/mvp/pixi.toml
@@ -15,7 +15,7 @@ jax = ">=0.9.1,<0.10"
 netcdf4 = ">=1.7.4,<2"
 
 [feature.vmec-jax.pypi-dependencies]
-vmec-jax = { git = "https://github.com/uwplasma/vmec_jax", rev = "cfdf674b0ca213b3b97244b0cf0273d481ec37fd" }
+vmec-jax = { git = "https://github.com/uwplasma/vmec_jax", rev = "fbe829c33f3bfcac5e2adc49b343cf43db280196" }
 
 [feature.vmec-jax.tasks.stage-1-vmec]
 cmd = "vmec_jax stage1-equilibrium/vmec_jax/input/input.HSX_QHS_vacuum_ns201"


### PR DESCRIPTION
## Summary

- Bump `vmec_jax` pin in `mvp/pixi.toml` from `cfdf674b` (2026-03-20) to `fbe829c3` (upstream HEAD, 2026-04-14).
- Picks up upstream fix [`b864f095`](https://github.com/uwplasma/vmec_jax/commit/b864f095ca) — *"wout: align mode-table metadata with downstream readers"* — which adds `mnmax`, `mnmax_nyq`, `mpol_nyq`, `ntor_nyq` as scalar variables in the wout NetCDF.
- Unblocks Stage 1 → Stage 2 chain (previously failed with `KeyError: 'mnmax'` in `booz_xform_jax.read_wout`).

## Test plan

- [x] `pixi install -e stage-1-vmec` resolves without error
- [x] Stage 1 produces a wout with `mnmax` and `mnmax_nyq` as scalar variables
- [x] Stage 2 (`pixi run -e stage-2-booz-jax stage-2-booz`) runs end-to-end on Stage 1's output

Closes #56
