### PR TITLE
fix: Normalize Stage 5 convergence metric to RMS and document the halt signal

### DIFF
--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -406,13 +406,15 @@ outputs/<run>/loop/iter_N/
 
 ### Convergence
 
-Convergence is decided by `pressure_converged()` in `stage5_post_processing.py`. A pass is converged when this pass's `transport_solution.h5` shows the total pressure profile `P(rho)` has reached steady state, i.e. the relative RMS change between its initial and final time slices falls below the configured tolerance:
+Convergence is decided by `pressure_converged()` in `stage5_post_processing.py`. A pass is converged when this pass's `transport_solution.h5` shows the total pressure profile `P(rho)` has reached steady state, i.e. the root-mean-square (over rho) of the pointwise relative change between its initial and final time slices falls below the configured tolerance:
 
 ```
-||P_final - P_initial|| / ||P_initial|| < pressure_rel_tol
+sqrt( mean_rho[ ((P_final - P_initial) / P_initial)^2 ] ) < pressure_rel_tol
 ```
 
-`pressure_rel_tol` is set in the top-level `convergence` block of the run config (defaulting to `1.0e-2`). The verdict is written to `converge_status.json` as `{"converged": true}` or `{"converged": false}`, and `ouroboros` stops the loop on the first `true`; otherwise it runs the full `--max-iters`. If the transport solution has fewer than two distinct time slices, convergence cannot be assessed and the pass reports `false`. A `return_converged_false()` placeholder is kept under an "Alternative Convergence Criteria" comment so a different criterion can be swapped in.
+Normalising by the number of rho points (rather than a bare L2 norm) keeps `pressure_rel_tol` independent of the profile's radial resolution.
+
+`pressure_rel_tol` is set in the top-level `convergence` block of the run config (defaulting to `1.0e-2`). Stage 5 post-processing (`build_signal()`) writes `converge_status.json` as `{"converged": <bool>, "halt": <bool>}`, and `ouroboros` stops the loop when either flag is `true`: `converged` on the first steady-state pass, or `halt` when the run cannot continue. `halt` is set when the total pressure is non-positive at any rho on the initial or final time slice, i.e. the equilibrium was not sustained; the loop stops so the run can restart from different initial conditions instead of feeding a collapsed profile forward. If neither holds, the loop runs the full `--max-iters`. If the transport solution has fewer than two distinct time slices, convergence cannot be assessed and the pass reports `converged: false` (not a halt). A `return_converged_false()` placeholder is kept under an "Alternative Convergence Criteria" comment so a different criterion can be swapped in.
 
 > [!NOTE]
 > To render the file-flow graph *including* this post-processing step, target the signal file; see the [README](../README.md#visualize-the-pipeline-graph). Omitting the target graphs the plain forward pass (stops at Stage 5).

--- a/stages/stage5-post-processing/stage5_post_processing.py
+++ b/stages/stage5-post-processing/stage5_post_processing.py
@@ -61,8 +61,11 @@ def pressure_converged(transport: Path, *, rel_tol: float) -> bool:
         )
         return False
 
-
-    rel_change = float(np.linalg.norm((p_final - p_initial) / p_initial))
+    # Root-mean-square of the pointwise relative change. Normalising by the number of
+    # rho points keeps rel_tol grid-resolution independent, so it
+    # reads as a true relative tolerance regardless of the profile's radial resolution.
+    rel = (p_final - p_initial) / p_initial
+    rel_change = float(np.sqrt(np.mean(rel**2)))
     logger.info("pressure relative RMS change = %.3e (rel_tol = %.3e)", rel_change, rel_tol)
     return rel_change < rel_tol
 


### PR DESCRIPTION
Follow-up to #95. Normalizes the Stage 5 convergence metric to the RMS of the pointwise relative change (`sqrt(mean((dP/P)^2))`) so `pressure_rel_tol` is independent of the rho grid resolution (a uniform 1% change now reads as `0.01` at any radial resolution, where the bare L2 norm scaled with sqrt(N)), and updates `docs/mvp-pipeline.md` with the corrected formula and the two-field `converge_status.json` (`{"converged", "halt"}`) contract.