### PR TITLE
Chore: Remove CODEOWNERS in favor of ruleset team reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# These users are required reviewers for all changes to main.
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
-
-* @RKHashmani @matthewfeickert


### PR DESCRIPTION
Review enforcement now lives in the main ruleset (team-based required reviewers + "Require review from Code Owners" unchecked), making the CODEOWNERS file redundant.

Resolves #85 