### PR TITLE
test: Orchestration and IO contracts

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -523,6 +523,622 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py313hcdf3177_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  test:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-scheduler-plugins-2.0.2-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.4.1-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.23.1-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.13-h4d16d09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cgl-0.60.10-hc46dffc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-clp-1.17.11-hc03379b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-osi-0.108.12-hf4fecb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.13-hc93afbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.2-py314h42812f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.52-ha5ea40c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py314h5bd0f2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-hf4e2dac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py314h2b28147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py314h312e2f4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py314h1bee95f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py314h5bd0f2a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sqlmodel-0.0.37-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-scheduler-plugins-2.0.2-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.4.1-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.23.1-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.2.0-py314h352cb57_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-cbc-2.10.13-h3e6914b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-cgl-0.60.10-h082c6d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-clp-1.17.11-h1805f0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-osi-0.108.12-h42e9861_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-utils-2.11.13-h6d11b10_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.16.2-h70963c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.6-h90308e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.88.2-h7aeb4f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-14.1.2-h45e821f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/greenlet-3.5.2-py314he6363bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.52-h75d4e7a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/immutables-0.21-py314h51f160d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-hc57f145_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-h88aa843_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-8_hb558247_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-nompi_h441b98c_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.3-hf685517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.2-h10b116e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.2-h3c6a4c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h79dcc73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h869d058_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py314hb76de3f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf4-1.7.4-nompi_py311hf700f0f_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.5.0-py314he1698a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulp-2.8.0-py314h8bc8a6e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pydantic-core-2.46.4-py314h451b6cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-2026.5.1-py314h721bf50_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py314hf8f541d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-1.17.3-py314h51f160d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.6-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2025.1-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sqlmodel-0.0.37-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-scheduler-plugins-2.0.2-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.4.1-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.23.1-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sqlmodel-0.0.37-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-cbc-2.10.13-h2032c40_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-cgl-0.60.10-h034796e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-clp-1.17.11-he934a02_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-osi-0.108.12-h8aa3827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-utils-2.11.13-h6bed822_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-14.1.2-hec8c438_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.2-py314he609de1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.52-hc0f3e19_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/immutables-0.21-py314hb84d1df_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hd5a2499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-h05bcc79_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-8_h1b118fd_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.10.0-nompi_h28ce51b_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.3-he8aa2a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.4-nompi_py311hfd37af6_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py314hb79c6fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pulp-2.8.0-py314h676fd1f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py314h54f3292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py314he1d1ac0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py314hb84d1df_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyh84498cf_0.conda
   sha256: e0304136ad68e797f0e9bc0d2adcedb3239d77a7363c7a5d708b8d7f1559be1e
@@ -536,6 +1152,18 @@ packages:
   license_family: MIT
   size: 22712
   timestamp: 1773008308747
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+  sha256: 1e8393a8ef060c62ef963fa9e0b3cc8f69b1dec4bdb51599c0dfcdeb9b8c7d12
+  md5: a5ec344abd4b0cdda5a52e870e4d25a3
+  depends:
+  - argparse-dataclass >=2.0.0
+  - configargparse >=1.7
+  - packaging >=24.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 22751
+  timestamp: 1780096495612
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
   sha256: 16c8e1ba64837b10460459e710e2578e8b0be5d1ed9501cfcf27b2ba316e5ad2
   md5: 0d8bbf1699b16ac225031ae0c73729f8
@@ -557,6 +1185,15 @@ packages:
   license: MIT
   size: 20041
   timestamp: 1773934363928
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+  sha256: 1fc3115ce77aee110a7cf7bc6ffb3a4ab82af3173109b0bad6ac9adb00296de7
+  md5: 78f0a9e3ec845ef8e35e319bc36dee9b
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.17.4,<2.0.0
+  license: MIT
+  size: 21021
+  timestamp: 1779291141116
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
   sha256: 7b7be41b59f2d904acb014ee182561610c930bef5f607742011ee23befe73831
   md5: e6fd8cfb23b294da699e395dbc968d11
@@ -629,6 +1266,46 @@ packages:
   license_family: MIT
   size: 883505
   timestamp: 1777722551210
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.23.1-pyhdfd78af_1.conda
+  sha256: 6d7a1d2e308506e867121edb6d258dbbb359ce3287631e54601e33edb110485d
+  md5: ff39f8e27137655553f9fbb842ee1aa2
+  depends:
+  - conda-inject >=1.3.1,<2.0
+  - configargparse
+  - connection_pool >=0.0.3
+  - docutils >=0.20,<0.23
+  - dpath >=2.1.6,<3.0.0
+  - gitpython
+  - humanfriendly
+  - immutables
+  - jinja2 >=3.0,<4.0
+  - jsonschema
+  - nbformat
+  - packaging >=24.0,<26
+  - platformdirs
+  - psutil
+  - pulp >=2.3.1,<3.4
+  - python >=3.11
+  - pyyaml
+  - referencing
+  - requests >=2.8.1,<3.0
+  - smart_open >=4.0,<8.0
+  - snakemake-interface-common >=1.20.1,<2.0
+  - snakemake-interface-executor-plugins >=9.3.2,<10.0
+  - snakemake-interface-logger-plugins >=1.1.0,<3.0.0
+  - snakemake-interface-report-plugins >=1.2.0,<2.0.0
+  - snakemake-interface-scheduler-plugins >=2.0.0,<3.0.0
+  - snakemake-interface-storage-plugins >=4.3.2,<5.0
+  - sqlmodel >=0.0.37,<0.0.38
+  - tabulate
+  - tenacity >=9.1.4,<10.0
+  - throttler
+  - wrapt
+  - yte >=1.5.5,<2.0
+  license: MIT
+  license_family: MIT
+  size: 888303
+  timestamp: 1781821379807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
   sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
@@ -640,6 +1317,9 @@ packages:
   - openmp_impl <0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 28948
   timestamp: 1770939786096
 - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
@@ -653,6 +1333,9 @@ packages:
   - libglib >=2.68.1,<3.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - at-spi2-atk >=2.38.0,<3.0a0
   size: 339899
   timestamp: 1619122953439
 - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
@@ -667,6 +1350,9 @@ packages:
   - xorg-libxtst
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - at-spi2-core >=2.40.3,<2.41.0a0
   size: 658390
   timestamp: 1625848454791
 - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
@@ -680,8 +1366,152 @@ packages:
   - atk-1.0 2.38.0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - atk-1.0 >=2.38.0
   size: 355900
   timestamp: 1713896169874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
+  sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
+  md5: 9329dcd00c4d61aa49e516dddd784e91
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.3,<0.10.4.0a0
+  size: 134649
+  timestamp: 1781802943551
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+  sha256: 06a0e2af439b21c94adff8fac5dd66dbda5f182fc80ac635c4903959ea306cbb
+  md5: fe81235aae00f32df8584267b4f2daf8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 57011
+  timestamp: 1780566647051
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
+  sha256: 6d2b33965bf6daeffd3ad336f41410053ff06ed6f2b2ce62c1ec27c0a39b4e7e
+  md5: f1c005b2e3b618706112ddd7f3af4521
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.0,<0.14.1.0a0
+  size: 242497
+  timestamp: 1780160843944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
+  sha256: 0e4952f9be8de7f281ca7d734a3a8f05ad0db856c6ef1e0897798c4afbcd9a54
+  md5: 595911421e25551e36fde7027bf33f38
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 22007
+  timestamp: 1780566239465
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
+  sha256: d2b844db1a4dfbc20b5129b7df4a656c1459c5fb16745101bbd802813ba8d411
+  md5: da0be1e8cb4a43c876f26d9d812dea06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 230293
+  timestamp: 1780586764553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
+  sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
+  md5: 12697e83c2a0e5b93fd03855a70eb360
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - s2n >=1.7.4,<1.7.5.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-io >=0.26.3,<0.26.4.0a0
+  size: 181839
+  timestamp: 1781649803811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+  sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
+  md5: f2b6275244daa12109bcd0a126f1fb85
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 154088
+  timestamp: 1781252014556
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
+  sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
+  md5: 5088795f3dfcf00a26f03c2a17ae8429
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 65759
+  timestamp: 1781063620400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+  sha256: ad49333d96a5f9bcce02752a6515cbb077d7513e358a8fb1a832f4e772d54bac
+  md5: 5c05a63452bf73c50aa272a6f961c4fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 101627
+  timestamp: 1780568539000
 - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py313h18e8e13_0.conda
   sha256: 310e114a783b249517d1dd6e74b3f339af30e947bc93446ae4e4e9c86fff7478
   md5: 0de0c2c1f2677ea074bdda91de5a4c01
@@ -694,6 +1524,24 @@ packages:
   license: BSD-3-Clause AND MIT AND EPL-2.0
   size: 242514
   timestamp: 1778594045042
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+  sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
+  md5: 2c2fae981fd2afd00812c92ac47d023d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - blosc >=1.21.6,<2.0a0
+  size: 48427
+  timestamp: 1733513201413
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py313hf159716_1.conda
   sha256: dadec2879492adede0a9af0191203f9b023f788c18efd45ecac676d424c458ae
   md5: 6c4d3597cf43f3439a51b2b13e29a4ba
@@ -709,6 +1557,22 @@ packages:
   license_family: MIT
   size: 367721
   timestamp: 1764017371123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+  sha256: 3ad3500bff54a781c29f16ce1b288b36606e2189d0b0ef2f67036554f47f12b0
+  md5: 8910d2c46f7e7b519129f486e0fe927a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - libbrotlicommon 1.2.0 hb03c661_1
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 367376
+  timestamp: 1764017265553
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -717,8 +1581,24 @@ packages:
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
   size: 260182
   timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
+  md5: 920bb03579f15389b9e512095ad995b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - c-ares >=1.34.6,<2.0a0
+  size: 207882
+  timestamp: 1765214722852
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
   sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
   md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -743,8 +1623,26 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
   size: 989514
   timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
+  sha256: 5889371679ebd4cc4d7a1b9a4a6f5ca7146527b9c6da14ba83f2edadbc45ac82
+  md5: 552b5d9d8a2a4be882e1c638953e7281
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.21.2
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 438385
+  timestamp: 1768510929901
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.13-h4d16d09_1.conda
   sha256: 200da7fefacb1a196dd7b4b6f45106cebe017042b1491e2b27c7cc833beed8ea
   md5: 5f68e67b2b9463501260e731e2999dec
@@ -768,6 +1666,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cbc >=2.10.13,<2.11.0a0
   size: 910148
   timestamp: 1778586394891
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cgl-0.60.10-hc46dffc_1.conda
@@ -792,6 +1693,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cgl >=0.60,<0.61.0a0
   size: 533910
   timestamp: 1778571381173
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-clp-1.17.11-hc03379b_1.conda
@@ -815,6 +1719,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-clp >=1.17,<1.18.0a0
   size: 1153761
   timestamp: 1778519879680
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-osi-0.108.12-hf4fecb4_1.conda
@@ -837,6 +1744,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-osi >=0.108,<0.109.0a0
   size: 378434
   timestamp: 1778511053515
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.13-hc93afbd_1.conda
@@ -856,6 +1766,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-utils >=2.11,<2.12.0a0
   size: 664399
   timestamp: 1778500281099
 - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
@@ -869,6 +1782,9 @@ packages:
   - libglib >=2.86.2,<3.0a0
   - libexpat >=2.7.3,<3.0a0
   license: AFL-2.1 OR GPL-2.0-or-later
+  run_exports:
+    weak:
+    - dbus >=1.16.2,<2.0a0
   size: 447649
   timestamp: 1764536047944
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
@@ -891,6 +1807,9 @@ packages:
   - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - epoxy >=1.5.10,<1.6.0a0
   size: 411735
   timestamp: 1758743520805
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
@@ -908,6 +1827,25 @@ packages:
   license_family: MIT
   size: 270705
   timestamp: 1771382710863
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+  sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+  md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.1,<3.0a0
+    - fonts-conda-ecosystem
+  size: 281880
+  timestamp: 1780450077431
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -915,6 +1853,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - fribidi >=1.0.16,<2.0a0
   size: 61244
   timestamp: 1757438574066
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
@@ -930,6 +1871,9 @@ packages:
   - libtiff >=4.7.1,<4.8.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gdk-pixbuf >=2.44.6,<3.0a0
   size: 577414
   timestamp: 1774985848058
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
@@ -943,6 +1887,18 @@ packages:
   license: LGPL-2.1-or-later
   size: 236955
   timestamp: 1778508800134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.2-h8094192_0.conda
+  sha256: 079757e4e0497d67505b52062668e4cc0d2a86ec065ae2c0c57487a178206061
+  md5: cfe66c21ae651b84a3d25a1dbb641a54
+  depends:
+  - libglib ==2.88.2 h0d30a3d_0
+  - libffi
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: LGPL-2.1-or-later
+  run_exports: {}
+  size: 238517
+  timestamp: 1782463895250
 - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
   sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
   md5: 2cd94587f3a401ae05e03a6caf09539d
@@ -954,6 +1910,20 @@ packages:
   license_family: LGPL
   size: 99596
   timestamp: 1755102025473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+  sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+  md5: cf09e9fc938518e91d0706572cadf17a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 100054
+  timestamp: 1780454302233
 - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
   sha256: 48d4aae8d2f7dd038b8c2b6a1b68b7bca13fa6b374b78c09fcc0757fa21234a1
   md5: 341fc61cfe8efa5c72d24db56c776f44
@@ -976,6 +1946,9 @@ packages:
   - pango >=1.56.4,<2.0a0
   license: EPL-1.0
   license_family: Other
+  run_exports:
+    weak:
+    - graphviz >=14.1.2,<15.0a0
   size: 2426455
   timestamp: 1769427102743
 - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.0-py313h5d5ffb9_0.conda
@@ -991,6 +1964,20 @@ packages:
   license_family: MIT
   size: 263299
   timestamp: 1777328965649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.2-py314h42812f9_0.conda
+  sha256: 4aa1f8147701b5ab71a71aa208ec1a4d0c8cfcaa68f1fff9ad5d2015abb8ddde
+  md5: 5fef7ee7545d98388c129de1a47537bb
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 267632
+  timestamp: 1781762129332
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.52-ha5ea40c_0.conda
   sha256: c6bb4f06331bcb0a566d84e0f0fad7af4b9035a03b13e2d5ecfaf13be57e6e10
   md5: bcaea22d85999a4f17918acfab877e61
@@ -1031,6 +2018,10 @@ packages:
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gtk3 >=3.24.52,<4.0a0
+    - adwaita-icon-theme
   size: 5939083
   timestamp: 1774288645605
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
@@ -1042,8 +2033,27 @@ packages:
   - libstdcxx-ng >=12
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gts >=0.7.6,<0.8.0a0
   size: 318312
   timestamp: 1686545244763
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
+  sha256: 48e18f20bc1ff15433299dd77c20a4160eb29572eea799ae5a73632c6c3d7dfd
+  md5: d93afa30018997705dd04513eeb5ac0f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 1345557
+  timestamp: 1775581268685
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
   sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
   md5: e194f6a2f498f0c7b1e6498bd0b12645
@@ -1063,11 +2073,75 @@ packages:
   license_family: MIT
   size: 2333599
   timestamp: 1776778392713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+  sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+  md5: 21ee4640b7c2d94e584349fa12b29b9a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - harfbuzz >=14.2.1
+  size: 2362258
+  timestamp: 1780450503234
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf4 >=4.2.15,<4.2.16.0a0
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
+  sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
+  md5: 3c126667b98ad8ccf390a91b9097f574
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf5 >=2.1.0,<3.0a0
+  size: 4377467
+  timestamp: 1781836834023
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
   sha256: 6d7e6e1286cb521059fe69696705100a03b006efb914ffe82a2ae97ecbae66b7
   md5: 129e404c5b001f3ef5581316971e3ea0
   license: GPL-2.0-or-later
   license_family: GPL
+  run_exports: {}
   size: 17625
   timestamp: 1771539597968
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
@@ -1079,6 +2153,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
   size: 12723451
   timestamp: 1773822285671
 - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py313h07c4f96_2.conda
@@ -1093,6 +2170,19 @@ packages:
   license_family: APACHE
   size: 54664
   timestamp: 1757685467253
+- conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py314h5bd0f2a_2.conda
+  sha256: 1c9163fd77943c55fe727f5399545141df54f696422bf101089a32526aea3234
+  md5: d4d65cfb5c2569d5dbd344039471a534
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 55407
+  timestamp: 1757685419776
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -1100,6 +2190,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
   size: 134088
   timestamp: 1754905959823
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
@@ -1117,6 +2210,24 @@ packages:
   license_family: MIT
   size: 1386730
   timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1388990
+  timestamp: 1781859420533
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -1127,6 +2238,7 @@ packages:
   - binutils_impl_linux-64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
+  run_exports: {}
   size: 728002
   timestamp: 1774197446916
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
@@ -1138,8 +2250,25 @@ packages:
   - libstdcxx >=14
   license: Apache-2.0
   license_family: Apache
+  run_exports:
+    weak:
+    - lerc >=4.1.0,<5.0a0
   size: 261513
   timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+  sha256: 822e4ae421a7e9c04e841323526321185f6659222325e1a9aedec811c686e688
+  md5: 86f7414544ae606282352fa1e116b41f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libaec >=1.1.5,<2.0a0
+  size: 36544
+  timestamp: 1769221884824
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_h4a7cf45_openblas.conda
   build_number: 7
   sha256: 081c850f99bc355821fac9c6e3727d40b3f8ce3beb50a5437cf03726b611ff39
@@ -1157,6 +2286,26 @@ packages:
   license_family: BSD
   size: 18716
   timestamp: 1778489854108
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  build_number: 8
+  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+  md5: 00fc660ab1b2f5ca07e92b4900d10c79
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - mkl <2027
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18804
+  timestamp: 1779859100675
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-7_h0358290_openblas.conda
   build_number: 7
   sha256: 956ae0bb1ec8b0c3663d75b151aceb0521b54e513bf97f621a035f9c87037970
@@ -1171,6 +2320,23 @@ packages:
   license_family: BSD
   size: 18675
   timestamp: 1778489861559
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  build_number: 8
+  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+  md5: 33a413f1095f8325e5c30fde3b0d2445
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18778
+  timestamp: 1779859107964
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
@@ -1182,8 +2348,30 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: Apache-2.0
   license_family: Apache
+  run_exports:
+    weak:
+    - libcups >=2.3.3,<2.4.0a0
   size: 4518030
   timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_0.conda
+  sha256: 93ab25f02666eb8696fa70d9c920f2e3b370742ee17e2758705038a72e11147f
+  md5: dcd79cabd5d435f48d75db3d81cb5874
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 479582
+  timestamp: 1782296544301
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -1192,6 +2380,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
   size: 73490
   timestamp: 1761979956660
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
@@ -1205,6 +2396,20 @@ packages:
   license_family: MIT
   size: 310785
   timestamp: 1757212153962
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+  sha256: 7d3187c11b7ae66c5595a8afd5a7ce352a490527fdf6614cab129bc7f2c16ba3
+  md5: d8d16b9b32a3c5df7e5b3350e2cbe058
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdrm >=2.4.127,<2.5.0a0
+  size: 311505
+  timestamp: 1778975798004
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -1215,6 +2420,9 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: BSD-2-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
   size: 134676
   timestamp: 1738479519902
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
@@ -1226,6 +2434,16 @@ packages:
   license: LicenseRef-libglvnd
   size: 44840
   timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  sha256: 9a25ea93e8272785405a21d30f84e620befb1d545f6dfaae18f06103b5df0443
+  md5: 75e9f795be506c96dd43cb09c7c8d557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 46500
+  timestamp: 1779728188901
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
   sha256: f6e7095260305dc05238062142fb8db4b940346329b5b54894a90610afa6749f
   md5: b513eb83b3137eca1192c34bf4f013a7
@@ -1237,6 +2455,32 @@ packages:
   license: LicenseRef-libglvnd
   size: 30380
   timestamp: 1731331017249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: e4b46919c9bb65930bce238bd2736110ed7b8c30e5cd5394e4e1edb48de54843
+  md5: 5bc6d55503483aabe8a90c5e7f49a2a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_3
+  - libgl-devel 1.7.0 ha4b6fd6_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libegl >=1.7.0,<2.0a0
+  size: 31718
+  timestamp: 1779728222280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 112766
+  timestamp: 1702146165126
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
   sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
   md5: a3b390520c563d78cc58974de95a03e5
@@ -1249,6 +2493,19 @@ packages:
   license_family: MIT
   size: 77241
   timestamp: 1777846112704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -1257,6 +2514,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.5.2,<3.6.0a0
   size: 58592
   timestamp: 1769456073053
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
@@ -1265,6 +2525,7 @@ packages:
   depends:
   - libfreetype6 >=2.14.3
   license: GPL-2.0-only OR FTL
+  run_exports: {}
   size: 8049
   timestamp: 1774298163029
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
@@ -1278,6 +2539,7 @@ packages:
   constrains:
   - freetype >=2.14.3
   license: GPL-2.0-only OR FTL
+  run_exports: {}
   size: 384575
   timestamp: 1774298162622
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
@@ -1291,6 +2553,7 @@ packages:
   - libgomp 15.2.0 he0feb66_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 1041084
   timestamp: 1778269013026
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
@@ -1300,6 +2563,9 @@ packages:
   - libgcc 15.2.0 he0feb66_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - libgcc
   size: 27694
   timestamp: 1778269016987
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda
@@ -1321,6 +2587,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: GD
   license_family: BSD
+  run_exports:
+    weak:
+    - libgd >=2.3.3,<2.4.0a0
   size: 177306
   timestamp: 1766331805898
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
@@ -1332,6 +2601,7 @@ packages:
   - libgfortran-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 27655
   timestamp: 1778269042954
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
@@ -1344,6 +2614,7 @@ packages:
   - libgfortran 15.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 2483673
   timestamp: 1778269025089
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
@@ -1356,6 +2627,17 @@ packages:
   license: LicenseRef-libglvnd
   size: 134712
   timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
+  md5: f25206d7322c0e9648e8b83694d143ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - libglx 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133469
+  timestamp: 1779728207669
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
   sha256: e281356c0975751f478c53e14f3efea6cd1e23c3069406d10708d6c409525260
   md5: 53e7cbb2beb03d69a478631e23e340e9
@@ -1366,6 +2648,19 @@ packages:
   license: LicenseRef-libglvnd
   size: 113911
   timestamp: 1731331012126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: 41d7d864ad1f199bdb06ff6cc3931455c8af62f1d2071a08c6fa08affbcb678f
+  md5: 63e43d278ee5084813fe3c2edf4834ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_3
+  - libglx-devel 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libgl >=1.7.0,<2.0a0
+  size: 115664
+  timestamp: 1779728218325
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
   sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
   md5: 17d484ab9c8179c6a6e5b7dbb5065afc
@@ -1381,6 +2676,24 @@ packages:
   license: LGPL-2.1-or-later
   size: 4754097
   timestamp: 1778508800134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+  sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+  md5: 889febc66cd9e4190f80ef9718fa239b
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.2,<3.0a0
+  size: 4754220
+  timestamp: 1782463895250
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   md5: 434ca7e50e40f4918ab701e3facd59a0
@@ -1389,6 +2702,15 @@ packages:
   license: LicenseRef-libglvnd
   size: 132463
   timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  sha256: e019ebe4e3f5cdf23e2f5e58ddf7ade27988c53820115b17b98f218ebcc87748
+  md5: eb83f3f8cecc3e9bff9e250817fc69b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133586
+  timestamp: 1779728183422
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
   sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
   md5: c8013e438185f33b13814c5c488acd5c
@@ -1399,6 +2721,17 @@ packages:
   license: LicenseRef-libglvnd
   size: 75504
   timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  sha256: 2f74713c9ca408ea84e88a30a9028153e7b553e8bb42e06139eac9a753c27da9
+  md5: ec3c4350aa0261bf7f87b8ca15c8e80e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 76586
+  timestamp: 1779728199059
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
   sha256: 0a930e0148ab6e61089bbcdba25a2e17ee383e7de82e7af10cc5c12c82c580f3
   md5: 27ac5ae872a21375d980bd4a6f99edf3
@@ -1410,6 +2743,20 @@ packages:
   license: LicenseRef-libglvnd
   size: 26388
   timestamp: 1731331003255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: a17ae2d4cb2de04a20882ae14ec3cc1958e868a4dec81e3d7eca30115ee50e94
+  md5: 16b6330783ce0d1ae8d22782173b32c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libglx >=1.7.0,<2.0a0
+  size: 27363
+  timestamp: 1779728211402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
   sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
   md5: faac990cb7aedc7f3a2224f2c9b0c26c
@@ -1417,6 +2764,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 603817
   timestamp: 1778268942614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -1426,6 +2776,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 790176
   timestamp: 1754908768807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
@@ -1437,6 +2790,9 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.1.4.1,<4.0a0
   size: 633831
   timestamp: 1775962768273
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-7_h47877c9_openblas.conda
@@ -1453,6 +2809,23 @@ packages:
   license_family: BSD
   size: 18694
   timestamp: 1778489869038
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  build_number: 8
+  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+  md5: 809be8ba8712c77bc7d44c2d99390dc4
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18790
+  timestamp: 1779859115086
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-7_h6ae95b6_openblas.conda
   build_number: 7
   sha256: 160a12bf36be2d73da4b65e156603c411db33338d0bba3fc29f87a78fee61fb5
@@ -1467,6 +2840,23 @@ packages:
   license_family: BSD
   size: 18707
   timestamp: 1778489876516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+  build_number: 8
+  sha256: 0b982865888a73fe7c2e7d8e8ee3738ac378b83012a7da1a12264a473cb2382b
+  md5: da17457f689df5c0f246d2f0b3798fd2
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  - libcblas 3.11.0 8_h0358290_openblas
+  - liblapack 3.11.0 8_h47877c9_openblas
+  constrains:
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapacke >=3.11.0,<3.12.0a0
+  size: 18824
+  timestamp: 1779859122364
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
   sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
   md5: b88d90cad08e6bc8ad540cb310a761fb
@@ -1476,6 +2866,9 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
   size: 113478
   timestamp: 1775825492909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
@@ -1486,8 +2879,54 @@ packages:
   - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
+  run_exports: {}
   size: 92400
   timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
+  sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
+  md5: 6d38346d49e4638ec98649121d295d54
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzip >=1.11.2,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnetcdf >=4.10.0,<4.10.1.0a0
+  size: 861080
+  timestamp: 1776686233788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+  md5: 2a45e7f8af083626f009645a6481f12d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 663344
+  timestamp: 1773854035739
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
   sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
   md5: 2d3278b721e40468295ca755c3b84070
@@ -1500,6 +2939,9 @@ packages:
   - openblas >=0.3.33,<0.3.34.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
   size: 5931919
   timestamp: 1776993658641
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
@@ -1512,6 +2954,19 @@ packages:
   license_family: MIT
   size: 28424
   timestamp: 1749901812541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+  sha256: f41721636a7c2e51bc2c642e1127955ab9c81145470714fdaac44d4d09e4af41
+  md5: 33082e13b4769b48cfeb648e15bfe3fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libpciaccess >=0.19,<0.20.0a0
+  size: 29147
+  timestamp: 1773533027610
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
   sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
   md5: eba48a68a1a2b9d3c0d9511548db85db
@@ -1520,6 +2975,9 @@ packages:
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
   size: 317729
   timestamp: 1776315175087
 - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
@@ -1541,6 +2999,28 @@ packages:
   license: LGPL-2.1-or-later
   size: 3474421
   timestamp: 1773814909137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+  sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
+  md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.18.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.6,<3.0a0
+  - harfbuzz >=14.2.0
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - librsvg >=2.62.3,<3.0a0
+  size: 3476570
+  timestamp: 1780450632624
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
   sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
   md5: 7dc38adcbf71e6b38748e919e16e0dce
@@ -1551,6 +3031,35 @@ packages:
   license: blessing
   size: 954962
   timestamp: 1777986471789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-hf4e2dac_2.conda
+  sha256: ba25a2aeb7092e964de2233097ffeee1e58c24803d0c67461ca8c742533100a3
+  md5: e1bbbfdfbf8ff501e60402a1fc6c143d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.2,<4.0a0
+  size: 963354
+  timestamp: 1782494470513
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+  md5: eecce068c7e4eddeb169591baac20ac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 304790
+  timestamp: 1745608545575
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
   sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
   md5: 5794b3bdc38177caf969dabd3af08549
@@ -1561,6 +3070,7 @@ packages:
   - libstdcxx-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 5852044
   timestamp: 1778269036376
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
@@ -1570,6 +3080,9 @@ packages:
   - libstdcxx 15.2.0 h934c35e_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - libstdcxx
   size: 27776
   timestamp: 1778269074600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
@@ -1587,6 +3100,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
+  run_exports:
+    weak:
+    - libtiff >=4.7.1,<4.8.0a0
   size: 435273
   timestamp: 1762022005702
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
@@ -1599,6 +3115,19 @@ packages:
   license_family: BSD
   size: 40297
   timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -1609,6 +3138,9 @@ packages:
   - libwebp 1.6.0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
   size: 429011
   timestamp: 1752159441324
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
@@ -1622,6 +3154,9 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
   size: 395888
   timestamp: 1727278577118
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
@@ -1640,6 +3175,25 @@ packages:
   license_family: MIT
   size: 837922
   timestamp: 1764794163823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+  sha256: 046f2ff4acebd8729fac03e99c8c307dfb48b6a32894ba8c11576e78f6e76e43
+  md5: dc8b067e22b414172bedd8e3f03f3c95
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 851166
+  timestamp: 1780213397575
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
   sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
   md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
@@ -1654,6 +3208,7 @@ packages:
   - libxml2 2.15.3
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 559775
   timestamp: 1776376739004
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -1669,8 +3224,28 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
   size: 46810
   timestamp: 1776376751152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
+  md5: a7b27c075c9b7f459f1c022090697cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libzip >=1.11.2,<2.0a0
+  size: 109043
+  timestamp: 1730442108429
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
   sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
   md5: d87ff7921124eccd67248aa483c23fec
@@ -1680,8 +3255,25 @@ packages:
   - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
   size: 63629
   timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+  sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
+  md5: 9de5350a85c4a20c685259b889aa6393
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - lz4-c >=1.10.0,<1.11.0a0
+  size: 167055
+  timestamp: 1733741040117
 - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_1.conda
   sha256: 72ed7c0216541d65a17b171bf2eec4a3b81e9158d8ed48e59e1ecd3ae302d263
   md5: aeb9b9da79fd0258b3db091d1fefcd71
@@ -1696,6 +3288,21 @@ packages:
   license_family: BSD
   size: 26100
   timestamp: 1772445154165
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+  sha256: c279be85b59a62d5c52f5dd9a4cd43ebd08933809a8416c22c3131595607d4cf
+  md5: 9a17c4307d23318476d7fbf0fedc0cde
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 27424
+  timestamp: 1772445227915
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
   sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
   md5: fc21868a1a5aacc937e7a18747acb8a5
@@ -1703,8 +3310,57 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
   size: 918956
   timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_108.conda
+  noarch: python
+  sha256: e000f6cee00d8ec94000ec71f0c880913c11bb50f8e695dbdd930f95546accfa
+  md5: 00192630eb74c7fa6e5e3e84686777fb
+  depends:
+  - python
+  - certifi
+  - cftime
+  - numpy
+  - packaging
+  - hdf5
+  - libnetcdf
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.23,<3
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1094073
+  timestamp: 1782151628345
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py314h2b28147_0.conda
+  sha256: bbc665584886c90daf3f33cfbf665f279cf91d4bd5323f0432c16d2bf4d525e7
+  md5: bdb21d2b990f9d3aee10fd43aca851fe
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - libcblas >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - liblapack >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 9075918
+  timestamp: 1782112541752
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   md5: da1b85b6a87e141f5140bb9924cecab0
@@ -1716,6 +3372,20 @@ packages:
   license_family: Apache
   size: 3167099
   timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+  sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+  md5: 79dd2074b5cd5c5c6b2930514a11e22d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3159683
+  timestamp: 1781069855778
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
   sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
   md5: d53ffc0edc8eabf4253508008493c5bc
@@ -1734,6 +3404,9 @@ packages:
   - libpng >=1.6.55,<1.7.0a0
   - libzlib >=1.3.2,<2.0a0
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - pango >=1.56.4,<2.0a0
   size: 458036
   timestamp: 1774281947855
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
@@ -1746,6 +3419,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 1222481
   timestamp: 1763655398280
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
@@ -1758,6 +3434,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
   size: 450960
   timestamp: 1754665235234
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
@@ -1772,6 +3451,19 @@ packages:
   license_family: BSD
   size: 228663
   timestamp: 1769678153829
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+  sha256: f15574ed6c8c8ed8c15a0c5a00102b1efe8b867c0bd286b498cd98d95bd69ae5
+  md5: 4f225a966cfee267a79c5cb6382bd121
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 231303
+  timestamp: 1769678156552
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -1780,6 +3472,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 8252
   timestamp: 1726802366959
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py313hf1034c9_3.conda
@@ -1794,6 +3487,19 @@ packages:
   license_family: MIT
   size: 228171
   timestamp: 1757853258550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py314h312e2f4_3.conda
+  sha256: 32354767a80f6650ad043356a975e7562c7286f7b2cdbb2acfe15bd057508e2f
+  md5: 057e330e50d141ee706f1d4c46594979
+  depends:
+  - amply >=0.1.2
+  - coin-or-cbc
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 230470
+  timestamp: 1757853295064
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
   sha256: d6705962afa2655cc22edcd075ce1f7e67c4407c005137d6d63c0dc5eaa76f47
   md5: ef0f9efec6ec28b17e22f787c7672c67
@@ -1809,6 +3515,22 @@ packages:
   license_family: MIT
   size: 1893749
   timestamp: 1778084222642
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
+  sha256: 802e216c39f1359aed60823b6e11d8ccd812b0ae1c81ae5ac1c81f99446409ab
+  md5: 0c96993dbeadf3a277cf757b9f1c9412
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1895020
+  timestamp: 1778084229247
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   build_number: 100
   sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
@@ -1835,6 +3557,38 @@ packages:
   size: 37358322
   timestamp: 1775614712638
   python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: 6d28ac2b061179deb434d3d57afa98ffd20ec3c5d44ab8048a1ca33424b22d38
+  md5: 0b9b2f83b5b600e1ac38becde8d0dd44
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 36717183
+  timestamp: 1781255094700
+  python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
   sha256: ef7df29b38ef04ec67a8888a4aa039973eaa377e8c4b59a7be0a1c50cd7e4ac6
   md5: f256753e840c3cd3766488c9437a8f8b
@@ -1848,6 +3602,20 @@ packages:
   license_family: MIT
   size: 201616
   timestamp: 1770223543730
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+  sha256: b318fb070c7a1f89980ef124b80a0b5ccf3928143708a85e0053cde0169c699d
+  md5: 2035f68f96be30dc60a5dfd7452c7941
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 202391
+  timestamp: 1770223462836
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -1857,6 +3625,9 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
   size: 345073
   timestamp: 1765813471974
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
@@ -1873,6 +3644,72 @@ packages:
   license_family: MIT
   size: 383230
   timestamp: 1764543223529
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.5.1-py314h1bee95f_0.conda
+  sha256: 79d753848377c415578f42285f5f87be711503b887c99e8890fd51d3fae1d6a5
+  md5: fb5b4fc759b225d4f32730cc8380ec8e
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 309696
+  timestamp: 1779976994059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
+  sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
+  md5: a20feedf58ce5441b115cebf284a9a75
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - s2n >=1.7.4,<1.7.5.0a0
+  size: 392550
+  timestamp: 1781634128636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
+  sha256: 85503102237f8515ab92319fc14609e894ac9e95e3a1398b0c49db1f9ee50877
+  md5: 62c390c1f8f51240f1ebc7ba782669ad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 17260022
+  timestamp: 1781912924009
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+  sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
+  md5: 98b6c9dc80eb87b2519b97bcf7e578dd
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - snappy >=1.2.2,<1.3.0a0
+  size: 45829
+  timestamp: 1762948049098
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.49-py313h54dd161_0.conda
   sha256: 6617540cd304d583e0f275398d670efae44a43d1c2e6899745d82f12aa8a5ac4
   md5: f4a105e76bbb8c03c9de71987353faa3
@@ -1887,6 +3724,21 @@ packages:
   license_family: MIT
   size: 3847834
   timestamp: 1775241332871
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+  sha256: 3c46e9af535a376c7269b61563f84c601235b00d50fc97f87ffbf3b68a51fe17
+  md5: aeb7447f3ea37b2bb32167267dcf0bfe
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4034632
+  timestamp: 1781547880247
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -1898,6 +3750,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
   size: 3301196
   timestamp: 1769460227866
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
@@ -1911,6 +3766,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - wayland >=1.25.0,<2.0a0
   size: 334139
   timestamp: 1773959575393
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py313h07c4f96_1.conda
@@ -1925,6 +3783,19 @@ packages:
   license_family: BSD
   size: 64865
   timestamp: 1756851811052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py314h5bd0f2a_1.conda
+  sha256: e2b6545651aed5e7dead39b7ba3bf8c2669f194c71e89621343bd0bb321a87f1
+  md5: 82da729c870ada2f675689a39b4f697f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 64997
+  timestamp: 1756851739706
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
   sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
   md5: b56e0c8432b56decafae7e78c5f29ba5
@@ -1936,6 +3807,18 @@ packages:
   license_family: MIT
   size: 399291
   timestamp: 1772021302485
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+  sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+  md5: b233b41be0bf210989d57160ed39b394
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 441670
+  timestamp: 1782027360439
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -1944,6 +3827,9 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libice >=1.1.2,<2.0a0
   size: 58628
   timestamp: 1734227592886
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
@@ -1956,6 +3842,9 @@ packages:
   - xorg-libice >=1.1.2,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libsm >=1.2.6,<2.0a0
   size: 27590
   timestamp: 1741896361728
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -1967,6 +3856,9 @@ packages:
   - libxcb >=1.17.0,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
   size: 839652
   timestamp: 1770819209719
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
@@ -1977,6 +3869,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxau >=1.0.12,<2.0a0
   size: 15321
   timestamp: 1762976464266
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
@@ -1989,6 +3884,9 @@ packages:
   - xorg-libxfixes >=6.0.2,<7.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcomposite >=0.4.7,<1.0a0
   size: 14415
   timestamp: 1770044404696
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
@@ -2002,6 +3900,9 @@ packages:
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcursor >=1.2.3,<2.0a0
   size: 32533
   timestamp: 1730908305254
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
@@ -2015,6 +3916,9 @@ packages:
   - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdamage >=1.1.6,<2.0a0
   size: 13217
   timestamp: 1727891438799
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -2025,6 +3929,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 20591
   timestamp: 1762976546182
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
@@ -2036,6 +3943,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
   size: 50326
   timestamp: 1769445253162
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
@@ -2047,6 +3957,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxfixes >=6.0.2,<7.0a0
   size: 20071
   timestamp: 1759282564045
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
@@ -2062,6 +3975,22 @@ packages:
   license_family: MIT
   size: 47179
   timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+  sha256: 495f99c8eacfa4ae2d8fed2a7f2105777af89acdc204df145d2bbbc380ac631b
+  md5: adba2e334082bb218db806d4c12277c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxi >=1.8.3,<2.0a0
+  size: 47717
+  timestamp: 1779111857071
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
   sha256: 3a9da41aac6dca9d3ff1b53ee18b9d314de88add76bafad9ca2287a494abcd86
   md5: 93f5d4b5c17c8540479ad65f206fea51
@@ -2073,6 +4002,9 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxinerama >=1.1.6,<1.2.0a0
   size: 14818
   timestamp: 1769432261050
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
@@ -2086,6 +4018,9 @@ packages:
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrandr >=1.5.5,<2.0a0
   size: 30456
   timestamp: 1769445263457
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
@@ -2097,6 +4032,9 @@ packages:
   - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
   size: 33005
   timestamp: 1734229037766
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
@@ -2110,6 +4048,9 @@ packages:
   - xorg-libxi >=1.7.10,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxtst >=1.2.5,<2.0a0
   size: 32808
   timestamp: 1727964811275
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
@@ -2122,6 +4063,9 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxxf86vm >=1.1.7,<2.0a0
   size: 18701
   timestamp: 1769434732453
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
@@ -2132,6 +4076,7 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 570010
   timestamp: 1766154256151
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -2142,6 +4087,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
   size: 85189
   timestamp: 1753484064210
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
@@ -2152,6 +4100,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
   size: 601375
   timestamp: 1764777111296
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
@@ -2164,6 +4115,9 @@ packages:
   - openmp_impl <0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 28926
   timestamp: 1770939656741
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
@@ -2177,6 +4131,9 @@ packages:
   - libglib >=2.68.1,<3.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - at-spi2-atk >=2.38.0,<3.0a0
   size: 322172
   timestamp: 1619123713021
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
@@ -2191,6 +4148,9 @@ packages:
   - xorg-libxtst
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - at-spi2-core >=2.40.3,<2.41.0a0
   size: 622407
   timestamp: 1625848355776
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
@@ -2204,8 +4164,143 @@ packages:
   - atk-1.0 2.38.0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - atk-1.0 >=2.38.0
   size: 358327
   timestamp: 1713898303194
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
+  sha256: 08b1667546b6cadc722a5690632430eb793e0e92895115e6b55a83ef2e6a098e
+  md5: ba4cb3df9e4a6013be09a6884070a69f
+  depends:
+  - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.3,<0.10.4.0a0
+  size: 144116
+  timestamp: 1781802957479
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
+  sha256: 8e034414d5805fdb6ff7c6a2d44446792b8e4e32c20b53ce4f86999da64c590a
+  md5: 74b8d65bdec1ef7da95acde54a1d649b
+  depends:
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 60443
+  timestamp: 1780566690962
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
+  sha256: 2151746543fe6f53fea754a2eafaee5c1aae3ab5653cfb7d4e684adc0b44034b
+  md5: 18a6c06d8874981e1bf97b11bde95d4b
+  depends:
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.0,<0.14.1.0a0
+  size: 266714
+  timestamp: 1780160817471
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
+  sha256: ecb5986725571eab54e8a20e5b0a189171b51c494bbdfb019c34bb33218d608a
+  md5: 4cdf3f4e3f148e7b8c75685d19c373ea
+  depends:
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 23281
+  timestamp: 1780566261942
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
+  sha256: 2261f841fae2fe87ed5dd61897eeeb3aa72a946ff3cf7d9474289820fd6914e5
+  md5: 7a2cfa541ed40c59f221e03b2e63d7e2
+  depends:
+  - libgcc >=14
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 217829
+  timestamp: 1780586784832
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
+  sha256: 2cb4a129d119356f0e7f02d36ff0625b856ec94db49018d0ef9ff5f7e61681a3
+  md5: 6a4abaf2e970323cc7056f4a2f639ca6
+  depends:
+  - libgcc >=14
+  - s2n >=1.7.4,<1.7.5.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-io >=0.26.3,<0.26.4.0a0
+  size: 186873
+  timestamp: 1781649826550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+  sha256: 9a62d67348d140c5b626f72f1d5f5192e6ea0cbdf047e7ebd9f46f33f63e268a
+  md5: 88df147dd58567e2a18eabd84d37f79f
+  depends:
+  - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - openssl >=3.5.7,<4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 160942
+  timestamp: 1781252023638
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
+  sha256: 2cdcddc176ad9a255e4f38c20eb72ee45bad879ac43f080c1ccb2f6ff06fd950
+  md5: 63d2469f561dbd794d4e73de32f16fb5
+  depends:
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 69143
+  timestamp: 1781063636600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
+  sha256: 5caf0bc9b514034718857342b1c6823a270f3cc8ad8045baeea44f80e4a9067d
+  md5: 1f8e43bb5e4f27d3b1f502b6f928ccdf
+  depends:
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 99764
+  timestamp: 1780568553770
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.5.0-py313h5c42d0f_0.conda
   sha256: 18188329658487e5bcf347c05a3bd54d79ab1cd6a225c635ee490a0253b14e45
   md5: 5c578c27b3e1de6eca8d5835d7079aad
@@ -2217,6 +4312,23 @@ packages:
   license: BSD-3-Clause AND MIT AND EPL-2.0
   size: 244976
   timestamp: 1778594051726
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+  sha256: f1e408fc32e1fda8dee9c3fceee5650fd622526e4dc6fa1f1926f497b5508d13
+  md5: 2cbbd6264ad58887c40aab37f2abdaba
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - blosc >=1.21.6,<2.0a0
+  size: 36414
+  timestamp: 1733513501944
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.2.0-py313hb260801_1.conda
   sha256: 5fe27389162240ab9a5cd8d112d51bdd9019f9a68c5593b5298e54f0437f714f
   md5: 523c55147ba15d3e0e0cdb9f67cda339
@@ -2232,6 +4344,22 @@ packages:
   license_family: MIT
   size: 372678
   timestamp: 1764017653333
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.2.0-py314h352cb57_1.conda
+  sha256: 5a5b0cdcd7ed89c6a8fb830924967f6314a2b71944bc1ebc2c105781ba97aa75
+  md5: a1b5c571a0923a205d663d8678df4792
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - libbrotlicommon 1.2.0 he30d5cf_1
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 373193
+  timestamp: 1764017486851
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
   sha256: b3495077889dde6bb370938e7db82be545c73e8589696ad0843a32221520ad4c
   md5: 840d8fc0d7b3209be93080bc20e07f2d
@@ -2239,8 +4367,23 @@ packages:
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
   size: 192412
   timestamp: 1771350241232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+  sha256: 7ec8a68efe479e2e298558cbc2e79d29430d5c7508254268818c0ae19b206519
+  md5: 1dfbec0d08f112103405756181304c16
+  depends:
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - c-ares >=1.34.6,<2.0a0
+  size: 217215
+  timestamp: 1765214743735
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
   sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
   md5: 043c13ed3a18396994be9b4fab6572ad
@@ -2264,8 +4407,26 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
   size: 927045
   timestamp: 1766416003626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
+  sha256: 9e1d45f421282233cd610278f38edd87345a621c301e8a201efffa90465dbcd0
+  md5: de94dba081079719017a6975975dbea0
+  depends:
+  - libgcc >=14
+  - numpy >=1.21.2
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 422019
+  timestamp: 1768510966492
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-cbc-2.10.13-h3e6914b_1.conda
   sha256: 1066e6e576ef5680b98ff5f1817e4356ac97926366515003c22fdb663af7fee0
   md5: c8e8ce03cd9d86239b44da95bf046f3d
@@ -2288,6 +4449,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cbc >=2.10.13,<2.11.0a0
   size: 887825
   timestamp: 1778586355888
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-cgl-0.60.10-h082c6d9_1.conda
@@ -2311,6 +4475,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cgl >=0.60,<0.61.0a0
   size: 528375
   timestamp: 1778571343211
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-clp-1.17.11-h1805f0b_1.conda
@@ -2333,6 +4500,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-clp >=1.17,<1.18.0a0
   size: 1117586
   timestamp: 1778522645270
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-osi-0.108.12-h42e9861_1.conda
@@ -2354,6 +4524,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-osi >=0.108,<0.109.0a0
   size: 358160
   timestamp: 1778512669451
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coin-or-utils-2.11.13-h6d11b10_1.conda
@@ -2372,6 +4545,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-utils >=2.11,<2.12.0a0
   size: 658369
   timestamp: 1778502358840
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.16.2-h70963c4_1.conda
@@ -2384,6 +4560,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - libexpat >=2.7.3,<3.0a0
   license: AFL-2.1 OR GPL-2.0-or-later
+  run_exports:
+    weak:
+    - dbus >=1.16.2,<2.0a0
   size: 480416
   timestamp: 1764536098891
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
@@ -2405,6 +4584,9 @@ packages:
   - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - epoxy >=1.5.10,<1.6.0a0
   size: 422103
   timestamp: 1758743388115
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.17.1-hba86a56_0.conda
@@ -2421,12 +4603,33 @@ packages:
   license_family: MIT
   size: 279044
   timestamp: 1771382728182
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+  sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
+  md5: f4d29a0cd77104a683607319a542ac7e
+  depends:
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.1,<3.0a0
+    - fonts-conda-ecosystem
+  size: 290522
+  timestamp: 1780450108132
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
   sha256: 1bfcd715bcb49a0b22d5d1899a22c6ff884b06f8e141eb746f3949752469a422
   md5: f3ac54914f7d3e1d68cb8d891765e5f9
   depends:
   - libgcc >=14
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - fribidi >=1.0.16,<2.0a0
   size: 62909
   timestamp: 1757438620177
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.6-h90308e0_0.conda
@@ -2441,6 +4644,9 @@ packages:
   - libtiff >=4.7.1,<4.8.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gdk-pixbuf >=2.44.6,<3.0a0
   size: 583708
   timestamp: 1774987740322
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.88.1-h7439e1d_2.conda
@@ -2453,6 +4659,17 @@ packages:
   license: LGPL-2.1-or-later
   size: 257707
   timestamp: 1778508920982
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.88.2-h7aeb4f4_0.conda
+  sha256: cbb0679fccff1b87253d24a8aee96bf3908f16c4a1a828c35578ed8e8d516a61
+  md5: c7195d7c970b8bdca5d6b5f6adb66886
+  depends:
+  - libglib ==2.88.2 h96a7f82_0
+  - libffi
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  run_exports: {}
+  size: 260096
+  timestamp: 1782464048865
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
   sha256: c9b1781fe329e0b77c5addd741e58600f50bef39321cae75eba72f2f381374b7
   md5: 4aa540e9541cc9d6581ab23ff2043f13
@@ -2463,6 +4680,19 @@ packages:
   license_family: LGPL
   size: 102400
   timestamp: 1755102000043
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+  sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
+  md5: 4db044857ab1d09b2e8f0013c65387c1
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 103119
+  timestamp: 1780455096710
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-14.1.2-h45e821f_0.conda
   sha256: 0ac1a90696a3250febdb1d63a3161b9aad5dc136e602f7f17df4894bd153162c
   md5: 60c3b65c5e60fc70e1b9f0de4d0c2247
@@ -2484,6 +4714,9 @@ packages:
   - pango >=1.56.4,<2.0a0
   license: EPL-1.0
   license_family: Other
+  run_exports:
+    weak:
+    - graphviz >=14.1.2,<15.0a0
   size: 2578234
   timestamp: 1769427141106
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/greenlet-3.5.0-py313h59403f9_0.conda
@@ -2499,6 +4732,20 @@ packages:
   license_family: MIT
   size: 267300
   timestamp: 1777328974331
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/greenlet-3.5.2-py314he6363bd_0.conda
+  sha256: 75f87af795e749f16da05f83ed6c3b1d7a471d96dae0131fe12317e33334602d
+  md5: cebdadc012305b8ada93a4bd7f281597
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - libgcc >=14
+  - libstdcxx >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 271966
+  timestamp: 1781762131323
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.52-h75d4e7a_0.conda
   sha256: 5db1347513253a2d200b111717eb452d4b95e9380db48b6dd2c8bb7bb256d754
   md5: f6a9ed300bcf3217da7f1955f57facec
@@ -2538,6 +4785,10 @@ packages:
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gtk3 >=3.24.52,<4.0a0
+    - adwaita-icon-theme
   size: 6023698
   timestamp: 1774296668544
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
@@ -2549,8 +4800,27 @@ packages:
   - libstdcxx-ng >=12
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gts >=0.7.6,<0.8.0a0
   size: 332673
   timestamp: 1686545222091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
+  sha256: 2949aa9b46bf96fa32b60db02040050df4f43dacb7f959cc0d4f55a3bed3e143
+  md5: ea167ebd2b4588a888ef5c5915c5915f
+  depends:
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 1319185
+  timestamp: 1775581729239
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.0-h1134a53_0.conda
   sha256: cb3e67e8045577b944b64534907d194ebc44e0959e0842847c18a4067eeeb9f6
   md5: 1775defbef30aa990498e753a948cb18
@@ -2569,11 +4839,73 @@ packages:
   license_family: MIT
   size: 2800967
   timestamp: 1776783366021
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
+  sha256: 17a671aa62e1f0a8750514353e3d6e9aab80598908d9b107fc7f3cf7972176b6
+  md5: 5f3ec279ab7cc391b7dff69dc08298fa
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - harfbuzz >=14.2.1
+  size: 2786349
+  timestamp: 1780454506157
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+  sha256: 70d1e2d3e0b9ae1b149a31a4270adfbb5a4ceb2f8c36d17feffcd7bcb6208022
+  md5: e1b6676b77b9690d07ea25de48aed97e
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf4 >=4.2.15,<4.2.16.0a0
+  size: 773862
+  timestamp: 1695661552544
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
+  sha256: 24899626cc632fd98e6ce1e00257f8f500ca60d18fc2a142da760a26b9c11eef
+  md5: fda606c9f7d6418d748f1776b5d9d88a
+  depends:
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf5 >=2.1.0,<3.0a0
+  size: 4191043
+  timestamp: 1781838634022
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
   sha256: 9f7fa161b33de5f001dc43f9d6399ba45b3fb1efb141ee2fec6bf05a48420d63
   md5: af62915a9e4154e16d97f99c64cec14e
   license: GPL-2.0-or-later
   license_family: GPL
+  run_exports: {}
   size: 17670
   timestamp: 1771540496764
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
@@ -2584,6 +4916,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
   size: 12837286
   timestamp: 1773822650615
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/immutables-0.21-py313h6194ac5_2.conda
@@ -2598,14 +4933,47 @@ packages:
   license_family: APACHE
   size: 55680
   timestamp: 1757685529224
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/immutables-0.21-py314h51f160d_2.conda
+  sha256: 17e33fb7725959843ef9c8b76b978da8003a2a96d5d36009171b46743e256a3b
+  md5: 1482daefe2a5ddcce8b5d47e6b2252a9
+  depends:
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 56315
+  timestamp: 1757685487599
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
   sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
   md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
   depends:
   - libgcc >=13
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
   size: 129048
   timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+  sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+  md5: 5fd2304064ef6199d1f91ec60ee7b820
+  depends:
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1518484
+  timestamp: 1781859412954
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
   sha256: b53999d888dda53c506b264e8c02b5f5c8e022c781eda0718f007339e6bc90ba
   md5: d9ca108bd680ea86a963104b6b3e95ca
@@ -2629,6 +4997,7 @@ packages:
   - binutils_impl_linux-aarch64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
+  run_exports: {}
   size: 875596
   timestamp: 1774197520746
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
@@ -2639,8 +5008,24 @@ packages:
   - libstdcxx >=14
   license: Apache-2.0
   license_family: Apache
+  run_exports:
+    weak:
+    - lerc >=4.1.0,<5.0a0
   size: 240444
   timestamp: 1773114901155
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
+  sha256: 8b74acb52cda5f4ba91f59c85132f582de5db9dceff4e252f49c2525d14c600c
+  md5: 345c7bf559743adb5375ee3603911065
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libaec >=1.1.5,<2.0a0
+  size: 37745
+  timestamp: 1769221878827
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-7_haddc8a3_openblas.conda
   build_number: 7
   sha256: f27ba323c2f1e1731b5e880fe520f178f55047f25be94f77e649605b2343c066
@@ -2658,6 +5043,26 @@ packages:
   license_family: BSD
   size: 18696
   timestamp: 1778489796402
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+  build_number: 8
+  sha256: c897399c943168c646f659952f73a9154f9122d7e9b151649dbe075dfdcd484b
+  md5: 8b44dad125760faa2b3925f5a6e3112d
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - mkl <2027
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18843
+  timestamp: 1779859042591
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-7_hd72aa62_openblas.conda
   build_number: 7
   sha256: c8f0192362966df0828419f042d6f94c079e5df00ad6bd05b5e84c12b42f8cc7
@@ -2672,6 +5077,23 @@ packages:
   license_family: BSD
   size: 18664
   timestamp: 1778489802790
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+  build_number: 8
+  sha256: 3ba039f0705022939d90e36c1ed2fcbafd7f5bb77563e3702202ae796b32f4d2
+  md5: 76242b7ad6e43809afa8671dd609b4ed
+  depends:
+  - libblas 3.11.0 8_haddc8a3_openblas
+  constrains:
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18817
+  timestamp: 1779859049133
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
   sha256: 41b04f995c9f63af8c4065a35931e46cbc2fdd6b9bf7e4c19f90d53cbb2bc8e5
   md5: 67828c963b17db7dc989fe5d509ef04a
@@ -2682,8 +5104,29 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: Apache-2.0
   license_family: Apache
+  run_exports:
+    weak:
+    - libcups >=2.3.3,<2.4.0a0
   size: 4553739
   timestamp: 1770903929794
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-hc57f145_0.conda
+  sha256: 738dfa4f3b148f77656b3e13371dad2f57c320c762d90d0f1142039b53d07d41
+  md5: 24e94f80c49aca799681ac65421d6920
+  depends:
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 504660
+  timestamp: 1782296544717
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
   sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
   md5: a9138815598fe6b91a1d6782ca657b0c
@@ -2691,6 +5134,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
   size: 71117
   timestamp: 1761979776756
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-he30d5cf_1.conda
@@ -2703,6 +5149,19 @@ packages:
   license_family: MIT
   size: 344548
   timestamp: 1757212128414
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.127-he30d5cf_0.conda
+  sha256: 2a941ffcd6b09380344c2cb5b198d2743ce4fc30ec9a5c8c83e53368d8015aef
+  md5: 987d35ad350bb552a30f3d314f6c7655
+  depends:
+  - libgcc >=14
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdrm >=2.4.127,<2.5.0a0
+  size: 345283
+  timestamp: 1778975814771
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
   sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
   md5: fb640d776fc92b682a14e001980825b1
@@ -2712,6 +5171,9 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: BSD-2-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
   size: 148125
   timestamp: 1738479808948
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
@@ -2722,6 +5184,15 @@ packages:
   license: LicenseRef-libglvnd
   size: 53551
   timestamp: 1731330990477
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_3.conda
+  sha256: b987d3874edfcd9c7ddca86c003cb04ae51160a72c173a24cd46ab9eeb8886ab
+  md5: ec017f25e5d01ef9dd81e95ff73ff051
+  depends:
+  - libglvnd 1.7.0 hd24410f_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 54600
+  timestamp: 1779728234591
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
   sha256: 9c8e9d2289316741d037f0c5003de42488780d181453543f75497dd5a4891c7c
   md5: cd8877e3833ba1bfac2fbaa5ae72c226
@@ -2732,6 +5203,31 @@ packages:
   license: LicenseRef-libglvnd
   size: 30397
   timestamp: 1731331017398
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_3.conda
+  sha256: 2b5ae66aa91215e915df3c520fed85a17231a067339b54f0594d93689b684c86
+  md5: 8ebac3af4a69a9a41c16442a65bf3ac4
+  depends:
+  - libegl 1.7.0 hd24410f_3
+  - libgl-devel 1.7.0 hd24410f_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libegl >=1.7.0,<2.0a0
+  size: 31552
+  timestamp: 1779728260736
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 115123
+  timestamp: 1702146237623
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.0-hfae3067_0.conda
   sha256: 206c422a7f4b462d1dc17d558f0299088d0992bd3309ae83f5440fcc4f130602
   md5: 3bacd6171f0a3f8fddd06c3d5ae01955
@@ -2743,6 +5239,18 @@ packages:
   license_family: MIT
   size: 76996
   timestamp: 1777846096032
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+  sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+  md5: fac3b65a605cd253037fdf3daf2de8d9
+  depends:
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77649
+  timestamp: 1781203572523
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
   sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
   md5: 2f364feefb6a7c00423e80dcb12db62a
@@ -2750,6 +5258,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.5.2,<3.6.0a0
   size: 55952
   timestamp: 1769456078358
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_0.conda
@@ -2760,6 +5271,15 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 8125
   timestamp: 1774301094057
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+  sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+  md5: a13e600f9d18488b1fd1257344dbfdaa
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 8381
+  timestamp: 1780933505754
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_0.conda
   sha256: 8e6b27fe4eec4c2fa7b7769a21973734c8dba1de80086fb0213e58375ac09f4c
   md5: b99ed99e42dafb27889483b3098cace7
@@ -2772,6 +5292,19 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 422941
   timestamp: 1774301093473
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+  sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+  md5: 426cc33f8745ce11a73baf73db3954a7
+  depends:
+  - libgcc >=14
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 424236
+  timestamp: 1780933505195
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
   sha256: 4592b096e553f67799ae70d4b6167eeda3ec74587d68c7aecbf4e7b1df136681
   md5: f35b3f52d0a2ec4ffe3c89ba135cdb9a
@@ -2782,6 +5315,7 @@ packages:
   - libgcc-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 622462
   timestamp: 1778268755949
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
@@ -2791,6 +5325,9 @@ packages:
   - libgcc 15.2.0 h8acb6b2_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - libgcc
   size: 27738
   timestamp: 1778268759211
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-h88aa843_12.conda
@@ -2811,6 +5348,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: GD
   license_family: BSD
+  run_exports:
+    weak:
+    - libgd >=2.3.3,<2.4.0a0
   size: 195554
   timestamp: 1766331786625
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
@@ -2822,6 +5362,7 @@ packages:
   - libgfortran-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 27728
   timestamp: 1778268784621
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
@@ -2833,6 +5374,7 @@ packages:
   - libgfortran 15.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 1487244
   timestamp: 1778268767295
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
@@ -2844,6 +5386,16 @@ packages:
   license: LicenseRef-libglvnd
   size: 145442
   timestamp: 1731331005019
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_3.conda
+  sha256: 05c75a2034bdbca29bab467d02ad770ed5e524e4f0670432258f2d8487c95348
+  md5: 6e893c36f31502dd195d3d58f455fdbd
+  depends:
+  - libglvnd 1.7.0 hd24410f_3
+  - libglx 1.7.0 hd24410f_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 148112
+  timestamp: 1779728248678
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
   sha256: ec5c3125b38295bad8acc80f793b8ee217ccb194338d73858be278db50ea82f1
   md5: 5d8323dff6a93596fb6f985cf6e8521a
@@ -2853,6 +5405,18 @@ packages:
   license: LicenseRef-libglvnd
   size: 113925
   timestamp: 1731331014056
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_3.conda
+  sha256: b7483884e5e8df362f113d7d7694f0a37ecf6409f1acaaa889f312688917c067
+  md5: 3a0adce33b3b8a52c76389db1edfec1b
+  depends:
+  - libgl 1.7.0 hd24410f_3
+  - libglx-devel 1.7.0 hd24410f_3
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libgl >=1.7.0,<2.0a0
+  size: 116084
+  timestamp: 1779728257534
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.1-h96a7f82_2.conda
   sha256: 050285afdb7bd98b1b8fb052af9da31fafde586a49d3b56dd33d5338b2d0e411
   md5: 16d72f76bf6fead4a29efb2fede0a06b
@@ -2867,12 +5431,36 @@ packages:
   license: LGPL-2.1-or-later
   size: 4946648
   timestamp: 1778508920982
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+  sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
+  md5: 31d404d8c0755d0f9062a4459f5a1084
+  depends:
+  - libgcc >=14
+  - libffi >=3.5.2,<3.6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.2,<3.0a0
+  size: 4943441
+  timestamp: 1782464048865
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
   sha256: 57ec3898a923d4bcc064669e90e8abfc4d1d945a13639470ba5f3748bd3090da
   md5: 9e115653741810778c9a915a2f8439e7
   license: LicenseRef-libglvnd
   size: 152135
   timestamp: 1731330986070
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_3.conda
+  sha256: ca124e53765a2b123e0ca6ce809c7caf188bb26e5fe125b69099378276d5e66f
+  md5: a2ad848c0aab2e326c6af08ea20502f4
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 146645
+  timestamp: 1779728228274
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
   sha256: 6591af640cb05a399fab47646025f8b1e1a06a0d4bbb4d2e320d6629b47a1c61
   md5: 1d4269e233636148696a67e2d30dad2a
@@ -2882,6 +5470,16 @@ packages:
   license: LicenseRef-libglvnd
   size: 77736
   timestamp: 1731330998960
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
+  sha256: 2698b415b9f7b692cd64e34db623e1a6e54ed54e78b0b4e5d4ea6762791e9118
+  md5: 338faf34b78d053841098c0528699e34
+  depends:
+  - libglvnd 1.7.0 hd24410f_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 76704
+  timestamp: 1779728242753
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
   sha256: 4bc28ecc38f30ca1ac66a8fb6c5703f4d888381ec46d3938b7c3383210061ec5
   md5: 1f9ddbb175a63401662d1c6222cef6ff
@@ -2892,11 +5490,27 @@ packages:
   license: LicenseRef-libglvnd
   size: 26362
   timestamp: 1731331008489
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
+  sha256: b30433c4f56bec0a7d9d288e0a456ed280183e32f3f4880ada2189fc12804a52
+  md5: 3da9719866b95bddcad86c8aec6a8ba2
+  depends:
+  - libglx 1.7.0 hd24410f_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libglx >=1.7.0,<2.0a0
+  size: 27651
+  timestamp: 1779728252006
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
   sha256: 2370ef0ffcbae5bede3c4bf136add4abc257245eb91f724c99bb4a43116c5a83
   md5: c5e8a379c4a2ec2aea4ba22758c001d9
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 587387
   timestamp: 1778268674393
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -2905,6 +5519,9 @@ packages:
   depends:
   - libgcc >=14
   license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 791226
   timestamp: 1754910975665
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
@@ -2915,6 +5532,9 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.1.4.1,<4.0a0
   size: 693143
   timestamp: 1775962625956
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-7_h88aeb00_openblas.conda
@@ -2931,6 +5551,23 @@ packages:
   license_family: BSD
   size: 18685
   timestamp: 1778489809140
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+  build_number: 8
+  sha256: d269a684afa0b2fdb44d6b60167f854f30410cdb5ee49a7275c026f6b10c8d05
+  md5: 3af3f2aa755abc5e91351114ae214f55
+  depends:
+  - libblas 3.11.0 8_haddc8a3_openblas
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18828
+  timestamp: 1779859055749
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-7_hb558247_openblas.conda
   build_number: 7
   sha256: 8bced21ae9b0e936d1e7e8cf23061016cf30ded8a6d442749faf0631fa1e7404
@@ -2945,6 +5582,23 @@ packages:
   license_family: BSD
   size: 18696
   timestamp: 1778489816382
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-8_hb558247_openblas.conda
+  build_number: 8
+  sha256: 6df81f56c233180d4912c5df7d82efb382d4472c8e70f30acf430bc05f296221
+  md5: 40b47c343582961fa1e3e210a7000a81
+  depends:
+  - libblas 3.11.0 8_haddc8a3_openblas
+  - libcblas 3.11.0 8_hd72aa62_openblas
+  - liblapack 3.11.0 8_h88aeb00_openblas
+  constrains:
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapacke >=3.11.0,<3.12.0a0
+  size: 18853
+  timestamp: 1779859062300
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
   sha256: d61962b9cd54c3554361550203c64d5b65b71e3058a285b66e4b04b9769f0a5c
   md5: 76298a9e6d71ee6e832a8d0d7373b261
@@ -2953,6 +5607,9 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
   size: 126102
   timestamp: 1775828008518
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
@@ -2962,8 +5619,52 @@ packages:
   - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
+  run_exports: {}
   size: 114056
   timestamp: 1769482343003
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-nompi_h441b98c_104.conda
+  sha256: 88002596e0e26d387c7091bce8672cfd87a1dec695b600e0ef55789f7ad8618a
+  md5: a6690e6628694b3a972ca973244180d9
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzip >=1.11.2,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnetcdf >=4.10.0,<4.10.1.0a0
+  size: 881371
+  timestamp: 1776686645132
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+  sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+  md5: be5f0f007a4500a226ef001115535a3d
+  depends:
+  - c-ares >=1.34.6,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 726928
+  timestamp: 1773854039807
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
   sha256: b018ecfb05e75a8eea3f21f6b5c5c2a54b5178bdcf19e2e2df2735740214a8c8
   md5: 58a66cd95e9692f08abe89f55a6f3f12
@@ -2975,6 +5676,9 @@ packages:
   - openblas >=0.3.33,<0.3.34.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
   size: 5121336
   timestamp: 1776993423004
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
@@ -2986,6 +5690,18 @@ packages:
   license_family: MIT
   size: 29512
   timestamp: 1749901899881
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
+  sha256: 5d26d751b7cc4b66e28ed1ae75900956600aaa5c5d874d5a8cf106d3aff834d3
+  md5: 462239e256bc180c9c45dd049ba797ee
+  depends:
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libpciaccess >=0.19,<0.20.0a0
+  size: 30294
+  timestamp: 1773533057559
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
   sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
   md5: f51503ac45a4888bce71af9027a2ecc9
@@ -2993,6 +5709,9 @@ packages:
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
   size: 341202
   timestamp: 1776315188425
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
@@ -3013,6 +5732,27 @@ packages:
   license: LGPL-2.1-or-later
   size: 3010317
   timestamp: 1773821086415
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.3-hf685517_0.conda
+  sha256: c95ac70755863d8522c1115b54afca86148ea25366b616aa84c993c2ca54b9ce
+  md5: 38209cc04b3e3e5624c534bc703e6939
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.18.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.6,<3.0a0
+  - harfbuzz >=14.2.0
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - librsvg >=2.62.3,<3.0a0
+  size: 3052373
+  timestamp: 1780456154830
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.1-h022381a_0.conda
   sha256: ad03b7d8e4d08001f0df88ee7a56108bb35bae4795a42b9a04cc1abfa822bd07
   md5: 2ec1119217d8f0d086e9a62f3cb0e5ea
@@ -3022,6 +5762,33 @@ packages:
   license: blessing
   size: 955361
   timestamp: 1777986487553
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.2-h10b116e_2.conda
+  sha256: 720506c6648afb41e0c547450a70cd5c86f5c63d8e73e0b344ca197712f1a7a9
+  md5: 634c615f46094282868ecaef04518131
+  depends:
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.2,<4.0a0
+  size: 967525
+  timestamp: 1782494438995
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+  sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+  md5: eecc495bcfdd9da8058969656f916cc2
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 311396
+  timestamp: 1745609845915
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
   sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
   md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
@@ -3031,6 +5798,7 @@ packages:
   - libstdcxx-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 5546559
   timestamp: 1778268777463
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
@@ -3040,6 +5808,9 @@ packages:
   - libstdcxx 15.2.0 hef695bb_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports:
+    strong:
+    - libstdcxx
   size: 27803
   timestamp: 1778268813278
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
@@ -3056,6 +5827,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
+  run_exports:
+    weak:
+    - libtiff >=4.7.1,<4.8.0a0
   size: 488407
   timestamp: 1762022048105
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42-h1022ec0_0.conda
@@ -3067,6 +5841,18 @@ packages:
   license_family: BSD
   size: 43567
   timestamp: 1775052485727
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+  sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+  md5: 58fa42bc4bc71fc329889497ec15effb
+  depends:
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 43248
+  timestamp: 1781625528371
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
   sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
   md5: 24e92d0942c799db387f5c9d7b81f1af
@@ -3076,6 +5862,9 @@ packages:
   - libwebp 1.6.0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
   size: 359496
   timestamp: 1752160685488
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
@@ -3088,6 +5877,9 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
   size: 397493
   timestamp: 1727280745441
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.1-h3c6a4c8_0.conda
@@ -3105,6 +5897,24 @@ packages:
   license_family: MIT
   size: 863646
   timestamp: 1764794352540
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.2-h3c6a4c8_0.conda
+  sha256: 8f44670a714a12589bc82ea179e46ba4a19c4458d5cee765ddd4d5224eccd912
+  md5: d6fc9ac66ea61eb662747959d0a68c57
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 875994
+  timestamp: 1780213408784
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h79dcc73_0.conda
   sha256: ad048a9ca1bf2cdfedb2b0c231050da416c44ee1436a3d1a83b51d2e2deaa842
   md5: 68866231cfe8789e780347f2482df96d
@@ -3118,6 +5928,7 @@ packages:
   - libxml2 2.15.3
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 601948
   timestamp: 1776376758674
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h869d058_0.conda
@@ -3132,8 +5943,27 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
   size: 48101
   timestamp: 1776376766341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
+  sha256: 9ae7edbe6dcdaa0371736118a1e05ffa47c15c0118a092ff1b0a35cbb621ac2d
+  md5: faf7adbb1938c4aa7a312f110f46859b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libzip >=1.11.2,<2.0a0
+  size: 117603
+  timestamp: 1730442215935
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
   sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
   md5: 502006882cf5461adced436e410046d1
@@ -3141,8 +5971,24 @@ packages:
   - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
   size: 69833
   timestamp: 1774072605429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
+  sha256: 67e55058d275beea76c1882399640c37b5be8be4eb39354c94b610928e9a0573
+  md5: 6654e411da94011e8fbe004eacb8fe11
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - lz4-c >=1.10.0,<1.11.0a0
+  size: 184953
+  timestamp: 1733740984533
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py313hfa222a2_1.conda
   sha256: e17b67ce69e04c9ac2b4d1e5458c924226cc8fba590f26c49983a2285879df56
   md5: ff5f5c0af92d01fff0aff006a8eb78a8
@@ -3156,14 +6002,75 @@ packages:
   license_family: BSD
   size: 26561
   timestamp: 1772446359098
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py314hb76de3f_1.conda
+  sha256: 383c188496d13a55658c06e61e7d4cdff2c9f9d5a0648769fca8250bece7e0ef
+  md5: e5de3c36dd548b35ff2a8aa49208dcb3
+  depends:
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 27913
+  timestamp: 1772446407659
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
   sha256: 369db85c5cd8d99dde364ce70725d76511d9c8199e5b820c740414091bf5bcca
   md5: b2a43456aa56fe80c2477a5094899eff
   depends:
   - libgcc >=14
   license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
   size: 960036
   timestamp: 1777422174534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf4-1.7.4-nompi_py311hf700f0f_108.conda
+  noarch: python
+  sha256: e0cbfefe2e07b84c43eb160f76af44ad92733f295ec3c9ef9857d3004866bdb9
+  md5: 33160e3c74ded95e81b05be823a9860c
+  depends:
+  - python
+  - certifi
+  - cftime
+  - numpy
+  - packaging
+  - hdf5
+  - libnetcdf
+  - libgcc >=14
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.23,<3
+  - libzlib >=1.3.2,<2.0a0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1067566
+  timestamp: 1782151952863
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.5.0-py314he1698a1_0.conda
+  sha256: 8677e6bd3a1a95f8ecf2b0f1ca39f30f55b1aa0865b217bb3cb55b29d3e092fa
+  md5: 10165160938f6498096bda3e0ff051ac
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - libcblas >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - liblapack >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 8158865
+  timestamp: 1782112546539
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.2-h546c87b_0.conda
   sha256: 348cb74c1530ac241215d047ef65d134cf797af935c97a68655319362b7e6a01
   md5: 3b129669089e4d6a5c6871dbb4669b99
@@ -3174,6 +6081,19 @@ packages:
   license_family: Apache
   size: 3706406
   timestamp: 1775589602258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+  sha256: da4a5df42614166b69c2f6d8602fc1425f7aaa699f77c3bafb5c7fe69b3d9fb7
+  md5: fa6260b3e6eababf6ca85a7eb3336383
+  depends:
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3704664
+  timestamp: 1781069675555
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
   sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
   md5: 3fc7cc25bba3381e77b753578058e3b0
@@ -3191,6 +6111,9 @@ packages:
   - libpng >=1.6.55,<1.7.0a0
   - libzlib >=1.3.2,<2.0a0
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - pango >=1.56.4,<2.0a0
   size: 470441
   timestamp: 1774284032397
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
@@ -3202,6 +6125,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 1166552
   timestamp: 1763655534263
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
@@ -3213,6 +6139,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
   size: 357913
   timestamp: 1754665583353
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py313h62ef0ea_0.conda
@@ -3227,6 +6156,19 @@ packages:
   license_family: BSD
   size: 233242
   timestamp: 1769678166435
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
+  sha256: ebef2c2e8f84d6d02baf3317d0c1c7c737f2f0bc8f28a8a2a2f8e606b3dc5514
+  md5: 4d45bdf8795717e336bfa2c6e0e7847d
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 236068
+  timestamp: 1769678155154
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
   sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
   md5: bb5a90c93e3bac3d5690acf76b4a6386
@@ -3234,6 +6176,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 8342
   timestamp: 1726803319942
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulp-2.8.0-py313h0216428_3.conda
@@ -3249,6 +6192,20 @@ packages:
   license_family: MIT
   size: 227855
   timestamp: 1757853358429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulp-2.8.0-py314h8bc8a6e_3.conda
+  sha256: b02d5abb421028052625b193b8b9fd8869d292b6b484f05841c4003df7268fb3
+  md5: 02bf7d5af7059846ef48818d6d9fa373
+  depends:
+  - amply >=0.1.2
+  - coin-or-cbc
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 229859
+  timestamp: 1757853315015
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pydantic-core-2.46.4-py313h5e7b836_0.conda
   sha256: da08964c8b23cbdcb8c4a3126426a7fbdcd225cd5dc8648314ebfb46b9aa609c
   md5: eccad43edab90cf670beeb452a568517
@@ -3264,6 +6221,22 @@ packages:
   license_family: MIT
   size: 1781052
   timestamp: 1778084245909
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pydantic-core-2.46.4-py314h451b6cc_0.conda
+  sha256: 1a7c6b18e404c13c4d959888ecb48a9ed9de0e41be2872932b83a35278088df0
+  md5: 9c3ace6aba6df14b943256095ac1281e
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1780773
+  timestamp: 1778084251775
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.13-h11c0449_100_cp313.conda
   build_number: 100
   sha256: d14e731e871d6379f8b82f3af5eb3382caa444880a9fc9d1d12033748277eb14
@@ -3289,6 +6262,37 @@ packages:
   size: 34042952
   timestamp: 1775613691000
   python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
+  build_number: 100
+  sha256: dd56fd95db3cb49a69fbe41df80afc8bd5214daa829bcd3930de80f0408ba5eb
+  md5: 416c74941d13d9f2b9e68b1a900f7f50
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 34900936
+  timestamp: 1781254861576
+  python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py313hd3a54cf_1.conda
   sha256: 9dbfdb53af5d27ac2eec5db4995979fdaaea76766d4f01cd3524dd7d24f79fb9
   md5: 14b86e046b0c5c5508602165287dd01c
@@ -3302,6 +6306,20 @@ packages:
   license_family: MIT
   size: 194182
   timestamp: 1770223431084
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+  sha256: 496b5e65dfdd0aaaaa5de0dcaaf3bceea00fcb4398acf152f89e567c82ec1046
+  md5: 9ae2c92975118058bd720e9ba2bb7c58
+  depends:
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 195678
+  timestamp: 1770223441816
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
   sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
   md5: 3d49cad61f829f4f0e0611547a9cda12
@@ -3310,6 +6328,9 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
   size: 357597
   timestamp: 1765815673644
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py313h8f1d341_0.conda
@@ -3325,6 +6346,68 @@ packages:
   license_family: MIT
   size: 379877
   timestamp: 1764543343027
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-2026.5.1-py314h721bf50_0.conda
+  sha256: 9f3cf6ca465df3261681182acd685d4fde4449daa5f7e2dbe312613d04929b70
+  md5: 8c968b5f8510ce46279981e455e3fa4c
+  depends:
+  - python
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 303746
+  timestamp: 1779976996862
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
+  sha256: 2123c7c025a0fd9ab0d46770524ef0e83c254c2a0af494e11230d613becbf87f
+  md5: 5a4f2fbdea654d46e98c8922c178ce0b
+  depends:
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - s2n >=1.7.4,<1.7.5.0a0
+  size: 358754
+  timestamp: 1781634162687
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
+  sha256: 401d63fc4d1b1d942b9cae09abac6cf2c65a121f2adc6d50096b5576e263af0c
+  md5: 3aad2b7b36cdd59c7ac05d4da908401f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 17107935
+  timestamp: 1781912692906
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
+  sha256: a8a79c53852fb07286407907402caa5a96b6e22b518c4f010be40647f9ee3726
+  md5: 3dec912091fb88614afa0af2712c1362
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - snappy >=1.2.2,<1.3.0a0
+  size: 47096
+  timestamp: 1762948094646
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlalchemy-2.0.49-py313hc37f9cf_0.conda
   sha256: 60a69c7cf1136db33703ce53f810c93c3eca85d117dbe121fa09478355c02007
   md5: 74369ed16f351dbb59d0545917cd94fa
@@ -3338,6 +6421,20 @@ packages:
   license_family: MIT
   size: 3852605
   timestamp: 1775241597035
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py314hf8f541d_0.conda
+  sha256: 9e09d6c18af3156f48b885c4f3ac2008e738fc69ab8f9598099972435e492eb2
+  md5: 316ea2a86e0d0408dea4ff80740a0245
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4050670
+  timestamp: 1781548196065
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
   sha256: e25c314b52764219f842b41aea2c98a059f06437392268f09b03561e4f6e5309
   md5: 7fc6affb9b01e567d2ef1d05b84aa6ed
@@ -3348,6 +6445,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
   size: 3368666
   timestamp: 1769464148928
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
@@ -3360,6 +6460,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - wayland >=1.25.0,<2.0a0
   size: 335260
   timestamp: 1773959583826
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-1.17.3-py313h6194ac5_1.conda
@@ -3374,6 +6477,19 @@ packages:
   license_family: BSD
   size: 64996
   timestamp: 1756851694287
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-1.17.3-py314h51f160d_1.conda
+  sha256: 3f311dc4faf9593d59bb993a25c2ce55f443267e6d7ec42c83de325c603f0250
+  md5: 69cc319c35952c14dfb5f00940a1021f
+  depends:
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 65955
+  timestamp: 1756851771522
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.47-he30d5cf_0.conda
   sha256: ec7ff9dffbd41faa31a30fa0724699f05bca000d57c745a195ecdb56888a8605
   md5: 4ac707a4279972357712af099cd1ae50
@@ -3384,6 +6500,17 @@ packages:
   license_family: MIT
   size: 399629
   timestamp: 1772021320967
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
+  sha256: 96078068df25ddccc60958be740e6fa99efb1e0fa2dae2f84e775201bf84d70c
+  md5: 3dbc6d9e1f8a8768e7ef9f57585a43ca
+  depends:
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 442725
+  timestamp: 1782027381059
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
   sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
   md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
@@ -3391,6 +6518,9 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libice >=1.1.2,<2.0a0
   size: 60433
   timestamp: 1734229908988
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
@@ -3402,6 +6532,9 @@ packages:
   - xorg-libice >=1.1.2,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libsm >=1.2.6,<2.0a0
   size: 28701
   timestamp: 1741897678254
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -3412,6 +6545,9 @@ packages:
   - libxcb >=1.17.0,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
   size: 869058
   timestamp: 1770819244991
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
@@ -3421,6 +6557,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxau >=1.0.12,<2.0a0
   size: 16317
   timestamp: 1762977521691
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
@@ -3432,6 +6571,9 @@ packages:
   - xorg-libxfixes >=6.0.2,<7.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcomposite >=0.4.7,<1.0a0
   size: 14915
   timestamp: 1770044415607
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
@@ -3444,6 +6586,9 @@ packages:
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcursor >=1.2.3,<2.0a0
   size: 34596
   timestamp: 1730908388714
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
@@ -3456,6 +6601,9 @@ packages:
   - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdamage >=1.1.6,<2.0a0
   size: 13794
   timestamp: 1727891406431
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
@@ -3465,6 +6613,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 21039
   timestamp: 1762979038025
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
@@ -3475,6 +6626,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
   size: 52409
   timestamp: 1769446753771
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
@@ -3485,6 +6639,9 @@ packages:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxfixes >=6.0.2,<7.0a0
   size: 20704
   timestamp: 1759284028146
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
@@ -3499,6 +6656,21 @@ packages:
   license_family: MIT
   size: 48197
   timestamp: 1727801059062
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.3-he30d5cf_0.conda
+  sha256: 0c1c7b39763469cfe0e9c6d0f9a39415321f477710719f4c5d63c61ea270271c
+  md5: f8ad5777ecc217d383a722598dbeb1ac
+  depends:
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxi >=1.8.3,<2.0a0
+  size: 49292
+  timestamp: 1779113229775
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.6-hfae3067_0.conda
   sha256: 2039990aa8454f19e8f890ff1e8582f12fa475af7e836b184adc17b88a22c9b8
   md5: a488ab283de297dc0de69796f7467a71
@@ -3509,6 +6681,9 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxinerama >=1.1.6,<1.2.0a0
   size: 15322
   timestamp: 1769432283298
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
@@ -3521,6 +6696,9 @@ packages:
   - xorg-libxrender >=0.9.12,<0.10.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrandr >=1.5.5,<2.0a0
   size: 31122
   timestamp: 1769445286951
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
@@ -3531,6 +6709,9 @@ packages:
   - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
   size: 33649
   timestamp: 1734229123157
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
@@ -3543,6 +6724,9 @@ packages:
   - xorg-libxi >=1.7.10,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxtst >=1.2.5,<2.0a0
   size: 33786
   timestamp: 1727964907993
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.7-he30d5cf_0.conda
@@ -3554,6 +6738,9 @@ packages:
   - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxxf86vm >=1.1.7,<2.0a0
   size: 19148
   timestamp: 1769434729220
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2025.1-he30d5cf_0.conda
@@ -3563,6 +6750,7 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 569539
   timestamp: 1766155414260
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
@@ -3572,6 +6760,9 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
   size: 88088
   timestamp: 1753484092643
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
@@ -3581,8 +6772,22 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
   size: 614429
   timestamp: 1764777145593
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
+  md5: aaa2a381ccc56eac91d63b6c1240312f
+  depends:
+  - cpython
+  - python-gil
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 8191
+  timestamp: 1744137672556
 - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
   sha256: a362b4f5c96a0bf4def96be1a77317e2730af38915eb9bec85e2a92836501ed7
   md5: b3f0179590f3c0637b7eb5309898f79e
@@ -3592,6 +6797,7 @@ packages:
   - librsvg
   license: LGPL-3.0-or-later OR CC-BY-SA-3.0
   license_family: LGPL
+  run_exports: {}
   size: 631452
   timestamp: 1758743294412
 - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.6-pyhd8ed1ab_1.conda
@@ -3604,6 +6810,17 @@ packages:
   license: EPL-2.0
   size: 21899
   timestamp: 1734603085333
+- conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+  sha256: a21c69c91d735faaf7b74dc2b3d013b14016951b66354461fc1d796caab9b1c4
+  md5: 69a01a9927733014f3955861e2969a7b
+  depends:
+  - docutils >=0.3
+  - pyparsing
+  - python >=3.10
+  license: EPL-2.0
+  run_exports: {}
+  size: 26885
+  timestamp: 1782349642228
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -3612,6 +6829,7 @@ packages:
   - typing-extensions >=4.0.0
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 18074
   timestamp: 1733247158254
 - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
@@ -3621,6 +6839,7 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 12806
   timestamp: 1764079623900
 - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -3631,8 +6850,19 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 64927
   timestamp: 1773935801332
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+  noarch: generic
+  sha256: 709cac7434d1c5a8828105036212a2a36022a07d807e89e2e99cac939c2d2526
+  md5: 40d89d8546ad6e139e73ec8f6d56068b
+  depends:
+  - python >=3.14
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  run_exports: {}
+  size: 7526
+  timestamp: 1781450817767
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
   sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
   md5: e18ad67cf881dcadee8b8d9e2f8e5f73
@@ -3641,6 +6871,36 @@ packages:
   license: ISC
   size: 131039
   timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+  md5: a9965dd99f683c5f444428f896635716
+  depends:
+  - __unix
+  license: ISC
+  run_exports: {}
+  size: 128866
+  timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  noarch: python
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 11065
+  timestamp: 1615209567874
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
   sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
   md5: 929471569c93acefb30282a22060dcd5
@@ -3649,6 +6909,15 @@ packages:
   license: ISC
   size: 135656
   timestamp: 1776866680878
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+  sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
+  md5: c13824fedced67005d3832c152fe9c2f
+  depends:
+  - python >=3.10
+  license: ISC
+  run_exports: {}
+  size: 133877
+  timestamp: 1781719949728
 - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   md5: a9167b9571f3baa9d448faa2139d1089
@@ -3656,6 +6925,7 @@ packages:
   - python >=3.10
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 58872
   timestamp: 1775127203018
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -3665,6 +6935,7 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 27011
   timestamp: 1733218222191
 - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
@@ -3675,6 +6946,7 @@ packages:
   - pyyaml >=6.0.0,<7.0.0
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 10327
   timestamp: 1717043667069
 - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
@@ -3686,6 +6958,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 45817
   timestamp: 1773233306055
 - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
@@ -3695,14 +6968,27 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 8331
   timestamp: 1608581999360
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
+  noarch: generic
+  sha256: 7a548856ef5307890a8cadfc196655117658f8c24589ce175caa4c1c2ded9d13
+  md5: b28fe35fd43d5f425c0dccbe5b5039fd
+  depends:
+  - python >=3.14,<3.15.0a0
+  - python_abi * *_cp314
+  license: Python-2.0
+  run_exports: {}
+  size: 49333
+  timestamp: 1781254618863
 - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
   sha256: 0d605569a77350fb681f9ed8d357cc71649b59a304099dc9d09fbeec5e84a65e
   md5: d6bd3cd217e62bbd7efe67ff224cd667
   depends:
   - python >=3.10
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  run_exports: {}
   size: 438002
   timestamp: 1766092633160
 - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
@@ -3712,6 +6998,7 @@ packages:
   - python >=3.10
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 21853
   timestamp: 1762165431693
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -3721,6 +7008,7 @@ packages:
   - python >=3.10
   - typing_extensions >=4.6.0
   license: MIT and PSF-2.0
+  run_exports: {}
   size: 21333
   timestamp: 1763918099466
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -3728,6 +7016,7 @@ packages:
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 397370
   timestamp: 1566932522327
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
@@ -3735,6 +7024,7 @@ packages:
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
   license_family: Other
+  run_exports: {}
   size: 96530
   timestamp: 1620479909603
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -3742,6 +7032,7 @@ packages:
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
   license_family: Other
+  run_exports: {}
   size: 700814
   timestamp: 1620479612257
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
@@ -3749,6 +7040,7 @@ packages:
   md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
+  run_exports: {}
   size: 1620504
   timestamp: 1727511233259
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
@@ -3758,6 +7050,7 @@ packages:
   - fonts-conda-forge
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 3667
   timestamp: 1566974674465
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
@@ -3770,6 +7063,7 @@ packages:
   - font-ttf-source-code-pro
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 4059
   timestamp: 1762351264405
 - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
@@ -3780,6 +7074,7 @@ packages:
   - smmap >=3.0.1,<6
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 53136
   timestamp: 1735887290843
 - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
@@ -3791,6 +7086,7 @@ packages:
   - typing_extensions >=3.10.0.2
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 162193
   timestamp: 1778065820061
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3803,6 +7099,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 95967
   timestamp: 1756364871835
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
@@ -3814,6 +7111,16 @@ packages:
   license_family: MIT
   size: 30731
   timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+  sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
+  md5: b395909221b9bd1df066e5930e18855b
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 32884
+  timestamp: 1782283986153
 - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
   sha256: fa2071da7fab758c669e78227e6094f6b3608228740808a6de5d6bce83d9e52d
   md5: 7fe569c10905402ed47024fc481bb371
@@ -3822,6 +7129,7 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 73563
   timestamp: 1733928021866
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -3831,6 +7139,7 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 17397
   timestamp: 1737618427549
 - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
@@ -3843,6 +7152,17 @@ packages:
   license_family: BSD
   size: 59038
   timestamp: 1776947141407
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+  sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
+  md5: 577b04680ae422adb86fc60d7b940659
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 163869
+  timestamp: 1781620148226
 - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -3850,6 +7170,7 @@ packages:
   - python >=3.10
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 13387
   timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
@@ -3861,6 +7182,7 @@ packages:
   - python
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 120685
   timestamp: 1764517220861
 - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -3875,6 +7197,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 82356
   timestamp: 1767839954256
 - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
@@ -3886,6 +7209,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 19236
   timestamp: 1757335715225
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
@@ -3902,6 +7226,7 @@ packages:
   - pywin32 >=300
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 65503
   timestamp: 1760643864586
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -3915,6 +7240,7 @@ packages:
   - traitlets >=5.1
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 100945
   timestamp: 1733402844974
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -3925,8 +7251,20 @@ packages:
   - python
   license: Apache-2.0
   license_family: APACHE
+  run_exports: {}
   size: 62477
   timestamp: 1745345660407
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+  sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
+  md5: 2c5ef45db85d34799771629bd5860fd7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 26308
+  timestamp: 1779972894916
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
@@ -3945,6 +7283,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 25877
   timestamp: 1764896838868
 - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -3959,6 +7298,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 346511
   timestamp: 1778103405862
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
@@ -3968,6 +7308,7 @@ packages:
   - python >=3.10
   license: BSD-2-Clause
   license_family: BSD
+  run_exports: {}
   size: 893031
   timestamp: 1774796815820
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -3978,6 +7319,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 110893
   timestamp: 1769003998136
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -3988,6 +7330,7 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 21085
   timestamp: 1733217331982
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -4007,6 +7350,7 @@ packages:
   - pytest-faulthandler >=2
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 294852
   timestamp: 1762354779909
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
@@ -4017,8 +7361,19 @@ packages:
   - python
   license: BSD-3-Clause
   license_family: BSD
+  run_exports: {}
   size: 244628
   timestamp: 1755304154927
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_100.conda
+  sha256: 84c129bdd6abcecac42a948f2670d17fe735d02d3a5a483a9b1f1bc33ba38c28
+  md5: 224f69f177eb5aae6c9a6052846bf609
+  depends:
+  - cpython 3.14.6.*
+  - python_abi * *_cp314
+  license: Python-2.0
+  run_exports: {}
+  size: 49315
+  timestamp: 1781254664376
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
   build_number: 8
   sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
@@ -4029,6 +7384,17 @@ packages:
   license_family: BSD
   size: 7002
   timestamp: 1752805902938
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 6989
+  timestamp: 1752805904792
 - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
   sha256: 0577eedfb347ff94d0f2fa6c052c502989b028216996b45c7f21236f25864414
   md5: 870293df500ca7e18bedefa5838a22ab
@@ -4040,6 +7406,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 51788
   timestamp: 1760379115194
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.0-pyhcf101f3_0.conda
@@ -4058,6 +7425,23 @@ packages:
   license_family: APACHE
   size: 68658
   timestamp: 1778534036810
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+  sha256: 1715246b19c9f85ee022933b4845f2fc14ac9184981b7b7d9b728bec8e9588da
+  md5: 4a85203c1d80c1059086ae860836ffb9
+  depends:
+  - python >=3.10
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - urllib3 >=1.26,<3
+  - python
+  constrains:
+  - chardet >=3.0.2,<8
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 68709
+  timestamp: 1778851103479
 - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.1-pyhcf101f3_0.conda
   sha256: 58185ed2290aa6ef0a5de7012c2a581d75a3577b7e93de455c19fa10d344570a
   md5: 8e4971d25d53f168dfb64d6f5ee1316d
@@ -4067,8 +7451,20 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 57112
   timestamp: 1778331246761
+- conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+  sha256: bc86861086db65c9b56dd6a1605755f41a9875b94fc3b69e137f686700d91aa1
+  md5: b899f1195be56d8215ed1973a8f409c3
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 27262
+  timestamp: 1781021238494
 - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
   sha256: ae723ba6ab7b1998a04ef16b357c1e0043ffd4f4ac9b0da71e393680343a3c86
   md5: 69db183edbe5b7c3e6c157980057a9d0
@@ -4088,6 +7484,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 30854
   timestamp: 1771872849343
 - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
@@ -4098,6 +7495,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 43964
   timestamp: 1772732795746
 - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
@@ -4108,6 +7506,7 @@ packages:
   - python
   license: Apache-2.0
   license_family: APACHE
+  run_exports: {}
   size: 31404
   timestamp: 1770510172846
 - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
@@ -4117,6 +7516,7 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 12341
   timestamp: 1691135604942
 - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
@@ -4127,6 +7527,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 24017
   timestamp: 1764486833072
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -4137,6 +7538,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 21561
   timestamp: 1774492402955
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
@@ -4149,6 +7551,17 @@ packages:
   license_family: BSD
   size: 115165
   timestamp: 1778074251714
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+  sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
+  md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 115158
+  timestamp: 1780507822178
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -4156,6 +7569,7 @@ packages:
   - typing_extensions ==4.15.0 pyhcf101f3_0
   license: PSF-2.0
   license_family: PSF
+  run_exports: {}
   size: 91383
   timestamp: 1756220668932
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
@@ -4167,6 +7581,7 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 20935
   timestamp: 1777105465795
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -4177,12 +7592,14 @@ packages:
   - python
   license: PSF-2.0
   license_family: PSF
+  run_exports: {}
   size: 51692
   timestamp: 1756220668932
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
   license: LicenseRef-Public-Domain
+  run_exports: {}
   size: 119135
   timestamp: 1767016325805
 - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
@@ -4196,6 +7613,7 @@ packages:
   - python >=3.10
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 103560
   timestamp: 1778188657149
 - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
@@ -4208,6 +7626,7 @@ packages:
   - pyyaml >=6.0,<7.0
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 16215
   timestamp: 1764250734338
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -4218,6 +7637,9 @@ packages:
   - llvm-openmp >=9.0.1
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - _openmp_mutex >=4.5
   size: 8325
   timestamp: 1764092507920
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
@@ -4232,8 +7654,140 @@ packages:
   - atk-1.0 2.38.0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - atk-1.0 >=2.38.0
   size: 347530
   timestamp: 1713896411580
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+  sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
+  md5: 1fc365a60432d78b729d1468fce1b6c9
+  depends:
+  - __osx >=11.0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.3,<0.10.4.0a0
+  size: 116705
+  timestamp: 1781803055465
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
+  sha256: 557bc47cbfd01dc569b930c102cd56ca5ba67750bd51a4fcee445246e7e536cd
+  md5: dcac0aa854a1f7f58a59226f5309a44e
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 45764
+  timestamp: 1780567235337
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
+  sha256: 223f67551038366555e6934802d8b375547b142157aad3fc3654c720ac1525c0
+  md5: 3a49923f2b3987a833a264caca603f84
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.0,<0.14.1.0a0
+  size: 226438
+  timestamp: 1780161234587
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
+  sha256: 4289ff476103d109623bd413b12d61307d6267e87fc6a8c29b0aec71dfa8fd84
+  md5: 497edff11fcb32865d8c5d6ab3aef6e0
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 21529
+  timestamp: 1780566290492
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
+  sha256: 06d3b08ed19cd63fd75750e325f19ebf7183b22ee27cbe2ca7b7dd6725d34885
+  md5: f0fc8139091eb8245209bb9ee8911a82
+  depends:
+  - __osx >=11.0
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 177282
+  timestamp: 1780586850553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
+  sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
+  md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-io >=0.26.3,<0.26.4.0a0
+  size: 176911
+  timestamp: 1781649841117
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+  sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
+  md5: 912c61c44a2782693d63af2272551455
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 132571
+  timestamp: 1781253082057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+  sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
+  md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 58773
+  timestamp: 1781798801665
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+  sha256: 9af1483700bb29870297e2390838d3c31293e8cf80fd8a8a9bd9a1446020a8d8
+  md5: 7c5f6a6efce80e728c1f743e064ab657
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 91975
+  timestamp: 1780568646105
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.5.0-py313h7208f8c_0.conda
   sha256: 3ff16bb31de2cd6699804388337a6efa8a33c12850b5387b13ef38460ca605a3
   md5: 27b54f7bbc635f824806978d9d201573
@@ -4245,6 +7799,23 @@ packages:
   license: BSD-3-Clause AND MIT AND EPL-2.0
   size: 243876
   timestamp: 1778594074850
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
+  sha256: c3fe902114b9a3ac837e1a32408cc2142c147ec054c1038d37aec6814343f48a
+  md5: 925acfb50a750aa178f7a0aced77f351
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - blosc >=1.21.6,<2.0a0
+  size: 33602
+  timestamp: 1733513285902
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py313hde1f3bb_1.conda
   sha256: 2e21dccccd68bedd483300f9ab87a425645f6776e6e578e10e0dd98c946e1be9
   md5: b03732afa9f4f54634d94eb920dfb308
@@ -4260,6 +7831,22 @@ packages:
   license_family: MIT
   size: 359568
   timestamp: 1764018359470
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
+  sha256: 5c2e471fd262fcc3c5a9d5ea4dae5917b885e0e9b02763dbd0f0d9635ed4cb99
+  md5: f9501812fe7c66b6548c7fcaa1c1f252
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - libbrotlicommon 1.2.0 hc919400_1
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 359854
+  timestamp: 1764018178608
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
   sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
   md5: 620b85a3f45526a8bc4d23fd78fc22f0
@@ -4267,8 +7854,23 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
   size: 124834
   timestamp: 1771350416561
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+  sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
+  md5: bcb3cba70cf1eec964a03b4ba7775f01
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - c-ares >=1.34.6,<2.0a0
+  size: 180327
+  timestamp: 1765215064054
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
   sha256: cde9b79ee206fe3ba6ca2dc5906593fb7a1350515f85b2a1135a4ce8ec1539e3
   md5: 36200ecfbbfbcb82063c87725434161f
@@ -4286,8 +7888,26 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pixman >=0.46.4,<1.0a0
   license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
   size: 900035
   timestamp: 1766416416791
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
+  sha256: 266ee94a54887cbe8c05ae4ea6d5ea575fafb9d7f64c0ce0859af0fc5a416e59
+  md5: a03f98abd72452e57a6667a58a5a2fdf
+  depends:
+  - __osx >=11.0
+  - numpy >=1.21.2
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 397425
+  timestamp: 1768511349471
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-cbc-2.10.13-h2032c40_1.conda
   sha256: 238328ef13c15fa87ff718ef6bfc32ee83c255f47af7d4ba07190ff865c652fa
   md5: f76979642f978340ec48d809c548732f
@@ -4310,6 +7930,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cbc >=2.10.13,<2.11.0a0
   size: 799849
   timestamp: 1778586417864
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-cgl-0.60.10-h034796e_1.conda
@@ -4333,6 +7956,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-cgl >=0.60,<0.61.0a0
   size: 440213
   timestamp: 1778571470907
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-clp-1.17.11-he934a02_1.conda
@@ -4355,6 +7981,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-clp >=1.17,<1.18.0a0
   size: 914273
   timestamp: 1778520263707
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-osi-0.108.12-h8aa3827_1.conda
@@ -4376,6 +8005,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-osi >=0.108,<0.109.0a0
   size: 326662
   timestamp: 1778511593409
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coin-or-utils-2.11.13-h6bed822_1.conda
@@ -4394,6 +8026,9 @@ packages:
   - coincbc * *_metapackage
   license: EPL-2.0
   license_family: OTHER
+  run_exports:
+    weak:
+    - coin-or-utils >=2.11,<2.12.0a0
   size: 553075
   timestamp: 1778500827484
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
@@ -4403,6 +8038,9 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - epoxy >=1.5.10,<1.6.0a0
   size: 296347
   timestamp: 1758743805063
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
@@ -4418,12 +8056,33 @@ packages:
   license_family: MIT
   size: 237308
   timestamp: 1771382999247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
+  sha256: 8607d8d0b32f9f6fc61ea8c06b537486b78428a04516658222fa4d1d521af765
+  md5: 9d928e6a62192141fb6540a3125b1345
+  depends:
+  - __osx >=11.0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libintl >=0.25.1,<1.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.1,<3.0a0
+    - fonts-conda-ecosystem
+  size: 248677
+  timestamp: 1780450500773
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
   sha256: d856dc6744ecfba78c5f7df3378f03a75c911aadac803fa2b41a583667b4b600
   md5: 04bdce8d93a4ed181d1d726163c2d447
   depends:
   - __osx >=11.0
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - fribidi >=1.0.16,<2.0a0
   size: 59391
   timestamp: 1757438897523
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
@@ -4439,6 +8098,9 @@ packages:
   - libtiff >=4.7.1,<4.8.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gdk-pixbuf >=2.44.6,<3.0a0
   size: 548309
   timestamp: 1774986047281
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h37541a8_2.conda
@@ -4452,6 +8114,18 @@ packages:
   license: LGPL-2.1-or-later
   size: 204902
   timestamp: 1778508895255
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.2-h246a70f_0.conda
+  sha256: 6a98eabd4d5bb902c391e9f7c9e655ce61292ff6f1bb0c592da42fd66e6c89f9
+  md5: 973a5ef252899cd0916418c75a864169
+  depends:
+  - libglib ==2.88.2 ha08bb59_0
+  - libffi
+  - __osx >=11.0
+  - libintl >=0.25.1,<1.0a0
+  license: LGPL-2.1-or-later
+  run_exports: {}
+  size: 205101
+  timestamp: 1782463971075
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
   sha256: c507ae9989dbea7024aa6feaebb16cbf271faac67ac3f0342ef1ab747c20475d
   md5: 0fc46fee39e88bbcf5835f71a9d9a209
@@ -4462,6 +8136,19 @@ packages:
   license_family: LGPL
   size: 81202
   timestamp: 1755102333712
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
+  sha256: c0a060d7b7a05669043ef3f68c7a1025c8594e1ab73735afb64c35e8baa41da5
+  md5: 0d576cff278a2e60456d5b2c0a1ffda3
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 82245
+  timestamp: 1780454628763
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-14.1.2-hec8c438_0.conda
   sha256: 755c72d469330265f80a615912a3b522aef6f26cbc52763862b6a3c492fbf97c
   md5: 1f3d859de3ca2bcaa845e92e87d73660
@@ -4483,6 +8170,9 @@ packages:
   - pango >=1.56.4,<2.0a0
   license: EPL-1.0
   license_family: Other
+  run_exports:
+    weak:
+    - graphviz >=14.1.2,<15.0a0
   size: 2218284
   timestamp: 1769427599940
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.0-py313h1188861_0.conda
@@ -4498,6 +8188,20 @@ packages:
   license_family: MIT
   size: 259835
   timestamp: 1777329110563
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.2-py314he609de1_0.conda
+  sha256: 0538d74bc47b2ac3cff2a6c1cfca23abf609909bc9395062a1130f399fb8ae77
+  md5: 98ee4e107dd538b2fbd183b0ecad5a84
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - libcxx >=19
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 263816
+  timestamp: 1781762277927
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.52-hc0f3e19_0.conda
   sha256: 26862a9898054b8552e55e609e5ce73c7ef1eb28bbe6fb87f0b9109d73cd09df
   md5: 5557a2433b1339b8e536c264afea41ef
@@ -4521,6 +8225,10 @@ packages:
   - pango >=1.56.4,<2.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gtk3 >=3.24.52,<4.0a0
+    - adwaita-icon-theme
   size: 9385734
   timestamp: 1774288504338
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
@@ -4531,8 +8239,27 @@ packages:
   - libglib >=2.76.3,<3.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
+  run_exports:
+    weak:
+    - gts >=0.7.6,<0.8.0a0
   size: 304331
   timestamp: 1686545503242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
+  sha256: 0762ed080bf45ca475da96796a8883a6c719603c44fa9b07a5883785649a4a0f
+  md5: ab9a6c652fd25407c9cf67b9b6b87496
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 1203956
+  timestamp: 1775583125726
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.0-h3103d1b_0.conda
   sha256: 40ccd6a589c60a4cedb2f9921dfa60ea5845b5ce323477b042b6f90218b239f6
   md5: ea75b03886981362d93bb4708ee14811
@@ -4551,11 +8278,72 @@ packages:
   license_family: MIT
   size: 2023669
   timestamp: 1776779039314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
+  sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
+  md5: 389b1c7cb4738fa74f8a142336807a13
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libcxx >=19
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libglib >=2.88.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - harfbuzz >=14.2.1
+  size: 1721040
+  timestamp: 1780451752518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf4 >=4.2.15,<4.2.16.0a0
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
+  sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
+  md5: 5cc8ba7775f6694349b7a71837bbad90
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf5 >=2.1.0,<3.0a0
+  size: 3342788
+  timestamp: 1781837329072
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
   sha256: 46a4958f2f916c5938f2a6dc0709f78b175ece42f601d79a04e0276d55d25d07
   md5: cfb39109ac5fa8601eb595d66d5bf156
   license: GPL-2.0-or-later
   license_family: GPL
+  run_exports: {}
   size: 17616
   timestamp: 1771539622983
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -4565,6 +8353,9 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
   size: 12361647
   timestamp: 1773822915649
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/immutables-0.21-py313hcdf3177_2.conda
@@ -4579,6 +8370,35 @@ packages:
   license_family: APACHE
   size: 51484
   timestamp: 1757685606874
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/immutables-0.21-py314hb84d1df_2.conda
+  sha256: 8fc009559f6fdce0bfc053898d62a48bdfcca1d4960f785922019e6999aca62f
+  md5: 0749dc3555b919277586d96a8e3240f7
+  depends:
+  - __osx >=11.0
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 52567
+  timestamp: 1757685575891
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+  md5: 8780f41b013d19219faef9c82260744b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1159780
+  timestamp: 1781859501654
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
   sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
   md5: 095e5749868adab9cae42d4b460e5443
@@ -4587,8 +8407,24 @@ packages:
   - libcxx >=19
   license: Apache-2.0
   license_family: Apache
+  run_exports:
+    weak:
+    - lerc >=4.1.0,<5.0a0
   size: 164222
   timestamp: 1773114244984
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
+  sha256: af9cd8db11eb719e38a3340c88bb4882cf19b5b4237d93845224489fc2a13b46
+  md5: 13e6d9ae0efbc9d2e9a01a91f4372b41
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libaec >=1.1.5,<2.0a0
+  size: 30390
+  timestamp: 1769222133373
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-7_h51639a9_openblas.conda
   build_number: 7
   sha256: 662935bfb93d2d097e26e273a3a2f504a9f833f64aa6f9e295b577655478c39b
@@ -4606,6 +8442,26 @@ packages:
   license_family: BSD
   size: 18783
   timestamp: 1778489983152
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+  build_number: 8
+  sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
+  md5: dbfe729181a32741ae63ecb41eefbac6
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18949
+  timestamp: 1779859141315
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-7_hb0561ab_openblas.conda
   build_number: 7
   sha256: 3ac3d27022b3ca8b1980c087e0ede250434f6ed90a4fdc78a8a5ed382bc75505
@@ -4620,6 +8476,41 @@ packages:
   license_family: BSD
   size: 18810
   timestamp: 1778489991330
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+  build_number: 8
+  sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
+  md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18911
+  timestamp: 1779859147634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hd5a2499_0.conda
+  sha256: 5f73f41b3504c9d41a60aa161f6c87c36f19f97c92b3510441db618e361dc946
+  md5: 862eb5c81e1295f492fa261a68a4233f
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 410874
+  timestamp: 1782297872451
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.5-h55c6f16_1.conda
   sha256: dddd01bd6b338221342a89530a1caffe6051a70cc8f8b1d8bb591d5447a3c603
   md5: ff484b683fecf1e875dfc7aa01d19796
@@ -4629,6 +8520,16 @@ packages:
   license_family: Apache
   size: 569359
   timestamp: 1778191546305
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+  md5: 89f76a2a21a3ec3ec983b5eb237c4113
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 569349
+  timestamp: 1781670209146
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
   sha256: 5e0b6961be3304a5f027a8c00bd0967fc46ae162cffb7553ff45c70f51b8314c
   md5: a6130c709305cd9828b4e1bd9ba0000c
@@ -4636,8 +8537,35 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
   size: 55420
   timestamp: 1761980066242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 107458
+  timestamp: 1702146414478
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.0-hf6b4638_0.conda
   sha256: f4b1cafc59afaede8fa0a2d9cf376840f1c553001acd72f6ead18bbc8ac8c49c
   md5: 65466e82c09e888ca7560c11a97d5450
@@ -4649,6 +8577,18 @@ packages:
   license_family: MIT
   size: 68789
   timestamp: 1777846180142
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 69362
+  timestamp: 1781203631990
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
   sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
   md5: 43c04d9cb46ef176bb2a4c77e324d599
@@ -4656,6 +8596,9 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.5.2,<3.6.0a0
   size: 40979
   timestamp: 1769456747661
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
@@ -4666,6 +8609,15 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 8091
   timestamp: 1774298691258
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
+  sha256: d5637b01941c0fc8f5cbb1f170c238f4ee153b3c1708b9d50f4f1305438ff051
+  md5: 0582e67cd14cfed773be2f3b1aba08e0
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 8365
+  timestamp: 1780933612390
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
   sha256: ff764608e1f2839e95e2cf9b243681475f8778c36af7a42b3f78f476fdbb1dd3
   md5: e98ba7b5f09a5f450eca083d5a1c4649
@@ -4678,6 +8630,19 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 338085
   timestamp: 1774298689297
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
+  sha256: abbfffd8a8c776bb8b59a10c8247fc3aa6b17ba0051e9f6d199dca38479f214f
+  md5: a0bb0678f67c464938d3693fa96f6884
+  depends:
+  - __osx >=11.0
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 338442
+  timestamp: 1780933611662
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
   sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
   md5: 644058123986582db33aebd4ae2ca184
@@ -4688,6 +8653,7 @@ packages:
   - libgomp 15.2.0 19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 404080
   timestamp: 1778273064154
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-h05bcc79_12.conda
@@ -4709,6 +8675,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: GD
   license_family: BSD
+  run_exports:
+    weak:
+    - libgd >=2.3.3,<2.4.0a0
   size: 159247
   timestamp: 1766331953491
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
@@ -4720,6 +8689,7 @@ packages:
   - libgfortran-ng ==15.2.0=*_19
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 139675
   timestamp: 1778273280875
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
@@ -4731,6 +8701,7 @@ packages:
   - libgfortran 15.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  run_exports: {}
   size: 599691
   timestamp: 1778273075448
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
@@ -4748,12 +8719,33 @@ packages:
   license: LGPL-2.1-or-later
   size: 4439458
   timestamp: 1778508895255
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
+  sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
+  md5: 03123cafdc96cef79fc8a615f9119b79
+  depends:
+  - __osx >=11.0
+  - pcre2 >=10.47,<10.48.0a0
+  - libiconv >=1.18,<2.0a0
+  - libintl >=0.25.1,<1.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.2,<3.0a0
+  size: 4437447
+  timestamp: 1782463971075
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
   sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
   md5: 4d5a7445f0b25b6a3ddbb56e790f5251
   depends:
   - __osx >=11.0
   license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 750379
   timestamp: 1754909073836
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
@@ -4763,6 +8755,9 @@ packages:
   - __osx >=11.0
   - libiconv >=1.18,<2.0a0
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libintl >=0.25.1,<1.0a0
   size: 90957
   timestamp: 1751558394144
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
@@ -4773,6 +8768,9 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.1.4.1,<4.0a0
   size: 555681
   timestamp: 1775962975624
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-7_hd9741b5_openblas.conda
@@ -4789,6 +8787,23 @@ packages:
   license_family: BSD
   size: 18780
   timestamp: 1778490000843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  build_number: 8
+  sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
+  md5: 85adeb3d469d082dbd9c8c39e36dec57
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18925
+  timestamp: 1779859153970
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-7_h1b118fd_openblas.conda
   build_number: 7
   sha256: d7c50f954c5183b0c53ca779a75dce9b54281a49d6008d59d35b82c5b625da8e
@@ -4803,6 +8818,23 @@ packages:
   license_family: BSD
   size: 18806
   timestamp: 1778490010077
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-8_h1b118fd_openblas.conda
+  build_number: 8
+  sha256: 589d3218009b4002d486a7d3f88d3313e81c1e7720ddb3ee4ee2eff07fa34f9b
+  md5: bd1b597f41e950e2058978497bf35c2e
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  - libcblas 3.11.0 8_hb0561ab_openblas
+  - liblapack 3.11.0 8_hd9741b5_openblas
+  constrains:
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapacke >=3.11.0,<3.12.0a0
+  size: 18968
+  timestamp: 1779859160325
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
   sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
   md5: b1fd823b5ae54fbec272cea0811bd8a9
@@ -4811,6 +8843,9 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
   size: 92472
   timestamp: 1775825802659
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
@@ -4820,8 +8855,52 @@ packages:
   - __osx >=11.0
   license: BSD-2-Clause
   license_family: BSD
+  run_exports: {}
   size: 73690
   timestamp: 1769482560514
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.10.0-nompi_h28ce51b_104.conda
+  sha256: 7156ff14abb062f30f0736990f70a34bfe145ee67994aa6dce37cfdab5182adc
+  md5: 8e9bde85f3327812324b652e7577b17d
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzip >=1.11.2,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnetcdf >=4.10.0,<4.10.1.0a0
+  size: 681162
+  timestamp: 1776687223384
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
+  md5: 6ea18834adbc3b33df9bd9fb45eaf95b
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 576526
+  timestamp: 1773854624224
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
   sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
   md5: 909e41855c29f0d52ae630198cd57135
@@ -4834,6 +8913,9 @@ packages:
   - openblas >=0.3.33,<0.3.34.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
   size: 4304965
   timestamp: 1776995497368
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
@@ -4843,6 +8925,9 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
   size: 289546
   timestamp: 1776315246750
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.1-he8aa2a2_0.conda
@@ -4863,6 +8948,27 @@ packages:
   license: LGPL-2.1-or-later
   size: 2402915
   timestamp: 1773816188394
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.3-he8aa2a2_0.conda
+  sha256: f5b4fb7b6f13bbfca59613bff2e70b5a398e80727b9d0f814837ffcbc34185e1
+  md5: 6973724fadafe66ac6e4f1c55c191407
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.18.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.6,<3.0a0
+  - harfbuzz >=14.2.0
+  - libglib >=2.88.1,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __osx >=11.0
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - librsvg >=2.62.3,<3.0a0
+  size: 2397567
+  timestamp: 1780452232118
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
   sha256: 49daec7c83e70d4efc17b813547824bc2bcf2f7256d84061d24fbfe537da9f74
   md5: 6681822ea9d362953206352371b6a904
@@ -4872,6 +8978,32 @@ packages:
   license: blessing
   size: 920047
   timestamp: 1777987051643
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_2.conda
+  sha256: 3fab2b5a39cc85c4522723438401f42e4b2171e2607e3afee4c7c27b84a561bf
+  md5: 741552acf3c51d5b762aa2968fb61103
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.2,<4.0a0
+  size: 927176
+  timestamp: 1782494542722
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+  md5: b68e8f66b94b44aaa8de4583d3d4cc40
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 279193
+  timestamp: 1745608793272
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
   sha256: e9248077b3fa63db94caca42c8dbc6949c6f32f94d1cafad127f9005d9b1507f
   md5: e2a72ab2fa54ecb6abab2b26cde93500
@@ -4886,6 +9018,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
+  run_exports:
+    weak:
+    - libtiff >=4.7.1,<4.8.0a0
   size: 373892
   timestamp: 1762022345545
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
@@ -4897,6 +9032,9 @@ packages:
   - libwebp 1.6.0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
   size: 294974
   timestamp: 1752159906788
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
@@ -4912,8 +9050,42 @@ packages:
   - libxml2 2.15.3
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 466360
   timestamp: 1776377102261
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
+  sha256: 2fe1d8de0854342ae9cabe408b476935f82f5636e153b3b497456264dc8ff3a1
+  md5: 8e037d73747d6fe34e12d7bcac10cf21
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 h5ef1a60_0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 41102
+  timestamp: 1776377119495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+  sha256: 507599a77c1ce823c2d3acaefaae4ead0686f183f3980467a4c4b8ba209eff40
+  md5: 7177414f275db66735a17d316b0a81d6
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libzip >=1.11.2,<2.0a0
+  size: 125507
+  timestamp: 1730442214849
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
   sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
   md5: bc5a5721b6439f2f62a84f2548136082
@@ -4923,6 +9095,9 @@ packages:
   - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
   size: 47759
   timestamp: 1774072956767
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.5-hc7d1edf_1.conda
@@ -4937,6 +9112,34 @@ packages:
   license_family: APACHE
   size: 285806
   timestamp: 1778447786965
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
+  md5: a9c118f6343fb6301b6f3b4e94c4c562
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.8|22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.8
+  size: 286313
+  timestamp: 1781736516782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+  sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
+  md5: 01511afc6cc1909c5303cf31be17b44f
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - lz4-c >=1.10.0,<1.11.0a0
+  size: 148824
+  timestamp: 1733741047892
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py313h65a2061_1.conda
   sha256: f62892a42948c61aa0a13d9a36ff811651f0a1102331223594aecf3cc042bece
   md5: 0195d558b0c0ab8f4af3089af83067c5
@@ -4951,14 +9154,76 @@ packages:
   license_family: BSD
   size: 26009
   timestamp: 1772445537524
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
+  sha256: 411153d14ee0d98be6e3751cf5cc0502db17bce2deebebb8779e33d29d0e525f
+  md5: d33c0a15882b70255abdd54711b06a45
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 27256
+  timestamp: 1772445397216
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
   sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
   md5: 343d10ed5b44030a2f67193905aea159
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
   size: 805509
   timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.4-nompi_py311hfd37af6_108.conda
+  noarch: python
+  sha256: 915352a474f66840cd0508fb20d46683cdb9dd2cf00b149b5362819edb52bce9
+  md5: ee0bd3a4953c1ade8cf5cc4b30a3cadf
+  depends:
+  - python
+  - certifi
+  - cftime
+  - numpy
+  - packaging
+  - hdf5
+  - libnetcdf
+  - __osx >=11.0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - numpy >=1.23,<3
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 997799
+  timestamp: 1782151689895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py314hb79c6fa_0.conda
+  sha256: dfd260fce05ff833ac121a1b1e4aa22d9c346a781c1e883dd871338cc1d9f8b0
+  md5: 5283d56d01517fa1780c72f2544e8603
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 7123654
+  timestamp: 1782112549976
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
   sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
   md5: 25dcccd4f80f1638428613e0d7c9b4e1
@@ -4969,6 +9234,19 @@ packages:
   license_family: Apache
   size: 3106008
   timestamp: 1775587972483
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
+  md5: 8187a86242741725bfa74785fe812979
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3102584
+  timestamp: 1781069820667
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
   sha256: b57c59cf5abb06d407b3a79017b990ca5bfb10c15a10c62fc29e113f2b12d9a9
   md5: 4b433508ebb295c05dd3d03daf27f7bb
@@ -4986,6 +9264,9 @@ packages:
   - libpng >=1.6.55,<1.7.0a0
   - libzlib >=1.3.2,<2.0a0
   license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - pango >=1.56.4,<2.0a0
   size: 425743
   timestamp: 1774282709773
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
@@ -4997,6 +9278,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 850231
   timestamp: 1763655726735
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
@@ -5007,6 +9291,9 @@ packages:
   - libcxx >=19
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
   size: 248045
   timestamp: 1754665282033
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py313h6688731_0.conda
@@ -5021,6 +9308,19 @@ packages:
   license_family: BSD
   size: 242596
   timestamp: 1769678288893
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
+  sha256: e0f31c053eb11803d63860c213b2b1b57db36734f5f84a3833606f7c91fedff9
+  md5: fc4c7ab223873eee32080d51600ce7e7
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 245502
+  timestamp: 1769678303655
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pulp-2.8.0-py313h02cf4f5_3.conda
   sha256: 703c126afbb70b34c8c37a855523985ddec169669037cad840d3b5697626f175
   md5: a2840bd568edda9880f186a47e94893f
@@ -5034,6 +9334,20 @@ packages:
   license_family: MIT
   size: 226858
   timestamp: 1757853482596
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pulp-2.8.0-py314h676fd1f_3.conda
+  sha256: fad9646989fb16b3f5f858ffd81dbac5d9f5e51e98b829fa19cfb5897fbc66db
+  md5: 568c38aba1768777e2e92bfd1a3e94f2
+  depends:
+  - amply >=0.1.2
+  - coin-or-cbc
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 229818
+  timestamp: 1757853438761
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py313h212e517_0.conda
   sha256: 5bcc20f2c21d8a20d8f2821caf31d8c0ef2fa3bcdaf7a9bdce62e37be819f1d7
   md5: 32bb0d4dbb1be2064c06248a1190aa96
@@ -5049,6 +9363,22 @@ packages:
   license_family: MIT
   size: 1720475
   timestamp: 1778084300413
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py314h54f3292_0.conda
+  sha256: c034a7cc16f279c260d3456fcfc625838495a7f9f55aa79408a629a427769bb2
+  md5: 16314d88257820013e698381af19153f
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1722694
+  timestamp: 1778084354332
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
   build_number: 100
   sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
@@ -5072,6 +9402,35 @@ packages:
   size: 12966447
   timestamp: 1775615694085
   python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+  build_number: 100
+  sha256: 984081c9fae3a3944c6f2707bbbbc70e8b961f02cdb7c640d9745e2636235632
+  md5: 4841be3d0cf616a860efc6e60af66f8b
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 14059371
+  timestamp: 1781254578985
+  python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h65a2061_1.conda
   sha256: 950725516f67c9691d81bb8dde8419581c5332c5da3da10c9ba8cbb1698b825d
   md5: 5d0c8b92128c93027632ca8f8dc1190f
@@ -5085,6 +9444,20 @@ packages:
   license_family: MIT
   size: 188763
   timestamp: 1770224094408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
+  sha256: 95f385f9606e30137cf0b5295f63855fd22223a4cf024d306cf9098ea1c4a252
+  md5: dcf51e564317816cb8d546891019b3ab
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 189475
+  timestamp: 1770223788648
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
   sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
   md5: f8381319127120ce51e081dce4865cf4
@@ -5093,6 +9466,9 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
   size: 313930
   timestamp: 1765813902568
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
@@ -5109,6 +9485,54 @@ packages:
   license_family: MIT
   size: 358961
   timestamp: 1764543165314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.5.1-py314he1d1ac0_0.conda
+  sha256: 764b78892f8ba2a7d5cb24c2911bd5718753ba5b130bf4e0d9a0bb0001c139b1
+  md5: 58fe40c3bba570ac2cbfac4f4ea983b7
+  depends:
+  - python
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 292087
+  timestamp: 1779977082395
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
+  sha256: 7ce218a4e1c55775547835d21a7ead0d50e5ac348fd638ce6ba316c48c8547b7
+  md5: e55fe08bb5d43e7120672338dd129030
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 14122215
+  timestamp: 1781912992503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+  sha256: cb9305ede19584115f43baecdf09a3866bfcd5bcca0d9e527bd76d9a1dbe2d8d
+  md5: fca4a2222994acd7f691e57f94b750c5
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - snappy >=1.2.2,<1.3.0a0
+  size: 38883
+  timestamp: 1762948066818
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.49-py313h6688731_0.conda
   sha256: c74db80d5e24f14c9621edf0d7528631ef117748423f053245c170a60e2b38c2
   md5: 56fc7ce3494a1077459d51359f5148e7
@@ -5123,6 +9547,21 @@ packages:
   license_family: MIT
   size: 3842925
   timestamp: 1775241461140
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
+  sha256: c355708c29086c3ce0916f5d5367cfea733f73d9c194b4fa5d21a40317374d32
+  md5: 540fe3cb235eb16dcf0ff5e13eb96411
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4036851
+  timestamp: 1781547978515
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
   sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
   md5: a9d86bc62f39b94c4661716624eb21b0
@@ -5131,6 +9570,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
   size: 3127137
   timestamp: 1769460817696
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py313hcdf3177_1.conda
@@ -5145,6 +9587,19 @@ packages:
   license_family: BSD
   size: 62577
   timestamp: 1756851972334
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py314hb84d1df_1.conda
+  sha256: 0f35a19fd99724e8620dc89a6fb9eb100d300f117292adde2c7e8cf12d566e10
+  md5: 104bf69250e32a42ca144d7f7abd5d5c
+  depends:
+  - __osx >=11.0
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 61800
+  timestamp: 1756851815321
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
   sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
   md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
@@ -5152,6 +9607,9 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
   size: 83386
   timestamp: 1753484079473
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
@@ -5162,5 +9620,8 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
   size: 433413
   timestamp: 1764777166076

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ scipy = ">=1.13,<2"
 pyyaml = ">=6,<7"
 
 [feature.test.tasks.test]
-cmd = "pytest -m 'not docker and not stage_env' && pytest --doctest-modules src/utils/config_edit.py src/utils/paths.py"
+cmd = "pytest -m 'not docker and not stage_env' && pytest --doctest-modules src/utils/config_edit.py src/utils/paths.py src/io_contracts.py"
 
 [environments]
 pipeline = { features = ["pipeline"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,5 +15,16 @@ pytest = ">=8,<9"
 [feature.pipeline.tasks.ouroboros]
 cmd = "python -m src.ouroboros"
 
+[feature.test.dependencies]
+numpy = ">=2,<3"
+h5py = ">=3,<4"
+netcdf4 = ">=1.6,<2"
+scipy = ">=1.13,<2"
+pyyaml = ">=6,<7"
+
+[feature.test.tasks.test]
+cmd = "pytest -m 'not docker and not stage_env' && pytest --doctest-modules src/utils/config_edit.py src/utils/paths.py"
+
 [environments]
 pipeline = { features = ["pipeline"], no-default-feature = true }
+test = { features = ["pipeline", "test"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,8 @@ version = "0.1.0"
 channels = ["conda-forge", "bioconda"]
 
 [feature.pipeline.dependencies]
-snakemake-minimal = ">=8,<10"
+# Floor 9.16: the DAG dry-run test passes --runtime-source-cache-path, added in snakemake 9.16.
+snakemake-minimal = ">=9.16,<10"
 graphviz = ">=9,<15"
 pytest = ">=8,<9"
 
@@ -23,7 +24,7 @@ scipy = ">=1.13,<2"
 pyyaml = ">=6,<7"
 
 [feature.test.tasks.test]
-cmd = "pytest -m 'not docker and not stage_env' && pytest --doctest-modules src/utils/config_edit.py src/utils/paths.py src/io_contracts.py"
+cmd = "pytest -m 'not docker and not stage_env and not e2e' && pytest --doctest-modules src/utils/config_edit.py src/utils/paths.py src/io_contracts.py"
 
 [environments]
 pipeline = { features = ["pipeline"], no-default-feature = true }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = --ignore=tests/stage4-turbulence/SPECTRAX-GK
+markers =
+    docker: requires a working Docker daemon and the GHCR stage images
+    e2e: full-pipeline end-to-end (implies docker)
+    stage_env: must run inside a per-stage pixi env (needs an upstream solver)
+    requires_baseline: needs local outputs/ baseline files (gitignored)

--- a/src/io_contracts.py
+++ b/src/io_contracts.py
@@ -121,7 +121,12 @@ def _check_species_profile(arr: np.ndarray, name: str, n_rho: int | None, proble
 
 
 def _check_transport_solution(data: dict[str, np.ndarray | None]) -> list[str]:
-    """Check the union contract read by the Stage 3/4/5 transport-snapshot loaders.
+    """Check the fields read by the Stage 3/4/5 transport-snapshot loaders.
+
+    The Stage 3 loader accepts either ``temperature`` or ``pressure`` and derives the
+    missing one, but the Stage 4 loader hard-requires ``temperature`` with no pressure
+    fallback. The contract therefore requires ``temperature`` (the field that satisfies
+    both readers) and keeps ``pressure`` optional.
 
     Required: ``rho``, species-resolved ``density`` and ``temperature``, and ``Er`` with
     no species axis. Optional: ``pressure`` (same rank as density) and ``ts``.

--- a/src/io_contracts.py
+++ b/src/io_contracts.py
@@ -1,0 +1,506 @@
+"""Reusable validators for the pipeline's inter-stage file and signal contracts.
+
+Each stage hands its successor a file (HDF5 or NetCDF) or, for the closed loop, a
+small JSON dict. A drift in the fields the next stage reads (a renamed dataset, a
+transposed axis, a dropped variable from a breaking upstream release) otherwise passes
+silently until the pipeline fails far downstream. These validators make each contract
+explicit: they check exactly the subset the next stage consumes, and can later be wired
+into the pipeline as runtime data-checks.
+
+Every validator is two layers. A pure inner ``_check_*`` collects all problems into a
+``list[str]`` from in-memory data, with no file access, so it is unit tested directly.
+A thin outer ``validate_*`` lazily imports ``h5py``/``netCDF4``, reads the consumed
+fields, and raises :class:`ContractError` with every problem joined if the list is
+non-empty. Lazy imports keep the module (and the pure checkers) usable without the
+heavy I/O libraries present.
+
+Contracts are built to the reader/writer code, not the spec docs, wherever in-repo code
+defines them; the two NetCDF files have only upstream readers, so their subsets follow
+the documented handoff plus the mode-number arrays their coefficients are indexed by.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+class ContractError(Exception):
+    """Raised when a file or signal violates its consumed-field contract."""
+
+
+def _raise_if(problems: list[str], subject: str) -> None:
+    """Raise :class:`ContractError` listing every problem, or return if there are none."""
+    if problems:
+        raise ContractError(f"{subject}:\n  " + "\n  ".join(problems))
+
+
+def _require(arr: np.ndarray | None, name: str, problems: list[str]) -> bool:
+    """Record a problem and return ``False`` when a required field is absent."""
+    if arr is None:
+        problems.append(f"missing required field '{name}'")
+        return False
+    return True
+
+
+def _finite(arr: np.ndarray | None, name: str, problems: list[str]) -> None:
+    """Record a problem when a floating-point array holds non-finite values."""
+    if arr is not None and np.issubdtype(arr.dtype, np.floating) and not np.all(np.isfinite(arr)):
+        problems.append(f"'{name}' contains non-finite values")
+
+
+def _check_1d(arr: np.ndarray, name: str, expected_len: int | None, problems: list[str]) -> None:
+    """Record a problem when an array is not 1D of ``expected_len`` (skipped if ``None``)."""
+    if arr.ndim != 1:
+        problems.append(f"'{name}' must be 1D, got shape {arr.shape}")
+    elif expected_len is not None and arr.shape[0] != expected_len:
+        problems.append(f"'{name}' length {arr.shape[0]} != expected {expected_len}")
+
+
+def _check_flux_2d(
+    arr: np.ndarray, name: str, n_species: int | None, n_radii: int | None, problems: list[str]
+) -> None:
+    """Record problems for a ``(n_species, n_radii)`` flux array's rank, axes, and finiteness."""
+    if arr.ndim != 2:
+        problems.append(f"'{name}' must be 2D (n_species, n_radii), got shape {arr.shape}")
+    else:
+        if n_species is not None and arr.shape[0] != n_species:
+            problems.append(f"'{name}' species axis {arr.shape[0]} != n_species {n_species}")
+        if n_radii is not None and arr.shape[1] != n_radii:
+            problems.append(f"'{name}' radius axis {arr.shape[1]} != len(rho) {n_radii}")
+    _finite(arr, name, problems)
+
+
+def _as_text(value: Any) -> str:
+    """Decode an HDF5 attribute to ``str`` whether stored as bytes or text."""
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+# transport_solution.h5 ------------------------------------------------------------------
+
+_TRANSPORT_FIELDS = ("rho", "density", "temperature", "pressure", "Er", "ts")
+
+
+def _check_species_profile(arr: np.ndarray, name: str, n_rho: int | None, problems: list[str]) -> None:
+    """Record problems for a species-resolved profile (static or time-resolved)."""
+    if arr.ndim not in (2, 3):
+        problems.append(
+            f"'{name}' must be 2D (n_species, n_rho) or 3D (n_time, n_species, n_rho), got shape {arr.shape}"
+        )
+    elif n_rho is not None and arr.shape[-1] != n_rho:
+        problems.append(f"'{name}' trailing axis {arr.shape[-1]} != len(rho) {n_rho}")
+    _finite(arr, name, problems)
+
+
+def _check_transport_solution(data: dict[str, np.ndarray | None]) -> list[str]:
+    """Check the union contract read by the Stage 3/4/5 transport-snapshot loaders.
+
+    Required: ``rho``, species-resolved ``density`` and ``temperature``, and ``Er`` with
+    no species axis. Optional: ``pressure`` (same rank as density) and ``ts``.
+    """
+    problems: list[str] = []
+
+    rho = data.get("rho")
+    n_rho: int | None = None
+    if _require(rho, "rho", problems):
+        if rho.ndim != 1:
+            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
+        else:
+            n_rho = rho.shape[0]
+        _finite(rho, "rho", problems)
+
+    density = data.get("density")
+    temperature = data.get("temperature")
+    for name, arr in (("density", density), ("temperature", temperature)):
+        if _require(arr, name, problems):
+            _check_species_profile(arr, name, n_rho, problems)
+    pressure = data.get("pressure")
+    if pressure is not None:
+        _check_species_profile(pressure, "pressure", n_rho, problems)
+
+    er = data.get("Er")
+    if _require(er, "Er", problems):
+        if er.ndim not in (1, 2):
+            problems.append(f"'Er' must be 1D (n_rho,) or 2D (n_time, n_rho), got shape {er.shape}")
+        elif n_rho is not None and er.shape[-1] != n_rho:
+            problems.append(f"'Er' trailing axis {er.shape[-1]} != len(rho) {n_rho}")
+        _finite(er, "Er", problems)
+
+    if density is not None and temperature is not None and density.shape != temperature.shape:
+        problems.append(f"'density' shape {density.shape} != 'temperature' shape {temperature.shape}")
+    # Er advances with the same time axis as the profiles but carries no species axis,
+    # so it must have exactly one fewer dimension than density.
+    if (
+        density is not None
+        and er is not None
+        and density.ndim in (2, 3)
+        and er.ndim in (1, 2)
+        and er.ndim != density.ndim - 1
+    ):
+        problems.append(
+            f"'Er' ndim {er.ndim} should be one less than 'density' ndim {density.ndim} (Er carries no species axis)"
+        )
+
+    ts = data.get("ts")
+    if ts is not None:
+        if ts.ndim != 1:
+            problems.append(f"'ts' must be 1D (n_time,), got shape {ts.shape}")
+        elif density is not None and density.ndim == 3 and ts.shape[0] != density.shape[0]:
+            problems.append(f"'ts' length {ts.shape[0]} != time axis {density.shape[0]}")
+        _finite(ts, "ts", problems)
+
+    return problems
+
+
+def validate_transport_solution(path: Path | str) -> None:
+    """Validate a NEOPAX ``transport_solution.h5`` against the transport-loader contract.
+
+    Parameters
+    ----------
+    path : Path or str
+        HDF5 file written by the transport stage.
+
+    Raises
+    ------
+    ContractError
+        If any required dataset is missing or malformed.
+    """
+    import h5py
+
+    with h5py.File(path, "r") as f:
+        data = {k: (np.asarray(f[k][()]) if k in f else None) for k in _TRANSPORT_FIELDS}
+    _raise_if(_check_transport_solution(data), f"{path} violates the transport_solution.h5 contract")
+
+
+# sfincs_jax_flux_profiles.h5 ------------------------------------------------------------
+
+_SFINCS_FIELDS = ("r", "rHat", "rho", "Gamma", "Q", "Upar", "species_names")
+
+
+def _check_sfincs_flux(data: dict[str, np.ndarray | None], attrs: dict[str, Any]) -> list[str]:
+    """Check the Stage 3 neoclassical flux profiles written by the sfincs radial scan."""
+    problems: list[str] = []
+
+    rho = data.get("rho")
+    n_radii: int | None = None
+    if _require(rho, "rho", problems):
+        if rho.ndim != 1:
+            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
+        else:
+            n_radii = rho.shape[0]
+        _finite(rho, "rho", problems)
+
+    for name in ("r", "rHat"):
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_1d(arr, name, n_radii, problems)
+            _finite(arr, name, problems)
+
+    n_species: int | None = None
+    species = data.get("species_names")
+    if _require(species, "species_names", problems):
+        if species.ndim != 1:
+            problems.append(f"'species_names' must be 1D, got shape {species.shape}")
+        else:
+            n_species = species.shape[0]
+
+    for name in ("Gamma", "Q", "Upar"):
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_flux_2d(arr, name, n_species, n_radii, problems)
+
+    if "axis_zero_padded" not in attrs:
+        problems.append("missing required root attribute 'axis_zero_padded'")
+
+    return problems
+
+
+def validate_sfincs_flux(path: Path | str) -> None:
+    """Validate a ``sfincs_jax_flux_profiles.h5`` against the Stage 3 flux contract.
+
+    Raises
+    ------
+    ContractError
+        If any required dataset or the ``axis_zero_padded`` attribute is missing or malformed.
+    """
+    import h5py
+
+    with h5py.File(path, "r") as f:
+        data = {k: (np.asarray(f[k][()]) if k in f else None) for k in _SFINCS_FIELDS}
+        attrs = dict(f.attrs)
+    _raise_if(_check_sfincs_flux(data, attrs), f"{path} violates the sfincs_jax_flux_profiles.h5 contract")
+
+
+# neopax_fluxes.h5 -----------------------------------------------------------------------
+
+_NEOPAX_FIELDS = ("rho", "r", "Gamma", "Q", "Upar")
+_NEOPAX_UNIT_ATTRS = (("particle_flux_units", "m^-2 s^-1"), ("heat_flux_units", "eV m^-2 s^-1"))
+
+
+def _check_neopax_fluxes(
+    data: dict[str, np.ndarray | None], species_names: np.ndarray | None, meta_attrs: dict[str, Any]
+) -> list[str]:
+    """Check the Stage 4 turbulence flux profiles written for NEOPAX consumption."""
+    problems: list[str] = []
+
+    rho = data.get("rho")
+    n_radii: int | None = None
+    if _require(rho, "rho", problems):
+        if rho.ndim != 1:
+            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
+        else:
+            n_radii = rho.shape[0]
+        _finite(rho, "rho", problems)
+
+    r = data.get("r")
+    if _require(r, "r", problems):
+        _check_1d(r, "r", n_radii, problems)
+        _finite(r, "r", problems)
+
+    n_species: int | None = None
+    if species_names is None:
+        problems.append("missing required field 'meta/species_names'")
+    elif species_names.ndim != 1:
+        problems.append(f"'meta/species_names' must be 1D, got shape {species_names.shape}")
+    else:
+        n_species = species_names.shape[0]
+
+    for name in ("Gamma", "Q", "Upar"):
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_flux_2d(arr, name, n_species, n_radii, problems)
+
+    # The writer always emits Upar as zeros; a non-zero column signals a wrong or
+    # mislabeled array rather than a valid parallel-flow field.
+    upar = data.get("Upar")
+    if upar is not None and np.issubdtype(upar.dtype, np.floating) and upar.size and not np.all(upar == 0.0):
+        problems.append("'Upar' must be all zeros for neopax_fluxes")
+
+    for attr, expected in _NEOPAX_UNIT_ATTRS:
+        if attr not in meta_attrs:
+            problems.append(f"missing required meta attribute '{attr}'")
+        elif _as_text(meta_attrs[attr]) != expected:
+            problems.append(f"meta attribute '{attr}' = {_as_text(meta_attrs[attr])!r}, expected {expected!r}")
+    if "minor_radius_m" not in meta_attrs:
+        problems.append("missing required meta attribute 'minor_radius_m'")
+
+    return problems
+
+
+def validate_neopax_fluxes(path: Path | str) -> None:
+    """Validate a ``neopax_fluxes.h5`` against the Stage 4 flux contract.
+
+    Raises
+    ------
+    ContractError
+        If any required dataset, the ``meta/species_names`` dataset, or a required
+        ``meta`` attribute is missing or malformed.
+    """
+    import h5py
+
+    with h5py.File(path, "r") as f:
+        data = {k: (np.asarray(f[k][()]) if k in f else None) for k in _NEOPAX_FIELDS}
+        species_names: np.ndarray | None = None
+        meta_attrs: dict[str, Any] = {}
+        if "meta" in f:
+            meta = f["meta"]
+            if "species_names" in meta:
+                species_names = np.asarray(meta["species_names"][()])
+            meta_attrs = dict(meta.attrs)
+    _raise_if(
+        _check_neopax_fluxes(data, species_names, meta_attrs),
+        f"{path} violates the neopax_fluxes.h5 contract",
+    )
+
+
+# wout_*.nc ------------------------------------------------------------------------------
+
+_WOUT_2D = ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc")
+_WOUT_1D = ("iotas", "phi", "phipf")
+_WOUT_MODES = ("xm", "xn")
+_WOUT_FIELDS = _WOUT_2D + _WOUT_1D + _WOUT_MODES + ("nfp",)
+
+
+def _check_wout(data: dict[str, np.ndarray | None]) -> list[str]:
+    """Check the Stage-2-consumed VMEC ``wout`` geometry subset.
+
+    The Fourier coefficient arrays are meaningless without their mode-number arrays
+    ``xm``/``xn`` and field-period count ``nfp``, so those are part of the contract.
+    """
+    problems: list[str] = []
+
+    xm = data.get("xm")
+    rmnc = data.get("rmnc")
+    mnmax: int | None = None
+    if xm is not None and xm.ndim == 1:
+        mnmax = xm.shape[0]
+    elif rmnc is not None and rmnc.ndim == 2:
+        mnmax = rmnc.shape[1]
+
+    iotas = data.get("iotas")
+    ns: int | None = None
+    if iotas is not None and iotas.ndim == 1:
+        ns = iotas.shape[0]
+    elif rmnc is not None and rmnc.ndim == 2:
+        ns = rmnc.shape[0]
+
+    for name in _WOUT_2D:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            if arr.ndim != 2:
+                problems.append(f"'{name}' must be 2D (ns, mnmax), got shape {arr.shape}")
+            else:
+                if ns is not None and arr.shape[0] != ns:
+                    problems.append(f"'{name}' radial axis {arr.shape[0]} != ns {ns}")
+                if mnmax is not None and arr.shape[1] != mnmax:
+                    problems.append(f"'{name}' mode axis {arr.shape[1]} != mnmax {mnmax}")
+            _finite(arr, name, problems)
+
+    for name in _WOUT_1D:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_1d(arr, name, ns, problems)
+            _finite(arr, name, problems)
+
+    for name in _WOUT_MODES:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_1d(arr, name, mnmax, problems)
+            _finite(arr, name, problems)
+
+    if data.get("nfp") is None:
+        problems.append("missing required field 'nfp'")
+
+    return problems
+
+
+def validate_wout(path: Path | str) -> None:
+    """Validate a VMEC ``wout`` NetCDF file against the Stage-2-consumed geometry subset.
+
+    Raises
+    ------
+    ContractError
+        If any consumed variable is missing or its shape is inconsistent.
+    """
+    from netCDF4 import Dataset
+
+    with Dataset(path, "r") as ds:
+        data = {k: (np.asarray(ds.variables[k][...]) if k in ds.variables else None) for k in _WOUT_FIELDS}
+    _raise_if(_check_wout(data), f"{path} violates the wout NetCDF contract")
+
+
+# boozmn_*.nc ----------------------------------------------------------------------------
+
+_BOOZMN_2D = ("bmnc_b",)
+_BOOZMN_1D_PROFILES = ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b")
+_BOOZMN_MODES = ("ixm_b", "ixn_b")
+_BOOZMN_FIELDS = _BOOZMN_2D + _BOOZMN_1D_PROFILES + _BOOZMN_MODES + ("jlist", "nfp_b")
+
+
+def _check_boozmn(data: dict[str, np.ndarray | None]) -> list[str]:
+    """Check the Stage-3-consumed Boozer ``boozmn`` subset.
+
+    ``bmnc_b`` is indexed ``[surface, mode]``, so its mode axis must agree with the
+    ``ixm_b``/``ixn_b`` mode-number arrays. The 1D profiles are only checked for rank
+    and finiteness: BOOZ_XFORM variants disagree on whether they span every VMEC surface
+    or only the ``jlist`` subset, so their length is not cross-checked against ``bmnc_b``.
+    """
+    problems: list[str] = []
+
+    bmnc = data.get("bmnc_b")
+    ixm = data.get("ixm_b")
+    mnboz: int | None = None
+    if ixm is not None and ixm.ndim == 1:
+        mnboz = ixm.shape[0]
+    elif bmnc is not None and bmnc.ndim == 2:
+        mnboz = bmnc.shape[1]
+
+    if _require(bmnc, "bmnc_b", problems):
+        if bmnc.ndim != 2:
+            problems.append(f"'bmnc_b' must be 2D (surfaces, mnboz), got shape {bmnc.shape}")
+        elif mnboz is not None and bmnc.shape[1] != mnboz:
+            problems.append(f"'bmnc_b' mode axis {bmnc.shape[1]} != mnboz {mnboz}")
+        _finite(bmnc, "bmnc_b", problems)
+
+    for name in _BOOZMN_1D_PROFILES:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            if arr.ndim != 1:
+                problems.append(f"'{name}' must be 1D (per-surface profile), got shape {arr.shape}")
+            _finite(arr, name, problems)
+
+    for name in _BOOZMN_MODES:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_1d(arr, name, mnboz, problems)
+
+    jlist = data.get("jlist")
+    if _require(jlist, "jlist", problems) and jlist.ndim != 1:
+        problems.append(f"'jlist' must be 1D, got shape {jlist.shape}")
+
+    if data.get("nfp_b") is None:
+        problems.append("missing required field 'nfp_b'")
+
+    return problems
+
+
+def validate_boozmn(path: Path | str) -> None:
+    """Validate a Boozer ``boozmn`` NetCDF file against the Stage-3-consumed subset.
+
+    Raises
+    ------
+    ContractError
+        If any consumed variable is missing or its mode axis is inconsistent.
+    """
+    from netCDF4 import Dataset
+
+    with Dataset(path, "r") as ds:
+        data = {k: (np.asarray(ds.variables[k][...]) if k in ds.variables else None) for k in _BOOZMN_FIELDS}
+    _raise_if(_check_boozmn(data), f"{path} violates the boozmn NetCDF contract")
+
+
+# converge_status.json signal ------------------------------------------------------------
+
+
+def _check_signal(signal: Any) -> list[str]:
+    """Check the closed-loop signal dict read by the loop driver.
+
+    Examples
+    --------
+    >>> _check_signal({"converged": True, "halt": False})
+    []
+    >>> _check_signal({"converged": True})
+    ["missing required key 'halt'"]
+    """
+    if not isinstance(signal, dict):
+        return [f"signal must be a dict, got {type(signal).__name__}"]
+    problems: list[str] = []
+    for key in ("converged", "halt"):
+        if key not in signal:
+            problems.append(f"missing required key '{key}'")
+        elif not isinstance(signal[key], (bool, np.bool_)):
+            problems.append(f"key '{key}' must be bool, got {type(signal[key]).__name__}")
+    return problems
+
+
+def validate_signal(signal: dict) -> None:
+    """Validate the closed-loop convergence signal ``{"converged", "halt"}``.
+
+    Parameters
+    ----------
+    signal : dict
+        Parsed ``converge_status.json`` payload (a dict, not a file path).
+
+    Raises
+    ------
+    ContractError
+        If a required key is missing or is not a bool.
+
+    Examples
+    --------
+    >>> validate_signal({"converged": True, "halt": False}) is None
+    True
+    """
+    _raise_if(_check_signal(signal), "signal dict violates the converge_status contract")

--- a/src/io_contracts.py
+++ b/src/io_contracts.py
@@ -317,17 +317,45 @@ def validate_neopax_fluxes(path: Path | str) -> None:
 
 # wout_*.nc ------------------------------------------------------------------------------
 
-_WOUT_2D = ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc")
+# rmnc/zmns/lmns live on the mn_mode grid indexed by xm/xn; bmnc/bsubumnc/bsubvmnc live on
+# the denser Nyquist grid indexed by xm_nyq/xn_nyq. Each family is checked against its own
+# mode count, so they are tracked separately.
+_WOUT_2D = ("rmnc", "zmns", "lmns")
+_WOUT_2D_NYQ = ("bmnc", "bsubumnc", "bsubvmnc")
 _WOUT_1D = ("iotas", "phi", "phipf")
 _WOUT_MODES = ("xm", "xn")
-_WOUT_FIELDS = _WOUT_2D + _WOUT_1D + _WOUT_MODES + ("nfp",)
+_WOUT_MODES_NYQ = ("xm_nyq", "xn_nyq")
+# Minor-radius scalars the Stage 4 reader needs to set the reference length; Aminor_p
+# directly, or volume_p with Rmajor_p to derive it.
+_WOUT_MINOR_RADIUS = ("Aminor_p", "volume_p", "Rmajor_p")
+_WOUT_FIELDS = (
+    _WOUT_2D + _WOUT_2D_NYQ + _WOUT_1D + _WOUT_MODES + _WOUT_MODES_NYQ + _WOUT_MINOR_RADIUS + ("nfp",)
+)
+
+
+def _check_wout_2d(arr: np.ndarray, name: str, ns: int | None, mnmax: int | None, problems: list[str]) -> None:
+    """Record problems for a wout Fourier-coefficient array shaped ``(ns, mode count)``."""
+    if arr.ndim != 2:
+        problems.append(f"'{name}' must be 2D (ns, mode count), got shape {arr.shape}")
+    else:
+        if ns is not None and arr.shape[0] != ns:
+            problems.append(f"'{name}' radial axis {arr.shape[0]} != ns {ns}")
+        if mnmax is not None and arr.shape[1] != mnmax:
+            problems.append(f"'{name}' mode axis {arr.shape[1]} != mode count {mnmax}")
+    _finite(arr, name, problems)
 
 
 def _check_wout(data: dict[str, np.ndarray | None]) -> list[str]:
     """Check the Stage-2-consumed VMEC ``wout`` geometry subset.
 
-    The Fourier coefficient arrays are meaningless without their mode-number arrays
-    ``xm``/``xn`` and field-period count ``nfp``, so those are part of the contract.
+    VMEC writes the shape coefficients ``rmnc``/``zmns``/``lmns`` on the ``mn_mode`` grid
+    indexed by ``xm``/``xn``, and the field-strength coefficients
+    ``bmnc``/``bsubumnc``/``bsubvmnc`` on the denser Nyquist grid indexed by
+    ``xm_nyq``/``xn_nyq``. Each coefficient family is checked against the mode count of its
+    own grid, and both families share the radial axis ``ns``. The coefficients are
+    meaningless without those mode-number arrays and the field-period count ``nfp``, so all
+    are required. The minor-radius scalars the Stage 4 reader needs are required too:
+    ``Aminor_p``, or ``volume_p`` together with ``Rmajor_p`` to derive it.
     """
     problems: list[str] = []
 
@@ -339,6 +367,14 @@ def _check_wout(data: dict[str, np.ndarray | None]) -> list[str]:
     elif rmnc is not None and rmnc.ndim == 2:
         mnmax = rmnc.shape[1]
 
+    xm_nyq = data.get("xm_nyq")
+    bmnc = data.get("bmnc")
+    mnmax_nyq: int | None = None
+    if xm_nyq is not None and xm_nyq.ndim == 1:
+        mnmax_nyq = xm_nyq.shape[0]
+    elif bmnc is not None and bmnc.ndim == 2:
+        mnmax_nyq = bmnc.shape[1]
+
     iotas = data.get("iotas")
     ns: int | None = None
     if iotas is not None and iotas.ndim == 1:
@@ -349,14 +385,11 @@ def _check_wout(data: dict[str, np.ndarray | None]) -> list[str]:
     for name in _WOUT_2D:
         arr = data.get(name)
         if _require(arr, name, problems):
-            if arr.ndim != 2:
-                problems.append(f"'{name}' must be 2D (ns, mnmax), got shape {arr.shape}")
-            else:
-                if ns is not None and arr.shape[0] != ns:
-                    problems.append(f"'{name}' radial axis {arr.shape[0]} != ns {ns}")
-                if mnmax is not None and arr.shape[1] != mnmax:
-                    problems.append(f"'{name}' mode axis {arr.shape[1]} != mnmax {mnmax}")
-            _finite(arr, name, problems)
+            _check_wout_2d(arr, name, ns, mnmax, problems)
+    for name in _WOUT_2D_NYQ:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_wout_2d(arr, name, ns, mnmax_nyq, problems)
 
     for name in _WOUT_1D:
         arr = data.get(name)
@@ -369,9 +402,18 @@ def _check_wout(data: dict[str, np.ndarray | None]) -> list[str]:
         if _require(arr, name, problems):
             _check_1d(arr, name, mnmax, problems)
             _finite(arr, name, problems)
+    for name in _WOUT_MODES_NYQ:
+        arr = data.get(name)
+        if _require(arr, name, problems):
+            _check_1d(arr, name, mnmax_nyq, problems)
+            _finite(arr, name, problems)
 
     if data.get("nfp") is None:
         problems.append("missing required field 'nfp'")
+
+    aminor = data.get("Aminor_p")
+    if aminor is None and not (data.get("volume_p") is not None and data.get("Rmajor_p") is not None):
+        problems.append("missing required minor-radius scalars: 'Aminor_p' or both 'volume_p' and 'Rmajor_p'")
 
     return problems
 
@@ -394,9 +436,12 @@ def validate_wout(path: Path | str) -> None:
 # boozmn_*.nc ----------------------------------------------------------------------------
 
 _BOOZMN_2D = ("bmnc_b",)
-_BOOZMN_1D_PROFILES = ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b")
+_BOOZMN_1D_PROFILES = ("iota_b", "buco_b", "bvco_b")
+# Some BOOZ_XFORM writers (including the in-repo booz_xform_jax) omit the toroidal-flux
+# profiles phi_b/phip_b; they are optional, but drift-checked when present.
+_BOOZMN_1D_OPTIONAL = ("phi_b", "phip_b")
 _BOOZMN_MODES = ("ixm_b", "ixn_b")
-_BOOZMN_FIELDS = _BOOZMN_2D + _BOOZMN_1D_PROFILES + _BOOZMN_MODES + ("jlist", "nfp_b")
+_BOOZMN_FIELDS = _BOOZMN_2D + _BOOZMN_1D_PROFILES + _BOOZMN_1D_OPTIONAL + _BOOZMN_MODES + ("jlist", "nfp_b")
 
 
 def _check_boozmn(data: dict[str, np.ndarray | None]) -> list[str]:
@@ -406,6 +451,8 @@ def _check_boozmn(data: dict[str, np.ndarray | None]) -> list[str]:
     ``ixm_b``/``ixn_b`` mode-number arrays. The 1D profiles are only checked for rank
     and finiteness: BOOZ_XFORM variants disagree on whether they span every VMEC surface
     or only the ``jlist`` subset, so their length is not cross-checked against ``bmnc_b``.
+    The toroidal-flux profiles ``phi_b``/``phip_b`` are optional because some writers omit
+    them; when a file does provide them, they are still checked for rank and finiteness.
     """
     problems: list[str] = []
 
@@ -427,6 +474,13 @@ def _check_boozmn(data: dict[str, np.ndarray | None]) -> list[str]:
     for name in _BOOZMN_1D_PROFILES:
         arr = data.get(name)
         if _require(arr, name, problems):
+            if arr.ndim != 1:
+                problems.append(f"'{name}' must be 1D (per-surface profile), got shape {arr.shape}")
+            _finite(arr, name, problems)
+
+    for name in _BOOZMN_1D_OPTIONAL:
+        arr = data.get(name)
+        if arr is not None:
             if arr.ndim != 1:
                 problems.append(f"'{name}' must be 1D (per-surface profile), got shape {arr.shape}")
             _finite(arr, name, problems)

--- a/src/io_contracts.py
+++ b/src/io_contracts.py
@@ -15,8 +15,11 @@ non-empty. Lazy imports keep the module (and the pure checkers) usable without t
 heavy I/O libraries present.
 
 Contracts are built to the reader/writer code, not the spec docs, wherever in-repo code
-defines them; the two NetCDF files have only upstream readers, so their subsets follow
-the documented handoff plus the mode-number arrays their coefficients are indexed by.
+defines them. The two NetCDF files are read by upstream stages and also in-repo by the
+Stage 4 radial scan (stages/stage4-turbulence/spectrax_gk_radial_scan.py), which reads the
+wout minor-radius scalars and the boozmn bmnc_b/ixm_b/ixn_b coefficients; their subsets
+follow the documented handoff, the mode-number arrays their coefficients are indexed by,
+and those in-repo reads.
 """
 
 from __future__ import annotations
@@ -78,6 +81,29 @@ def _as_text(value: Any) -> str:
     return value.decode() if isinstance(value, bytes) else str(value)
 
 
+def _check_rho(rho: np.ndarray | None, problems: list[str]) -> int | None:
+    """Check the shared required 1D ``rho`` coordinate, returning its length or ``None``."""
+    n_rho: int | None = None
+    if _require(rho, "rho", problems):
+        if rho.ndim != 1:
+            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
+        else:
+            n_rho = rho.shape[0]
+        _finite(rho, "rho", problems)
+    return n_rho
+
+
+def _check_species_names(species: np.ndarray | None, name: str, problems: list[str]) -> int | None:
+    """Check a required 1D species-label array (``name`` labels it), returning its count or ``None``."""
+    n_species: int | None = None
+    if _require(species, name, problems):
+        if species.ndim != 1:
+            problems.append(f"'{name}' must be 1D, got shape {species.shape}")
+        else:
+            n_species = species.shape[0]
+    return n_species
+
+
 # transport_solution.h5 ------------------------------------------------------------------
 
 _TRANSPORT_FIELDS = ("rho", "density", "temperature", "pressure", "Er", "ts")
@@ -102,14 +128,7 @@ def _check_transport_solution(data: dict[str, np.ndarray | None]) -> list[str]:
     """
     problems: list[str] = []
 
-    rho = data.get("rho")
-    n_rho: int | None = None
-    if _require(rho, "rho", problems):
-        if rho.ndim != 1:
-            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
-        else:
-            n_rho = rho.shape[0]
-        _finite(rho, "rho", problems)
+    n_rho = _check_rho(data.get("rho"), problems)
 
     density = data.get("density")
     temperature = data.get("temperature")
@@ -119,6 +138,10 @@ def _check_transport_solution(data: dict[str, np.ndarray | None]) -> list[str]:
     pressure = data.get("pressure")
     if pressure is not None:
         _check_species_profile(pressure, "pressure", n_rho, problems)
+        if density is not None and pressure.ndim != density.ndim:
+            problems.append(
+                f"'pressure' ndim {pressure.ndim} != 'density' ndim {density.ndim} (pressure must share density's rank)"
+            )
 
     er = data.get("Er")
     if _require(er, "Er", problems):
@@ -183,14 +206,7 @@ def _check_sfincs_flux(data: dict[str, np.ndarray | None], attrs: dict[str, Any]
     """Check the Stage 3 neoclassical flux profiles written by the sfincs radial scan."""
     problems: list[str] = []
 
-    rho = data.get("rho")
-    n_radii: int | None = None
-    if _require(rho, "rho", problems):
-        if rho.ndim != 1:
-            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
-        else:
-            n_radii = rho.shape[0]
-        _finite(rho, "rho", problems)
+    n_radii = _check_rho(data.get("rho"), problems)
 
     for name in ("r", "rHat"):
         arr = data.get(name)
@@ -198,13 +214,7 @@ def _check_sfincs_flux(data: dict[str, np.ndarray | None], attrs: dict[str, Any]
             _check_1d(arr, name, n_radii, problems)
             _finite(arr, name, problems)
 
-    n_species: int | None = None
-    species = data.get("species_names")
-    if _require(species, "species_names", problems):
-        if species.ndim != 1:
-            problems.append(f"'species_names' must be 1D, got shape {species.shape}")
-        else:
-            n_species = species.shape[0]
+    n_species = _check_species_names(data.get("species_names"), "species_names", problems)
 
     for name in ("Gamma", "Q", "Upar"):
         arr = data.get(name)
@@ -245,27 +255,14 @@ def _check_neopax_fluxes(
     """Check the Stage 4 turbulence flux profiles written for NEOPAX consumption."""
     problems: list[str] = []
 
-    rho = data.get("rho")
-    n_radii: int | None = None
-    if _require(rho, "rho", problems):
-        if rho.ndim != 1:
-            problems.append(f"'rho' must be 1D, got shape {rho.shape}")
-        else:
-            n_radii = rho.shape[0]
-        _finite(rho, "rho", problems)
+    n_radii = _check_rho(data.get("rho"), problems)
 
     r = data.get("r")
     if _require(r, "r", problems):
         _check_1d(r, "r", n_radii, problems)
         _finite(r, "r", problems)
 
-    n_species: int | None = None
-    if species_names is None:
-        problems.append("missing required field 'meta/species_names'")
-    elif species_names.ndim != 1:
-        problems.append(f"'meta/species_names' must be 1D, got shape {species_names.shape}")
-    else:
-        n_species = species_names.shape[0]
+    n_species = _check_species_names(species_names, "meta/species_names", problems)
 
     for name in ("Gamma", "Q", "Upar"):
         arr = data.get(name)
@@ -534,7 +531,7 @@ def _check_signal(signal: Any) -> list[str]:
     for key in ("converged", "halt"):
         if key not in signal:
             problems.append(f"missing required key '{key}'")
-        elif not isinstance(signal[key], (bool, np.bool_)):
+        elif not isinstance(signal[key], bool):
             problems.append(f"key '{key}' must be bool, got {type(signal[key]).__name__}")
     return problems
 

--- a/src/utils/config_edit.py
+++ b/src/utils/config_edit.py
@@ -23,6 +23,11 @@ def apply_assignments(text: str, assignments: Mapping[str, str]) -> str:
         The config file contents.
     assignments : Mapping[str, str]
         Maps each config key to its replacement value (the text after the ``=``).
+
+    Examples
+    --------
+    >>> apply_assignments("vmec_file = old", {"vmec_file": '"new.nc"'})
+    'vmec_file = "new.nc"'
     """
     for key, value in assignments.items():
         text = re.sub(

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -51,6 +51,30 @@ def resolve_pipeline_paths(
         - paths generated under ``outputs/``: ``s5_resolved_config`` (the
           path-resolved NEOPAX copy NEOPAX actually runs) and ``s1_feedback``
           (the evolved Stage 1 boundary the loop feeds to the next iteration).
+
+    Examples
+    --------
+    >>> config = {
+    ...     "run_name": "demo",
+    ...     "input_dir": "inputs/demo",
+    ...     "output_dir": "outputs/demo",
+    ...     "filenames": {
+    ...         "s1_input": "vmec_input.{run_name}",
+    ...         "s3_config": "sfincs_input.{run_name}",
+    ...         "s4_config": "{run_name}.toml",
+    ...         "s5_config": "common_input.toml",
+    ...         "s1_output": "wout_{run_name}.nc",
+    ...         "s2_output": "boozmn_{run_name}.nc",
+    ...         "s3_output": "sfincs_jax_flux_profiles.h5",
+    ...         "s4_output": "neopax_fluxes.h5",
+    ...         "s5_output": "transport_solution.h5",
+    ...         "s5_signal": "converge_status.json",
+    ...     },
+    ... }
+    >>> resolve_pipeline_paths(config)["s1_output"]
+    'outputs/demo/stage1_equilibrium/wout_demo.nc'
+    >>> resolve_pipeline_paths(config, output_dir="outputs/demo/loop/iter_1/output")["s5_signal"]
+    'outputs/demo/loop/iter_1/output/stage5_post_processing/converge_status.json'
     """
     run_name = config["run_name"]
     input_dir = input_dir if input_dir is not None else config["input_dir"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+"""driftless-star test suite.
+
+The hyphenated ``tests/stageN-*`` directories are intentionally not packages:
+their names cannot be imported, so pytest loads their test modules as top-level
+files instead.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the driftless-star test suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def config() -> dict:
+    """The committed quick_run config (``inputs/quick_run/config.yaml``)."""
+    import yaml
+
+    return yaml.safe_load((REPO_ROOT / "inputs/quick_run/config.yaml").read_text())
+
+
+@pytest.fixture
+def paths(config: dict) -> dict:
+    """All pipeline paths resolved from the quick_run config."""
+    from src.utils import resolve_pipeline_paths
+
+    return resolve_pipeline_paths(config)

--- a/tests/data/vmec_indata_min.txt
+++ b/tests/data/vmec_indata_min.txt
@@ -1,0 +1,6 @@
+! Minimal VMEC INDATA namelist for exercising the pressure-fit rewrite.
+! Only the &INDATA delimiters and a rewritable AM line are required; the writer
+! reads no VMEC values, replaces AM, and inserts PMASS_TYPE and PRES_SCALE.
+&INDATA
+  AM = 0.0
+/

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -39,6 +39,9 @@ def _dry_run(tmp_path: Path, targets: list[str], config_overrides: list[str]) ->
     )
 
 
+# This runs the default forward pass and asserts it plans successfully (exit code 0), that all five stage rules are
+# scheduled, and that the post-processing rule is NOT scheduled, because the default target is a pure forward pass with
+# no loop-closing step. This catches Snakefile wiring/parse errors without Docker.
 def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
     result = _dry_run(tmp_path, targets=[], config_overrides=[])
     output = result.stdout + result.stderr
@@ -48,6 +51,9 @@ def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
     assert "stage5_post_processing" not in output  # rule all is a pure forward pass
 
 
+# When you explicitly ask Snakemake to build the convergence-signal file (the loop-closing target), the post-processing
+# rule SHOULD be pulled in. This resolves that target path, dry-runs with it as the goal, and asserts
+# `stage5_post_processing` now appears in the plan, confirming the loop-closing rule wires up on demand.
 def test_s5_signal_target_schedules_post_processing(tmp_path: Path) -> None:
     config = yaml.safe_load((REPO_ROOT / "inputs/quick_run/config.yaml").read_text())
     s5_signal = resolve_pipeline_paths(config, output_dir=f"{tmp_path}/out")["s5_signal"]
@@ -59,6 +65,9 @@ def test_s5_signal_target_schedules_post_processing(tmp_path: Path) -> None:
     assert "stage5_post_processing" in output, output
 
 
+# The Snakefile validates the `device` config at parse time, before any job runs. This dry-runs with `device=bogus` and
+# asserts the run fails (non-zero exit) with a message saying device must be 'cpu' or 'gpu', confirming a bad value is
+# caught early rather than deep into an execution.
 def test_invalid_device_fails_at_parse(tmp_path: Path) -> None:
     result = _dry_run(tmp_path, targets=[], config_overrides=["device=bogus"])
     output = result.stdout + result.stderr

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -1,15 +1,15 @@
-"""Dry-run test of the Snakemake forward-pass DAG.
+"""Dry-run tests of the Snakemake forward-pass DAG.
 
 ``snakemake -n`` parses the Snakefile and plans the job graph without running any
-container, so it catches wiring and parse-time errors with no Docker. This test
-asserts the dry run exits 0 from the committed quick_run config and that all five
-forward-pass rules are scheduled, while ``stage5_post_processing`` is not (the
-default ``rule all`` target is a pure forward pass).
+container, so it catches wiring and parse-time errors with no Docker.
 
 Overriding ``output_dir`` to a tmp dir keeps the Snakefile's parse-time
-``prepare_neopax_config`` write, and every planned artifact path, out of the repo;
-``--runtime-source-cache-path`` keeps Snakemake's own runtime source cache under tmp
-too, so the dry run stays hermetic in restricted (sandboxed or CI) environments.
+``prepare_neopax_config`` write, and every planned artifact path, out of the repo,
+and ``--runtime-source-cache-path`` keeps Snakemake's own runtime source cache under
+tmp. This is not full filesystem hermeticity: Snakemake still writes ``.snakemake/``
+metadata into the repo root during a dry run, but that directory is gitignored.
+``--workflow-profile none`` stops a user-level profile from injecting flags, so the
+planned DAG is the same everywhere.
 """
 
 from __future__ import annotations
@@ -17,24 +17,51 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import yaml
+
+from src.utils import resolve_pipeline_paths
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FORWARD_RULES = ("stage1_vmec", "stage2_boozer", "stage3_sfincs", "stage4_spectrax", "stage5_neopax")
 
 
-def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
-    result = subprocess.run(
-        ["snakemake", "-n",
+def _dry_run(tmp_path: Path, targets: list[str], config_overrides: list[str]) -> subprocess.CompletedProcess:
+    """Plan the quick_run DAG with ``snakemake -n``, redirecting every write under ``tmp_path``."""
+    return subprocess.run(
+        ["snakemake", "-n", *targets,
          "--configfile", "inputs/quick_run/config.yaml",
-         # Redirect Snakemake's runtime source cache under tmp so the dry run is
-         # hermetic in restricted/CI environments (default is the user cache dir).
+         "--workflow-profile", "none",
          "--runtime-source-cache-path", f"{tmp_path}/srccache",
-         "--config", f"output_dir={tmp_path}/out"],
+         "--config", f"output_dir={tmp_path}/out", *config_overrides],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
     )
+
+
+def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=[])
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
     for rule in FORWARD_RULES:
         assert rule in output, f"rule {rule} not scheduled:\n{output}"
     assert "stage5_post_processing" not in output  # rule all is a pure forward pass
+
+
+def test_s5_signal_target_schedules_post_processing(tmp_path: Path) -> None:
+    config = yaml.safe_load((REPO_ROOT / "inputs/quick_run/config.yaml").read_text())
+    s5_signal = resolve_pipeline_paths(config, output_dir=f"{tmp_path}/out")["s5_signal"]
+    result = _dry_run(tmp_path, targets=[s5_signal], config_overrides=[])
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    # Requesting the convergence signal pulls in the loop-closing rule and formats its
+    # shell string, which rule all (a pure forward pass) never reaches.
+    assert "stage5_post_processing" in output, output
+
+
+def test_invalid_device_fails_at_parse(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["device=bogus"])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    # The Snakefile's parse-time device guard rejects anything but cpu/gpu.
+    assert "must be 'cpu' or 'gpu'" in output, output

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -1,0 +1,35 @@
+"""Dry-run test of the Snakemake forward-pass DAG.
+
+``snakemake -n`` parses the Snakefile and plans the job graph without running any
+container, so it catches wiring and parse-time errors with no Docker. This test
+asserts the dry run exits 0 from the committed quick_run config and that all five
+forward-pass rules are scheduled, while ``stage5_post_processing`` is not (the
+default ``rule all`` target is a pure forward pass).
+
+Overriding ``output_dir`` to a tmp dir keeps the Snakefile's parse-time
+``prepare_neopax_config`` write, and every planned artifact path, out of the repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORWARD_RULES = ("stage1_vmec", "stage2_boozer", "stage3_sfincs", "stage4_spectrax", "stage5_neopax")
+
+
+def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
+    result = subprocess.run(
+        ["snakemake", "-n",
+         "--configfile", "inputs/quick_run/config.yaml",
+         "--config", f"output_dir={tmp_path}/out"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    for rule in FORWARD_RULES:
+        assert rule in output, f"rule {rule} not scheduled:\n{output}"
+    assert "stage5_post_processing" not in output  # rule all is a pure forward pass

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -7,7 +7,9 @@ forward-pass rules are scheduled, while ``stage5_post_processing`` is not (the
 default ``rule all`` target is a pure forward pass).
 
 Overriding ``output_dir`` to a tmp dir keeps the Snakefile's parse-time
-``prepare_neopax_config`` write, and every planned artifact path, out of the repo.
+``prepare_neopax_config`` write, and every planned artifact path, out of the repo;
+``--runtime-source-cache-path`` keeps Snakemake's own runtime source cache under tmp
+too, so the dry run stays hermetic in restricted (sandboxed or CI) environments.
 """
 
 from __future__ import annotations
@@ -23,6 +25,9 @@ def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
     result = subprocess.run(
         ["snakemake", "-n",
          "--configfile", "inputs/quick_run/config.yaml",
+         # Redirect Snakemake's runtime source cache under tmp so the dry run is
+         # hermetic in restricted/CI environments (default is the user cache dir).
+         "--runtime-source-cache-path", f"{tmp_path}/srccache",
          "--config", f"output_dir={tmp_path}/out"],
         cwd=REPO_ROOT,
         capture_output=True,

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers: synthetic handoff-file builders and the stage-script importer."""

--- a/tests/helpers/stage_import.py
+++ b/tests/helpers/stage_import.py
@@ -30,8 +30,9 @@ def load_stage_module(relpath: str) -> ModuleType:
     Parameters
     ----------
     relpath : str
-        Script path relative to the repo root, e.g.
-        ``"stages/stage2-boozer/run_boozer.py"``.
+        Script path relative to the repo root, e.g. ``"stages/stage2-boozer/run_boozer.py"``. It is
+        joined onto the repo root and not constrained to stay under it. ``..`` segments resolve
+        normally, so throwaway scripts written to a temporary directory can be loaded as well.
 
     Returns
     -------
@@ -41,7 +42,7 @@ def load_stage_module(relpath: str) -> ModuleType:
     Raises
     ------
     FileNotFoundError
-        If ``relpath`` does not resolve to a file under the repo root.
+        If ``relpath`` does not resolve to an existing file.
     ImportError
         If the file stem is already registered from a different file, or if an
         import spec cannot be built for the file.

--- a/tests/helpers/stage_import.py
+++ b/tests/helpers/stage_import.py
@@ -5,6 +5,8 @@ they cannot be imported as ``stages.stageN.<module>``. ``load_stage_module`` loa
 one by file path so its pure helpers (argument parsers, math, post-processing) can
 be unit tested in the ``test`` env. Those scripts import their solver packages
 lazily inside functions, so loading a module does not require the solver installed.
+A script's own directory is added to ``sys.path`` so a module-level import of a
+sibling script resolves.
 """
 
 from __future__ import annotations
@@ -42,5 +44,9 @@ def load_stage_module(relpath: str, name: str | None = None) -> ModuleType:
         raise ImportError(f"cannot create import spec for {path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = module
+    # Some stage scripts import a sibling script by bare module name at module top,
+    # so the script's own directory must be importable before it is executed.
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
     spec.loader.exec_module(module)
     return module

--- a/tests/helpers/stage_import.py
+++ b/tests/helpers/stage_import.py
@@ -19,34 +19,63 @@ from types import ModuleType
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def load_stage_module(relpath: str, name: str | None = None) -> ModuleType:
+def load_stage_module(relpath: str) -> ModuleType:
     """Load a stage script by repo-relative path and return the executed module.
+
+    A module is registered in ``sys.modules`` under its file stem. Re-loading the
+    same file returns the cached module without re-executing it. Requesting a
+    different file whose stem collides with an already-loaded module raises
+    ``ImportError`` rather than silently shadowing the cached one.
 
     Parameters
     ----------
     relpath : str
         Script path relative to the repo root, e.g.
         ``"stages/stage2-boozer/run_boozer.py"``.
-    name : str, optional
-        Module name to register under; defaults to the file stem.
 
     Returns
     -------
     ModuleType
         The loaded module, with its top-level names bound.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``relpath`` does not resolve to a file under the repo root.
+    ImportError
+        If the file stem is already registered from a different file, or if an
+        import spec cannot be built for the file.
     """
     path = REPO_ROOT / relpath
     if not path.is_file():
         raise FileNotFoundError(f"stage module not found: {path}")
-    mod_name = name or path.stem
+    mod_name = path.stem
+    cached = sys.modules.get(mod_name)
+    if cached is not None:
+        cached_file = getattr(cached, "__file__", None)
+        if cached_file is not None and Path(cached_file).resolve() == path.resolve():
+            return cached
+        raise ImportError(
+            f"stage module name {mod_name!r} is already loaded from {cached_file}; "
+            f"cannot reload it from a different file {path}"
+        )
     spec = importlib.util.spec_from_file_location(mod_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot create import spec for {path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = module
-    # Some stage scripts import a sibling script by bare module name at module top,
-    # so the script's own directory must be importable before it is executed.
+    # A stage script may import a sibling script by bare module name at module top,
+    # so the script's directory must be importable before the script is executed.
+    # These sys.path entries are session-lifetime: one is added per stage directory
+    # and never removed, because those sibling imports must keep resolving for every
+    # later load in the same pytest process. No cleanup is done here on purpose.
     if str(path.parent) not in sys.path:
         sys.path.insert(0, str(path.parent))
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # A body that raises leaves a half-initialized module in sys.modules; drop
+        # it so a failed load cannot be mistaken for a cached success later.
+        sys.modules.pop(mod_name, None)
+        raise
     return module

--- a/tests/helpers/stage_import.py
+++ b/tests/helpers/stage_import.py
@@ -1,0 +1,46 @@
+"""Import a stage script that has no package ``__init__``.
+
+Scripts under ``stages/`` run as standalone files and have no ``__init__.py``, so
+they cannot be imported as ``stages.stageN.<module>``. ``load_stage_module`` loads
+one by file path so its pure helpers (argument parsers, math, post-processing) can
+be unit tested in the ``test`` env. Those scripts import their solver packages
+lazily inside functions, so loading a module does not require the solver installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_stage_module(relpath: str, name: str | None = None) -> ModuleType:
+    """Load a stage script by repo-relative path and return the executed module.
+
+    Parameters
+    ----------
+    relpath : str
+        Script path relative to the repo root, e.g.
+        ``"stages/stage2-boozer/run_boozer.py"``.
+    name : str, optional
+        Module name to register under; defaults to the file stem.
+
+    Returns
+    -------
+    ModuleType
+        The loaded module, with its top-level names bound.
+    """
+    path = REPO_ROOT / relpath
+    if not path.is_file():
+        raise FileNotFoundError(f"stage module not found: {path}")
+    mod_name = name or path.stem
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/helpers/synthetic.py
+++ b/tests/helpers/synthetic.py
@@ -2,9 +2,11 @@
 
 These write the minimal fields a stage reader consumes, so post-processing helpers and
 the contract validators can be unit tested without running a solver. Fields follow the
-reader/writer code, not the spec docs. Each builder produces a valid file in one call:
-the caller supplies the core physics arrays and any single field can be overridden (or,
-for the NetCDF builders, dropped via ``omit``) to construct a deliberately-broken file.
+reader/writer code, not the spec docs. Each builder produces a valid file in one call. The
+HDF5 builders take the core physics arrays from the caller; the NetCDF builders use fixed,
+self-consistent dimensions mirroring the real solver layout. To construct a
+deliberately-broken file, override a field on an HDF5 builder or drop a required variable
+from a NetCDF builder via ``omit``.
 """
 
 from __future__ import annotations
@@ -61,10 +63,7 @@ def write_sfincs_flux(
     rho: np.ndarray,
     gamma: np.ndarray,
     q: np.ndarray,
-    r: np.ndarray | None = None,
     upar: np.ndarray | None = None,
-    species_names: Sequence[str] = ("e", "D", "T"),
-    axis_zero_padded: bool = False,
 ) -> Path:
     """Write a synthetic ``sfincs_jax_flux_profiles.h5`` neoclassical flux file.
 
@@ -73,37 +72,35 @@ def write_sfincs_flux(
     path : Path
         Destination HDF5 file.
     rho : np.ndarray
-        Radial coordinate, shape ``(n_radii,)``.
+        Radial coordinate, shape ``(n_radii,)``; also written to ``r`` and ``rHat``.
     gamma, q : np.ndarray
-        Particle and heat flux, shape ``(n_species, n_radii)``.
-    r : np.ndarray, optional
-        Effective radius written to both ``r`` and ``rHat``; defaults to ``rho``.
+        Particle and heat flux, shape ``(n_species, n_radii)`` with three species.
     upar : np.ndarray, optional
         Parallel flow, shape ``(n_species, n_radii)``; defaults to zeros.
-    species_names : sequence of str
-        Species labels, stored as fixed-length bytes.
-    axis_zero_padded : bool
-        Root attribute recording whether an axis (rho=0) row was prepended.
 
     Returns
     -------
     Path
         The written file path.
+
+    Notes
+    -----
+    The ``species_names`` dataset (``e``, ``D``, ``T``) and the ``axis_zero_padded`` root
+    attribute are written with fixed values because the contract validator consumes them.
     """
     rho_arr = np.asarray(rho, dtype=float)
-    r_arr = rho_arr if r is None else np.asarray(r, dtype=float)
     gamma_arr = np.asarray(gamma, dtype=float)
     q_arr = np.asarray(q, dtype=float)
     upar_arr = np.zeros_like(gamma_arr) if upar is None else np.asarray(upar, dtype=float)
     with h5py.File(path, "w") as f:
-        f.create_dataset("r", data=r_arr)
-        f.create_dataset("rHat", data=r_arr)
+        f.create_dataset("r", data=rho_arr)
+        f.create_dataset("rHat", data=rho_arr)
         f.create_dataset("rho", data=rho_arr)
         f.create_dataset("Gamma", data=gamma_arr)
         f.create_dataset("Q", data=q_arr)
         f.create_dataset("Upar", data=upar_arr)
-        f.create_dataset("species_names", data=np.asarray([str(s).encode("utf-8") for s in species_names]))
-        f.attrs["axis_zero_padded"] = bool(axis_zero_padded)
+        f.create_dataset("species_names", data=np.asarray([b"e", b"D", b"T"]))
+        f.attrs["axis_zero_padded"] = False
     return path
 
 
@@ -113,10 +110,7 @@ def write_neopax_fluxes(
     rho: np.ndarray,
     gamma: np.ndarray,
     q: np.ndarray,
-    r: np.ndarray | None = None,
     upar: np.ndarray | None = None,
-    species_names: Sequence[str] = ("e", "D", "T"),
-    minor_radius_m: float = 1.0,
 ) -> Path:
     """Write a synthetic ``neopax_fluxes.h5`` turbulence flux file.
 
@@ -125,54 +119,54 @@ def write_neopax_fluxes(
     path : Path
         Destination HDF5 file.
     rho : np.ndarray
-        Radial coordinate, shape ``(n_radii,)``.
+        Radial coordinate, shape ``(n_radii,)``; also written to ``r``.
     gamma, q : np.ndarray
-        Particle and heat flux, shape ``(n_species, n_radii)``.
-    r : np.ndarray, optional
-        Physical radius; defaults to ``rho``.
+        Particle and heat flux, shape ``(n_species, n_radii)`` with three species.
     upar : np.ndarray, optional
         Parallel flow, shape ``(n_species, n_radii)``; defaults to zeros to match the writer.
-    species_names : sequence of str
-        Species labels, stored in ``meta`` as variable-length UTF-8 strings.
-    minor_radius_m : float
-        Minor radius written to ``meta`` attributes.
 
     Returns
     -------
     Path
         The written file path.
+
+    Notes
+    -----
+    The ``meta`` group's ``species_names`` (``e``, ``D``, ``T``), flux-unit attributes, and
+    ``minor_radius_m`` are written with fixed values because the contract validator consumes them.
     """
     rho_arr = np.asarray(rho, dtype=float)
-    r_arr = rho_arr if r is None else np.asarray(r, dtype=float)
     gamma_arr = np.asarray(gamma, dtype=float)
     q_arr = np.asarray(q, dtype=float)
     upar_arr = np.zeros_like(gamma_arr) if upar is None else np.asarray(upar, dtype=float)
     with h5py.File(path, "w") as f:
         f.create_dataset("rho", data=rho_arr)
-        f.create_dataset("r", data=r_arr)
+        f.create_dataset("r", data=rho_arr)
         f.create_dataset("Gamma", data=gamma_arr)
         f.create_dataset("Q", data=q_arr)
         f.create_dataset("Upar", data=upar_arr)
         meta = f.create_group("meta")
         vlen = h5py.string_dtype(encoding="utf-8")
-        meta.create_dataset("species_names", data=np.asarray(list(species_names), dtype=object), dtype=vlen)
+        meta.create_dataset("species_names", data=np.asarray(["e", "D", "T"], dtype=object), dtype=vlen)
         meta.attrs["particle_flux_units"] = "m^-2 s^-1"
         meta.attrs["heat_flux_units"] = "eV m^-2 s^-1"
-        meta.attrs["minor_radius_m"] = float(minor_radius_m)
+        meta.attrs["minor_radius_m"] = 1.0
     return path
 
 
-def write_wout(path: Path, *, ns: int = 4, mnmax: int = 3, nfp: int = 1, omit: Sequence[str] = ()) -> Path:
+def write_wout(path: Path, *, omit: Sequence[str] = ()) -> Path:
     """Write a synthetic VMEC ``wout`` NetCDF file with the Stage-2-consumed geometry subset.
+
+    Mirrors the real VMEC layout: the shape coefficients ``rmnc``/``zmns``/``lmns`` sit on
+    the ``mn_mode`` grid (indexed by ``xm``/``xn``) and the field-strength coefficients
+    ``bmnc``/``bsubumnc``/``bsubvmnc`` on the denser ``mn_mode_nyq`` grid (indexed by
+    ``xm_nyq``/``xn_nyq``), which is why the two mode dimensions differ in size. A scalar
+    ``Aminor_p`` supplies the minor radius the Stage 4 reader needs.
 
     Parameters
     ----------
     path : Path
         Destination NetCDF file.
-    ns, mnmax : int
-        Radial surface count and Fourier mode count (the two dimension sizes).
-    nfp : int
-        Number of field periods (a scalar variable).
     omit : sequence of str
         Variable names to skip, for building a file missing a required field. NetCDF ties
         every variable to a dimension, so dropping one is the way to make a broken file.
@@ -184,37 +178,49 @@ def write_wout(path: Path, *, ns: int = 4, mnmax: int = 3, nfp: int = 1, omit: S
     """
     from netCDF4 import Dataset
 
+    ns = 4
+    mn_mode = 3
+    mn_mode_nyq = 5
     with Dataset(path, "w") as ds:
-        ds.createDimension("ns", ns)
-        ds.createDimension("mnmax", mnmax)
-        for name in ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc"):
+        ds.createDimension("radius", ns)
+        ds.createDimension("mn_mode", mn_mode)
+        ds.createDimension("mn_mode_nyq", mn_mode_nyq)
+        for name in ("rmnc", "zmns", "lmns"):
             if name not in omit:
-                ds.createVariable(name, "f8", ("ns", "mnmax"))[:] = np.ones((ns, mnmax))
+                ds.createVariable(name, "f8", ("radius", "mn_mode"))[:] = np.ones((ns, mn_mode))
+        for name in ("bmnc", "bsubumnc", "bsubvmnc"):
+            if name not in omit:
+                ds.createVariable(name, "f8", ("radius", "mn_mode_nyq"))[:] = np.ones((ns, mn_mode_nyq))
         for name in ("iotas", "phi", "phipf"):
             if name not in omit:
-                ds.createVariable(name, "f8", ("ns",))[:] = np.linspace(0.0, 1.0, ns)
+                ds.createVariable(name, "f8", ("radius",))[:] = np.linspace(0.0, 1.0, ns)
         if "xm" not in omit:
-            ds.createVariable("xm", "f8", ("mnmax",))[:] = np.arange(mnmax, dtype=float)
+            ds.createVariable("xm", "f8", ("mn_mode",))[:] = np.arange(mn_mode, dtype=float)
         if "xn" not in omit:
-            ds.createVariable("xn", "f8", ("mnmax",))[:] = np.zeros(mnmax)
+            ds.createVariable("xn", "f8", ("mn_mode",))[:] = np.zeros(mn_mode)
+        if "xm_nyq" not in omit:
+            ds.createVariable("xm_nyq", "f8", ("mn_mode_nyq",))[:] = np.arange(mn_mode_nyq, dtype=float)
+        if "xn_nyq" not in omit:
+            ds.createVariable("xn_nyq", "f8", ("mn_mode_nyq",))[:] = np.zeros(mn_mode_nyq)
         if "nfp" not in omit:
-            ds.createVariable("nfp", "i4")[...] = int(nfp)
+            ds.createVariable("nfp", "i4")[...] = 1
+        if "Aminor_p" not in omit:
+            ds.createVariable("Aminor_p", "f8")[...] = 0.3
     return path
 
 
-def write_boozmn(
-    path: Path, *, n_surf: int = 3, mnboz: int = 4, nfp: int = 1, omit: Sequence[str] = ()
-) -> Path:
+def write_boozmn(path: Path, *, omit: Sequence[str] = ()) -> Path:
     """Write a synthetic Boozer ``boozmn`` NetCDF file with the Stage-3-consumed subset.
+
+    Mirrors the real booz_xform_jax layout: ``bmnc_b`` and ``jlist`` sit on the packed
+    ``pack_rad`` surface grid while the profiles ``iota_b``/``buco_b``/``bvco_b`` span the
+    full ``radius`` grid, so those dimensions differ in size. The toroidal-flux profiles
+    ``phi_b``/``phip_b`` are not written, matching the real file.
 
     Parameters
     ----------
     path : Path
         Destination NetCDF file.
-    n_surf, mnboz : int
-        Boozer surface count and mode count (the two dimension sizes).
-    nfp : int
-        Number of field periods (a scalar variable).
     omit : sequence of str
         Variable names to skip, for building a file missing a required field.
 
@@ -225,20 +231,24 @@ def write_boozmn(
     """
     from netCDF4 import Dataset
 
+    pack_rad = 3
+    radius = pack_rad + 1
+    mnboz = 4
     with Dataset(path, "w") as ds:
-        ds.createDimension("radius", n_surf)
+        ds.createDimension("radius", radius)
+        ds.createDimension("pack_rad", pack_rad)
         ds.createDimension("mn_mode", mnboz)
         if "bmnc_b" not in omit:
-            ds.createVariable("bmnc_b", "f8", ("radius", "mn_mode"))[:] = np.ones((n_surf, mnboz))
-        for name in ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b"):
+            ds.createVariable("bmnc_b", "f8", ("pack_rad", "mn_mode"))[:] = np.ones((pack_rad, mnboz))
+        for name in ("iota_b", "buco_b", "bvco_b"):
             if name not in omit:
-                ds.createVariable(name, "f8", ("radius",))[:] = np.linspace(0.0, 1.0, n_surf)
+                ds.createVariable(name, "f8", ("radius",))[:] = np.linspace(0.0, 1.0, radius)
         if "ixm_b" not in omit:
             ds.createVariable("ixm_b", "i4", ("mn_mode",))[:] = np.arange(mnboz)
         if "ixn_b" not in omit:
             ds.createVariable("ixn_b", "i4", ("mn_mode",))[:] = np.zeros(mnboz)
         if "jlist" not in omit:
-            ds.createVariable("jlist", "i4", ("radius",))[:] = np.arange(2, 2 + n_surf)
+            ds.createVariable("jlist", "i4", ("pack_rad",))[:] = np.arange(2, 2 + pack_rad)
         if "nfp_b" not in omit:
-            ds.createVariable("nfp_b", "i4")[...] = int(nfp)
+            ds.createVariable("nfp_b", "i4")[...] = 1
     return path

--- a/tests/helpers/synthetic.py
+++ b/tests/helpers/synthetic.py
@@ -1,12 +1,15 @@
-"""Synthetic HDF5 builders for the pipeline's inter-stage file contracts.
+"""Synthetic HDF5 and NetCDF builders for the pipeline's inter-stage file contracts.
 
-These write the minimal datasets a stage reader consumes, so post-processing helpers
-can be unit tested without running a solver. Datasets follow the reader code: flat,
-top-level, lowercase, species-resolved profiles.
+These write the minimal fields a stage reader consumes, so post-processing helpers and
+the contract validators can be unit tested without running a solver. Fields follow the
+reader/writer code, not the spec docs. Each builder produces a valid file in one call:
+the caller supplies the core physics arrays and any single field can be overridden (or,
+for the NetCDF builders, dropped via ``omit``) to construct a deliberately-broken file.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import h5py
@@ -20,6 +23,7 @@ def write_transport_solution(
     pressure: np.ndarray | None = None,
     temperature: np.ndarray | None = None,
     density: np.ndarray | None = None,
+    er: np.ndarray | None = None,
 ) -> Path:
     """Write a synthetic ``transport_solution.h5`` from caller-supplied profiles.
 
@@ -34,6 +38,9 @@ def write_transport_solution(
         or ``(n_time, n_species, n_rho)`` for a time-resolved one. Provide either
         ``pressure`` or both ``temperature`` and ``density`` so a reader can form a
         total pressure.
+    er : np.ndarray, optional
+        Radial electric field ``Er``, shape ``(n_rho,)`` static or ``(n_time, n_rho)``
+        time-resolved. Carries no species axis. Required by the Stage 3/4 readers.
 
     Returns
     -------
@@ -42,7 +49,196 @@ def write_transport_solution(
     """
     with h5py.File(path, "w") as f:
         f.create_dataset("rho", data=np.asarray(rho, dtype=float))
-        for name, arr in (("pressure", pressure), ("temperature", temperature), ("density", density)):
+        for name, arr in (("pressure", pressure), ("temperature", temperature), ("density", density), ("Er", er)):
             if arr is not None:
                 f.create_dataset(name, data=np.asarray(arr, dtype=float))
+    return path
+
+
+def write_sfincs_flux(
+    path: Path,
+    *,
+    rho: np.ndarray,
+    gamma: np.ndarray,
+    q: np.ndarray,
+    r: np.ndarray | None = None,
+    upar: np.ndarray | None = None,
+    species_names: Sequence[str] = ("e", "D", "T"),
+    axis_zero_padded: bool = False,
+) -> Path:
+    """Write a synthetic ``sfincs_jax_flux_profiles.h5`` neoclassical flux file.
+
+    Parameters
+    ----------
+    path : Path
+        Destination HDF5 file.
+    rho : np.ndarray
+        Radial coordinate, shape ``(n_radii,)``.
+    gamma, q : np.ndarray
+        Particle and heat flux, shape ``(n_species, n_radii)``.
+    r : np.ndarray, optional
+        Effective radius written to both ``r`` and ``rHat``; defaults to ``rho``.
+    upar : np.ndarray, optional
+        Parallel flow, shape ``(n_species, n_radii)``; defaults to zeros.
+    species_names : sequence of str
+        Species labels, stored as fixed-length bytes.
+    axis_zero_padded : bool
+        Root attribute recording whether an axis (rho=0) row was prepended.
+
+    Returns
+    -------
+    Path
+        The written file path.
+    """
+    rho_arr = np.asarray(rho, dtype=float)
+    r_arr = rho_arr if r is None else np.asarray(r, dtype=float)
+    gamma_arr = np.asarray(gamma, dtype=float)
+    q_arr = np.asarray(q, dtype=float)
+    upar_arr = np.zeros_like(gamma_arr) if upar is None else np.asarray(upar, dtype=float)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("r", data=r_arr)
+        f.create_dataset("rHat", data=r_arr)
+        f.create_dataset("rho", data=rho_arr)
+        f.create_dataset("Gamma", data=gamma_arr)
+        f.create_dataset("Q", data=q_arr)
+        f.create_dataset("Upar", data=upar_arr)
+        f.create_dataset("species_names", data=np.asarray([str(s).encode("utf-8") for s in species_names]))
+        f.attrs["axis_zero_padded"] = bool(axis_zero_padded)
+    return path
+
+
+def write_neopax_fluxes(
+    path: Path,
+    *,
+    rho: np.ndarray,
+    gamma: np.ndarray,
+    q: np.ndarray,
+    r: np.ndarray | None = None,
+    upar: np.ndarray | None = None,
+    species_names: Sequence[str] = ("e", "D", "T"),
+    minor_radius_m: float = 1.0,
+) -> Path:
+    """Write a synthetic ``neopax_fluxes.h5`` turbulence flux file.
+
+    Parameters
+    ----------
+    path : Path
+        Destination HDF5 file.
+    rho : np.ndarray
+        Radial coordinate, shape ``(n_radii,)``.
+    gamma, q : np.ndarray
+        Particle and heat flux, shape ``(n_species, n_radii)``.
+    r : np.ndarray, optional
+        Physical radius; defaults to ``rho``.
+    upar : np.ndarray, optional
+        Parallel flow, shape ``(n_species, n_radii)``; defaults to zeros to match the writer.
+    species_names : sequence of str
+        Species labels, stored in ``meta`` as variable-length UTF-8 strings.
+    minor_radius_m : float
+        Minor radius written to ``meta`` attributes.
+
+    Returns
+    -------
+    Path
+        The written file path.
+    """
+    rho_arr = np.asarray(rho, dtype=float)
+    r_arr = rho_arr if r is None else np.asarray(r, dtype=float)
+    gamma_arr = np.asarray(gamma, dtype=float)
+    q_arr = np.asarray(q, dtype=float)
+    upar_arr = np.zeros_like(gamma_arr) if upar is None else np.asarray(upar, dtype=float)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=rho_arr)
+        f.create_dataset("r", data=r_arr)
+        f.create_dataset("Gamma", data=gamma_arr)
+        f.create_dataset("Q", data=q_arr)
+        f.create_dataset("Upar", data=upar_arr)
+        meta = f.create_group("meta")
+        vlen = h5py.string_dtype(encoding="utf-8")
+        meta.create_dataset("species_names", data=np.asarray(list(species_names), dtype=object), dtype=vlen)
+        meta.attrs["particle_flux_units"] = "m^-2 s^-1"
+        meta.attrs["heat_flux_units"] = "eV m^-2 s^-1"
+        meta.attrs["minor_radius_m"] = float(minor_radius_m)
+    return path
+
+
+def write_wout(path: Path, *, ns: int = 4, mnmax: int = 3, nfp: int = 1, omit: Sequence[str] = ()) -> Path:
+    """Write a synthetic VMEC ``wout`` NetCDF file with the Stage-2-consumed geometry subset.
+
+    Parameters
+    ----------
+    path : Path
+        Destination NetCDF file.
+    ns, mnmax : int
+        Radial surface count and Fourier mode count (the two dimension sizes).
+    nfp : int
+        Number of field periods (a scalar variable).
+    omit : sequence of str
+        Variable names to skip, for building a file missing a required field. NetCDF ties
+        every variable to a dimension, so dropping one is the way to make a broken file.
+
+    Returns
+    -------
+    Path
+        The written file path.
+    """
+    from netCDF4 import Dataset
+
+    with Dataset(path, "w") as ds:
+        ds.createDimension("ns", ns)
+        ds.createDimension("mnmax", mnmax)
+        for name in ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc"):
+            if name not in omit:
+                ds.createVariable(name, "f8", ("ns", "mnmax"))[:] = np.ones((ns, mnmax))
+        for name in ("iotas", "phi", "phipf"):
+            if name not in omit:
+                ds.createVariable(name, "f8", ("ns",))[:] = np.linspace(0.0, 1.0, ns)
+        if "xm" not in omit:
+            ds.createVariable("xm", "f8", ("mnmax",))[:] = np.arange(mnmax, dtype=float)
+        if "xn" not in omit:
+            ds.createVariable("xn", "f8", ("mnmax",))[:] = np.zeros(mnmax)
+        if "nfp" not in omit:
+            ds.createVariable("nfp", "i4")[...] = int(nfp)
+    return path
+
+
+def write_boozmn(
+    path: Path, *, n_surf: int = 3, mnboz: int = 4, nfp: int = 1, omit: Sequence[str] = ()
+) -> Path:
+    """Write a synthetic Boozer ``boozmn`` NetCDF file with the Stage-3-consumed subset.
+
+    Parameters
+    ----------
+    path : Path
+        Destination NetCDF file.
+    n_surf, mnboz : int
+        Boozer surface count and mode count (the two dimension sizes).
+    nfp : int
+        Number of field periods (a scalar variable).
+    omit : sequence of str
+        Variable names to skip, for building a file missing a required field.
+
+    Returns
+    -------
+    Path
+        The written file path.
+    """
+    from netCDF4 import Dataset
+
+    with Dataset(path, "w") as ds:
+        ds.createDimension("radius", n_surf)
+        ds.createDimension("mn_mode", mnboz)
+        if "bmnc_b" not in omit:
+            ds.createVariable("bmnc_b", "f8", ("radius", "mn_mode"))[:] = np.ones((n_surf, mnboz))
+        for name in ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b"):
+            if name not in omit:
+                ds.createVariable(name, "f8", ("radius",))[:] = np.linspace(0.0, 1.0, n_surf)
+        if "ixm_b" not in omit:
+            ds.createVariable("ixm_b", "i4", ("mn_mode",))[:] = np.arange(mnboz)
+        if "ixn_b" not in omit:
+            ds.createVariable("ixn_b", "i4", ("mn_mode",))[:] = np.zeros(mnboz)
+        if "jlist" not in omit:
+            ds.createVariable("jlist", "i4", ("radius",))[:] = np.arange(2, 2 + n_surf)
+        if "nfp_b" not in omit:
+            ds.createVariable("nfp_b", "i4")[...] = int(nfp)
     return path

--- a/tests/helpers/synthetic.py
+++ b/tests/helpers/synthetic.py
@@ -1,0 +1,48 @@
+"""Synthetic HDF5 builders for the pipeline's inter-stage file contracts.
+
+These write the minimal datasets a stage reader consumes, so post-processing helpers
+can be unit tested without running a solver. Datasets follow the reader code: flat,
+top-level, lowercase, species-resolved profiles.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def write_transport_solution(
+    path: Path,
+    *,
+    rho: np.ndarray,
+    pressure: np.ndarray | None = None,
+    temperature: np.ndarray | None = None,
+    density: np.ndarray | None = None,
+) -> Path:
+    """Write a synthetic ``transport_solution.h5`` from caller-supplied profiles.
+
+    Parameters
+    ----------
+    path : Path
+        Destination HDF5 file.
+    rho : np.ndarray
+        Radial coordinate, shape ``(n_rho,)``.
+    pressure, temperature, density : np.ndarray, optional
+        Species-resolved profiles shaped ``(n_species, n_rho)`` for a static profile
+        or ``(n_time, n_species, n_rho)`` for a time-resolved one. Provide either
+        ``pressure`` or both ``temperature`` and ``density`` so a reader can form a
+        total pressure.
+
+    Returns
+    -------
+    Path
+        The written file path.
+    """
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=np.asarray(rho, dtype=float))
+        for name, arr in (("pressure", pressure), ("temperature", temperature), ("density", density)):
+            if arr is not None:
+                f.create_dataset(name, data=np.asarray(arr, dtype=float))
+    return path

--- a/tests/helpers/test_stage_import.py
+++ b/tests/helpers/test_stage_import.py
@@ -1,0 +1,82 @@
+"""Tests for the stage-script loader in ``tests.helpers.stage_import``.
+
+These use throwaway scripts written under ``tmp_path`` so they do not depend on
+any real ``stages/`` file or on the order in which other test modules load stage
+scripts. Every probe module is registered under a distinctive stem and removed
+from ``sys.modules`` on teardown so it cannot leak into the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.stage_import import REPO_ROOT, load_stage_module
+
+
+@pytest.fixture
+def clean_sys_modules() -> None:
+    """Remove any ``sys.modules`` entries a test adds, so probes do not leak."""
+    before = set(sys.modules)
+    try:
+        yield
+    finally:
+        for name in set(sys.modules) - before:
+            del sys.modules[name]
+
+
+def _relpath(script: Path) -> str:
+    """Repo-relative path string that ``load_stage_module`` joins onto the repo root."""
+    return os.path.relpath(script, REPO_ROOT)
+
+
+def test_reloading_same_file_returns_cached_and_executes_once(
+    tmp_path: Path, clean_sys_modules: None
+) -> None:
+    counter = tmp_path / "exec_count.txt"
+    script = tmp_path / "_stage_import_memo_probe.py"
+    script.write_text(
+        f'with open({str(counter)!r}, "a", encoding="utf-8") as _f:\n'
+        f'    _f.write("x")\n'
+        f"VALUE = 42\n"
+    )
+    relpath = _relpath(script)
+
+    first = load_stage_module(relpath)
+    second = load_stage_module(relpath)
+
+    assert first is second
+    assert first.VALUE == 42
+    assert counter.read_text() == "x"  # body ran exactly once, not once per call
+
+
+def test_stem_collision_with_different_file_raises(tmp_path: Path, clean_sys_modules: None) -> None:
+    dir_a = tmp_path / "col_a"
+    dir_b = tmp_path / "col_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    script_a = dir_a / "_stage_import_collision_probe.py"
+    script_b = dir_b / "_stage_import_collision_probe.py"
+    script_a.write_text("VALUE = 'a'\n")
+    script_b.write_text("VALUE = 'b'\n")
+
+    load_stage_module(_relpath(script_a))
+    with pytest.raises(ImportError) as excinfo:
+        load_stage_module(_relpath(script_b))
+
+    message = str(excinfo.value)
+    assert "col_a" in message  # names the cached file's path
+    assert "col_b" in message  # names the requested file's path
+
+
+def test_failed_load_leaves_no_cached_module(tmp_path: Path, clean_sys_modules: None) -> None:
+    script = tmp_path / "_stage_import_boom_probe.py"
+    script.write_text("raise RuntimeError('boom during import')\n")
+
+    with pytest.raises(RuntimeError, match="boom during import"):
+        load_stage_module(_relpath(script))
+
+    assert "_stage_import_boom_probe" not in sys.modules

--- a/tests/helpers/test_stage_import.py
+++ b/tests/helpers/test_stage_import.py
@@ -17,6 +17,9 @@ import pytest
 from tests.helpers.stage_import import REPO_ROOT, load_stage_module
 
 
+# `load_stage_module` registers modules in the global `sys.modules`. This fixture snapshots that registry before the
+# test and deletes any entries the test added afterward. A test using it can load throwaway modules without leaking them
+# into later tests.
 @pytest.fixture
 def clean_sys_modules() -> None:
     """Remove any ``sys.modules`` entries a test adds, so probes do not leak."""
@@ -33,6 +36,9 @@ def _relpath(script: Path) -> str:
     return os.path.relpath(script, REPO_ROOT)
 
 
+# `load_stage_module` should cache by file, running a script's body only once. This writes a probe script that appends
+# an "x" to a counter file every time its body runs, loads it twice, and asserts both loads return the very same module
+# object and that the counter contains a single "x" (the body ran once, not once per call).
 def test_reloading_same_file_returns_cached_and_executes_once(
     tmp_path: Path, clean_sys_modules: None
 ) -> None:
@@ -53,6 +59,9 @@ def test_reloading_same_file_returns_cached_and_executes_once(
     assert counter.read_text() == "x"  # body ran exactly once, not once per call
 
 
+# The loader keys modules by filename stem, so two different files sharing a stem would collide. This creates two files
+# with the same name in different folders, loads the first, and asserts loading the second raises ImportError whose
+# message names both paths, so the collision fails loudly instead of one file silently shadowing the other.
 def test_stem_collision_with_different_file_raises(tmp_path: Path, clean_sys_modules: None) -> None:
     dir_a = tmp_path / "col_a"
     dir_b = tmp_path / "col_b"
@@ -72,6 +81,9 @@ def test_stem_collision_with_different_file_raises(tmp_path: Path, clean_sys_mod
     assert "col_b" in message  # names the requested file's path
 
 
+# If a script raises while being imported, the loader must not leave a half-initialized module cached (which a later
+# load could mistake for success). This writes a script that raises on import, asserts that error propagates, and then
+# asserts the module's name is absent from `sys.modules`, confirming the loader cleaned up after the failure.
 def test_failed_load_leaves_no_cached_module(tmp_path: Path, clean_sys_modules: None) -> None:
     script = tmp_path / "_stage_import_boom_probe.py"
     script.write_text("raise RuntimeError('boom during import')\n")

--- a/tests/io_contracts/test_baseline_artifacts.py
+++ b/tests/io_contracts/test_baseline_artifacts.py
@@ -1,0 +1,117 @@
+"""Opportunistic contract checks against the real pipeline baseline outputs.
+
+The other ``tests/io_contracts`` modules build synthetic files and prove the validators in
+``src/io_contracts.py`` flag the right defects. This module is the complement: it runs those
+same five file validators against the actual, gitignored baseline artifacts produced by a
+local pipeline run, so a re-run whose upstream solver drifted (a renamed dataset, a
+transposed axis, a dropped variable from a breaking dependency bump) is caught here rather
+than silently downstream.
+
+Discovery reads the committed ``inputs/quick_run/config.yaml`` and resolves paths through
+``src.utils.resolve_pipeline_paths`` for both output layouts: the plain forward pass
+(``outputs/quick_run/stageN_.../``) and every closed-loop iteration
+(``outputs/quick_run/loop/iter_*/output/stageN_.../``), mirroring how the loop driver and
+``tests/orchestration/test_ouroboros.py`` build iteration paths. Whichever of those exist on
+this machine are validated.
+
+Because ``outputs/`` is gitignored, CI and fresh clones have no baseline: each parametrized
+case then finds zero files and skips with a clear reason instead of failing. The whole module
+is marked ``requires_baseline`` (registered in ``pytest.ini``) so it can also be selected or
+excluded explicitly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from src.io_contracts import (
+    validate_boozmn,
+    validate_neopax_fluxes,
+    validate_sfincs_flux,
+    validate_transport_solution,
+    validate_wout,
+)
+
+pytestmark = pytest.mark.requires_baseline
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = REPO_ROOT / "inputs/quick_run/config.yaml"
+
+# (output-artifact key, its file validator), in forward-pass chain order.
+_ARTIFACT_VALIDATORS: tuple[tuple[str, Callable[[Path], None]], ...] = (
+    ("s1_output", validate_wout),
+    ("s2_output", validate_boozmn),
+    ("s3_output", validate_sfincs_flux),
+    ("s4_output", validate_neopax_fluxes),
+    ("s5_output", validate_transport_solution),
+)
+_ARTIFACT_KEYS = tuple(key for key, _ in _ARTIFACT_VALIDATORS)
+
+
+def _discover_baseline_artifacts() -> dict[str, list[Path]]:
+    """Collect every existing local baseline file for the five output artifacts.
+
+    Reads the quick_run config once, resolves the plain forward-pass layout plus every
+    ``loop/iter_*/output`` closed-loop layout, and keeps only the paths present on disk.
+
+    Returns
+    -------
+    dict[str, list[Path]]
+        Maps each artifact key in ``_ARTIFACT_KEYS`` to its existing files (empty when the
+        gitignored baseline is absent, e.g. in CI).
+    """
+    import yaml
+
+    from src.utils import resolve_pipeline_paths
+
+    config = yaml.safe_load(_CONFIG_PATH.read_text())
+
+    layouts: list[dict[str, str]] = [resolve_pipeline_paths(config)]
+    # Closed-loop iteration output roots (each holds a full stageN_<name>/ tree of its
+    # own), derived from the config's output_dir like the loop driver derives them.
+    loop_root = REPO_ROOT / config["output_dir"] / "loop"
+    for output_dir in sorted(loop_root.glob("iter_*/output")):
+        # Mirror the iteration call shape used in tests/orchestration/test_ouroboros.py:
+        # the sibling input/ folder is the iteration's input_dir.
+        input_dir = output_dir.parent / "input"
+        layouts.append(
+            resolve_pipeline_paths(config, input_dir=str(input_dir), output_dir=str(output_dir))
+        )
+
+    found: dict[str, list[Path]] = {key: [] for key in _ARTIFACT_KEYS}
+    for layout in layouts:
+        for key in _ARTIFACT_KEYS:
+            # resolve_pipeline_paths returns repo-relative paths for the plain layout and
+            # absolute paths for the loop layouts; REPO_ROOT / <either> normalizes both.
+            path = REPO_ROOT / layout[key]
+            if path.exists():
+                found[key].append(path)
+    return found
+
+
+@pytest.fixture(scope="module")
+def baseline_artifacts() -> dict[str, list[Path]]:
+    """Discover the local baseline artifacts once for the whole module."""
+    return _discover_baseline_artifacts()
+
+
+@pytest.mark.parametrize(
+    ("key", "validator"),
+    _ARTIFACT_VALIDATORS,
+    ids=[key for key, _ in _ARTIFACT_VALIDATORS],
+)
+def test_baseline_artifact_satisfies_contract(
+    baseline_artifacts: dict[str, list[Path]],
+    key: str,
+    validator: Callable[[Path], None],
+) -> None:
+    """Every discovered baseline file for this artifact must still satisfy its contract."""
+    files = baseline_artifacts[key]
+    if not files:
+        pytest.skip(f"no local baseline file found for {key} (gitignored outputs/ absent); nothing to validate")
+    # A ContractError from any file is the drift signal we want surfaced.
+    for path in files:
+        validator(path)

--- a/tests/io_contracts/test_baseline_artifacts.py
+++ b/tests/io_contracts/test_baseline_artifacts.py
@@ -98,6 +98,10 @@ def baseline_artifacts() -> dict[str, list[Path]]:
     return _discover_baseline_artifacts()
 
 
+# Runs each of the five real file validators against the actual baseline outputs found on disk.
+# `@pytest.mark.parametrize` turns this into five separate test cases (one per artifact/validator pair). If no baseline
+# file exists for an artifact (e.g. on CI, where outputs/ is gitignored), that case skips with a clear reason; otherwise
+# a validator raising ContractError signals real output drift.
 @pytest.mark.parametrize(
     ("key", "validator"),
     _ARTIFACT_VALIDATORS,

--- a/tests/io_contracts/test_boozmn.py
+++ b/tests/io_contracts/test_boozmn.py
@@ -1,9 +1,11 @@
 """Tests for the Boozer ``boozmn`` NetCDF contract in ``src/io_contracts.py``.
 
-The Stage-3-consumed subset is ``bmnc_b`` (indexed ``[surface, mode]``), the 1D Boozer
-profiles, the ``ixm_b``/``ixn_b`` mode-number arrays, ``jlist``, and ``nfp_b``.
-Shape-mismatch cases run on the inner checker; the valid and missing-``bmnc_b`` files
-exercise the NetCDF read plus the raise.
+The Stage-3-consumed subset is ``bmnc_b`` (indexed ``[surface, mode]``), the required 1D
+Boozer profiles ``iota_b``/``buco_b``/``bvco_b``, the ``ixm_b``/``ixn_b`` mode-number
+arrays, ``jlist``, and ``nfp_b``. The toroidal-flux profiles ``phi_b``/``phip_b`` are
+absent from the real writer, so the valid case omits them; when a file does provide them
+they are still drift-checked for rank. Shape-mismatch cases run on the inner checker; the
+valid and missing-``bmnc_b`` files exercise the NetCDF read plus the raise.
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ from tests.helpers.synthetic import write_boozmn
 
 def _valid(n_surf: int = 3, mnboz: int = 4) -> dict[str, np.ndarray | None]:
     data: dict[str, np.ndarray | None] = {"bmnc_b": np.ones((n_surf, mnboz))}
-    data.update({name: np.linspace(0.0, 1.0, n_surf) for name in ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b")})
+    data.update({name: np.linspace(0.0, 1.0, n_surf + 1) for name in ("iota_b", "buco_b", "bvco_b")})
     data.update({"ixm_b": np.arange(mnboz), "ixn_b": np.zeros(mnboz, dtype=int)})
     data.update({"jlist": np.arange(2, 2 + n_surf), "nfp_b": np.array(1)})
     return data
@@ -45,6 +47,12 @@ def test_mode_array_length_mismatch_flagged() -> None:
     data = _valid(n_surf=3, mnboz=4)
     data["ixm_b"] = np.arange(2)  # sets mnboz to 2, so ixn_b length 4 is inconsistent
     assert any("ixn_b" in problem for problem in _check_boozmn(data))
+
+
+def test_present_2d_phi_b_flagged() -> None:
+    data = _valid()
+    data["phi_b"] = np.ones((3, 2))  # optional, but a 2D array is drift and must be flagged
+    assert any("phi_b" in problem and "1D" in problem for problem in _check_boozmn(data))
 
 
 def test_missing_nfp_b_flagged() -> None:

--- a/tests/io_contracts/test_boozmn.py
+++ b/tests/io_contracts/test_boozmn.py
@@ -49,6 +49,12 @@ def test_mode_array_length_mismatch_flagged() -> None:
     assert any("ixn_b" in problem for problem in _check_boozmn(data))
 
 
+def test_nonfinite_bmnc_flagged() -> None:
+    data = _valid()
+    data["bmnc_b"][0, 0] = np.nan
+    assert "'bmnc_b' contains non-finite values" in _check_boozmn(data)
+
+
 def test_present_2d_phi_b_flagged() -> None:
     data = _valid()
     data["phi_b"] = np.ones((3, 2))  # optional, but a 2D array is drift and must be flagged

--- a/tests/io_contracts/test_boozmn.py
+++ b/tests/io_contracts/test_boozmn.py
@@ -1,0 +1,63 @@
+"""Tests for the Boozer ``boozmn`` NetCDF contract in ``src/io_contracts.py``.
+
+The Stage-3-consumed subset is ``bmnc_b`` (indexed ``[surface, mode]``), the 1D Boozer
+profiles, the ``ixm_b``/``ixn_b`` mode-number arrays, ``jlist``, and ``nfp_b``.
+Shape-mismatch cases run on the inner checker; the valid and missing-``bmnc_b`` files
+exercise the NetCDF read plus the raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.io_contracts import ContractError, _check_boozmn, validate_boozmn
+from tests.helpers.synthetic import write_boozmn
+
+
+def _valid(n_surf: int = 3, mnboz: int = 4) -> dict[str, np.ndarray | None]:
+    data: dict[str, np.ndarray | None] = {"bmnc_b": np.ones((n_surf, mnboz))}
+    data.update({name: np.linspace(0.0, 1.0, n_surf) for name in ("iota_b", "buco_b", "bvco_b", "phi_b", "phip_b")})
+    data.update({"ixm_b": np.arange(mnboz), "ixn_b": np.zeros(mnboz, dtype=int)})
+    data.update({"jlist": np.arange(2, 2 + n_surf), "nfp_b": np.array(1)})
+    return data
+
+
+def test_valid_inner_passes() -> None:
+    assert _check_boozmn(_valid()) == []
+
+
+def test_missing_bmnc_flagged() -> None:
+    data = _valid()
+    data["bmnc_b"] = None
+    assert "missing required field 'bmnc_b'" in _check_boozmn(data)
+
+
+def test_mode_axis_mismatch_flagged() -> None:
+    data = _valid(n_surf=3, mnboz=4)
+    data["bmnc_b"] = np.ones((3, 2))  # mode axis 2 != mnboz 4 (from ixm_b)
+    assert any("bmnc_b" in problem and "mode axis" in problem for problem in _check_boozmn(data))
+
+
+def test_mode_array_length_mismatch_flagged() -> None:
+    data = _valid(n_surf=3, mnboz=4)
+    data["ixm_b"] = np.arange(2)  # sets mnboz to 2, so ixn_b length 4 is inconsistent
+    assert any("ixn_b" in problem for problem in _check_boozmn(data))
+
+
+def test_missing_nfp_b_flagged() -> None:
+    data = _valid()
+    data["nfp_b"] = None
+    assert "missing required field 'nfp_b'" in _check_boozmn(data)
+
+
+def test_valid_file_passes(tmp_path: Path) -> None:
+    assert validate_boozmn(write_boozmn(tmp_path / "b.nc")) is None
+
+
+def test_file_missing_bmnc_raises(tmp_path: Path) -> None:
+    written = write_boozmn(tmp_path / "b.nc", omit=("bmnc_b",))
+    with pytest.raises(ContractError, match="bmnc_b"):
+        validate_boozmn(written)

--- a/tests/io_contracts/test_boozmn.py
+++ b/tests/io_contracts/test_boozmn.py
@@ -37,12 +37,17 @@ def test_missing_bmnc_flagged() -> None:
     assert "missing required field 'bmnc_b'" in _check_boozmn(data)
 
 
+# Gives `bmnc_b` a mode axis of 2 while the mode-number array `ixm_b` says there are 4 modes. Asserts the checker flags
+# this "mode axis" mismatch, since the coefficients and their mode list must line up.
 def test_mode_axis_mismatch_flagged() -> None:
     data = _valid(n_surf=3, mnboz=4)
     data["bmnc_b"] = np.ones((3, 2))  # mode axis 2 != mnboz 4 (from ixm_b)
     assert any("bmnc_b" in problem and "mode axis" in problem for problem in _check_boozmn(data))
 
 
+# The two mode-number arrays `ixm_b` and `ixn_b` must have the same length. This shrinks `ixm_b` to length 2 (which sets
+# the expected mode count to 2), leaving `ixn_b` at length 4, and asserts the checker complains about `ixn_b` being
+# inconsistent.
 def test_mode_array_length_mismatch_flagged() -> None:
     data = _valid(n_surf=3, mnboz=4)
     data["ixm_b"] = np.arange(2)  # sets mnboz to 2, so ixn_b length 4 is inconsistent
@@ -55,6 +60,8 @@ def test_nonfinite_bmnc_flagged() -> None:
     assert "'bmnc_b' contains non-finite values" in _check_boozmn(data)
 
 
+# `phi_b` is optional, but when present it must be a 1D per-surface profile. This supplies a 2D `phi_b` and asserts the
+# checker flags it as not 1D, showing optional fields are still shape-checked when provided.
 def test_present_2d_phi_b_flagged() -> None:
     data = _valid()
     data["phi_b"] = np.ones((3, 2))  # optional, but a 2D array is drift and must be flagged
@@ -71,6 +78,8 @@ def test_valid_file_passes(tmp_path: Path) -> None:
     assert validate_boozmn(write_boozmn(tmp_path / "b.nc")) is None
 
 
+# End-to-end failure path: writes a real Boozer file with `bmnc_b` omitted and asserts `validate_boozmn` raises a
+# ContractError mentioning `bmnc_b`, confirming bad files are rejected.
 def test_file_missing_bmnc_raises(tmp_path: Path) -> None:
     written = write_boozmn(tmp_path / "b.nc", omit=("bmnc_b",))
     with pytest.raises(ContractError, match="bmnc_b"):

--- a/tests/io_contracts/test_neopax_fluxes.py
+++ b/tests/io_contracts/test_neopax_fluxes.py
@@ -54,6 +54,12 @@ def test_missing_minor_radius_flagged() -> None:
     assert "missing required meta attribute 'minor_radius_m'" in _check_neopax_fluxes(data, species, attrs)
 
 
+def test_nonfinite_q_flagged() -> None:
+    data, species, attrs = _valid()
+    data["Q"][0, 0] = np.nan
+    assert "'Q' contains non-finite values" in _check_neopax_fluxes(data, species, attrs)
+
+
 def test_valid_file_passes(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     flux = np.ones((3, 5))

--- a/tests/io_contracts/test_neopax_fluxes.py
+++ b/tests/io_contracts/test_neopax_fluxes.py
@@ -1,0 +1,69 @@
+"""Tests for the ``neopax_fluxes.h5`` contract in ``src/io_contracts.py``.
+
+Built to the Stage 4 writer: top-level ``rho``/``r`` and ``(n_species, n_radii)``
+``Gamma``/``Q``/``Upar`` (``Upar`` all zeros), plus a ``meta`` group carrying vlen-utf8
+``species_names`` and unit attributes. Malformed cases run on the inner checker; the
+valid and non-zero-``Upar`` files exercise the h5 read plus the raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.io_contracts import ContractError, _check_neopax_fluxes, validate_neopax_fluxes
+from tests.helpers.synthetic import write_neopax_fluxes
+
+
+def _valid(n_species: int = 3, n_radii: int = 5) -> tuple[dict[str, np.ndarray | None], np.ndarray, dict[str, object]]:
+    rho = np.linspace(0.0, 1.0, n_radii)
+    flux = np.ones((n_species, n_radii))
+    data = {"rho": rho, "r": rho.copy(), "Gamma": flux.copy(), "Q": flux.copy(), "Upar": np.zeros((n_species, n_radii))}
+    species = np.array(["e", "D", "T"], dtype=object)
+    attrs = {"particle_flux_units": "m^-2 s^-1", "heat_flux_units": "eV m^-2 s^-1", "minor_radius_m": 1.0}
+    return data, species, attrs
+
+
+def test_valid_inner_passes() -> None:
+    data, species, attrs = _valid()
+    assert _check_neopax_fluxes(data, species, attrs) == []
+
+
+def test_nonzero_upar_flagged() -> None:
+    data, species, attrs = _valid()
+    data["Upar"] = np.ones((3, 5))
+    assert "'Upar' must be all zeros for neopax_fluxes" in _check_neopax_fluxes(data, species, attrs)
+
+
+def test_missing_meta_species_flagged() -> None:
+    data, _, attrs = _valid()
+    assert "missing required field 'meta/species_names'" in _check_neopax_fluxes(data, None, attrs)
+
+
+def test_wrong_units_flagged() -> None:
+    data, species, attrs = _valid()
+    attrs["particle_flux_units"] = "wrong"
+    assert any("particle_flux_units" in problem for problem in _check_neopax_fluxes(data, species, attrs))
+
+
+def test_missing_minor_radius_flagged() -> None:
+    data, species, attrs = _valid()
+    del attrs["minor_radius_m"]
+    assert "missing required meta attribute 'minor_radius_m'" in _check_neopax_fluxes(data, species, attrs)
+
+
+def test_valid_file_passes(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    flux = np.ones((3, 5))
+    written = write_neopax_fluxes(tmp_path / "n.h5", rho=rho, gamma=flux, q=flux)
+    assert validate_neopax_fluxes(written) is None
+
+
+def test_file_nonzero_upar_raises(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    flux = np.ones((3, 5))
+    written = write_neopax_fluxes(tmp_path / "n.h5", rho=rho, gamma=flux, q=flux, upar=np.ones((3, 5)))
+    with pytest.raises(ContractError, match="Upar"):
+        validate_neopax_fluxes(written)

--- a/tests/io_contracts/test_neopax_fluxes.py
+++ b/tests/io_contracts/test_neopax_fluxes.py
@@ -31,6 +31,8 @@ def test_valid_inner_passes() -> None:
     assert _check_neopax_fluxes(data, species, attrs) == []
 
 
+# The Stage 4 writer always emits `Upar` (parallel flow) as all zeros, so a non-zero value signals a wrong or mislabeled
+# array. This sets `Upar` to all ones and asserts the checker flags that it must be all zeros.
 def test_nonzero_upar_flagged() -> None:
     data, species, attrs = _valid()
     data["Upar"] = np.ones((3, 5))
@@ -42,6 +44,8 @@ def test_missing_meta_species_flagged() -> None:
     assert "missing required field 'meta/species_names'" in _check_neopax_fluxes(data, None, attrs)
 
 
+# The contract pins the exact expected unit strings. This sets `particle_flux_units` to a bogus value and asserts the
+# checker flags it, confirming units must match, not just be present.
 def test_wrong_units_flagged() -> None:
     data, species, attrs = _valid()
     attrs["particle_flux_units"] = "wrong"
@@ -60,6 +64,8 @@ def test_nonfinite_q_flagged() -> None:
     assert "'Q' contains non-finite values" in _check_neopax_fluxes(data, species, attrs)
 
 
+# Writes a real, valid HDF5 flux file to a temp directory and asserts the public `validate_neopax_fluxes` reads it and
+# returns None (no error).
 def test_valid_file_passes(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     flux = np.ones((3, 5))
@@ -67,6 +73,8 @@ def test_valid_file_passes(tmp_path: Path) -> None:
     assert validate_neopax_fluxes(written) is None
 
 
+# End-to-end failure path: writes a real file whose `Upar` is all ones (should be zeros) and asserts
+# `validate_neopax_fluxes` raises a ContractError mentioning `Upar`.
 def test_file_nonzero_upar_raises(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     flux = np.ones((3, 5))

--- a/tests/io_contracts/test_sfincs_flux.py
+++ b/tests/io_contracts/test_sfincs_flux.py
@@ -1,0 +1,66 @@
+"""Tests for the ``sfincs_jax_flux_profiles.h5`` contract in ``src/io_contracts.py``.
+
+Built to the Stage 3 writer: top-level ``r``/``rHat``/``rho`` and ``(n_species,
+n_radii)`` ``Gamma``/``Q``/``Upar``, bytes ``species_names``, and a root
+``axis_zero_padded`` attribute. Malformed cases run on the inner checker; the valid and
+wrong-radius files exercise the h5 read plus the raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.io_contracts import ContractError, _check_sfincs_flux, validate_sfincs_flux
+from tests.helpers.synthetic import write_sfincs_flux
+
+
+def _valid_data(n_species: int = 3, n_radii: int = 5) -> dict[str, np.ndarray | None]:
+    rho = np.linspace(0.0, 1.0, n_radii)
+    flux = np.ones((n_species, n_radii))
+    return {
+        "r": rho.copy(),
+        "rHat": rho.copy(),
+        "rho": rho,
+        "Gamma": flux.copy(),
+        "Q": flux.copy(),
+        "Upar": np.zeros((n_species, n_radii)),
+        "species_names": np.array([b"e", b"D", b"T"]),
+    }
+
+
+def test_valid_inner_passes() -> None:
+    assert _check_sfincs_flux(_valid_data(), {"axis_zero_padded": True}) == []
+
+
+def test_missing_gamma_flagged() -> None:
+    data = _valid_data()
+    data["Gamma"] = None
+    assert "missing required field 'Gamma'" in _check_sfincs_flux(data, {"axis_zero_padded": True})
+
+
+def test_species_axis_mismatch_flagged() -> None:
+    data = _valid_data(n_species=3, n_radii=5)
+    data["Q"] = np.ones((2, 5))  # 2 species but species_names has 3
+    assert any("Q" in problem and "species axis" in problem for problem in _check_sfincs_flux(data, {"axis_zero_padded": True}))
+
+
+def test_missing_attr_flagged() -> None:
+    assert "missing required root attribute 'axis_zero_padded'" in _check_sfincs_flux(_valid_data(), {})
+
+
+def test_valid_file_passes(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    flux = np.ones((3, 5))
+    written = write_sfincs_flux(tmp_path / "s.h5", rho=rho, gamma=flux, q=flux)
+    assert validate_sfincs_flux(written) is None
+
+
+def test_file_wrong_radius_axis_raises(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    flux = np.ones((3, 4))  # radius axis 4 != len(rho) 5
+    written = write_sfincs_flux(tmp_path / "s.h5", rho=rho, gamma=flux, q=flux, upar=np.zeros((3, 4)))
+    with pytest.raises(ContractError, match="radius axis"):
+        validate_sfincs_flux(written)

--- a/tests/io_contracts/test_sfincs_flux.py
+++ b/tests/io_contracts/test_sfincs_flux.py
@@ -41,12 +41,17 @@ def test_missing_gamma_flagged() -> None:
     assert "missing required field 'Gamma'" in _check_sfincs_flux(data, {"axis_zero_padded": True})
 
 
+# Flux arrays are shaped (n_species, n_radii). This gives `Q` only 2 species-rows while `species_names` lists 3 species,
+# and asserts the checker flags the "species axis" mismatch.
 def test_species_axis_mismatch_flagged() -> None:
     data = _valid_data(n_species=3, n_radii=5)
     data["Q"] = np.ones((2, 5))  # 2 species but species_names has 3
     assert any("Q" in problem and "species axis" in problem for problem in _check_sfincs_flux(data, {"axis_zero_padded": True}))
 
 
+# Passes valid data but an empty attributes dict (`{}`), so the required root attribute `axis_zero_padded` is absent,
+# and asserts the checker reports it missing. Shows that file-level metadata, not just datasets, is part of the
+# contract.
 def test_missing_attr_flagged() -> None:
     assert "missing required root attribute 'axis_zero_padded'" in _check_sfincs_flux(_valid_data(), {})
 
@@ -64,6 +69,9 @@ def test_valid_file_passes(tmp_path: Path) -> None:
     assert validate_sfincs_flux(written) is None
 
 
+# End-to-end failure path: writes a real file whose flux radius axis (4) disagrees with the length of `rho` (5), and
+# asserts `validate_sfincs_flux` raises a ContractError mentioning "radius axis". Confirms shape drift is caught when
+# reading a real file, not just an in-memory dict.
 def test_file_wrong_radius_axis_raises(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     flux = np.ones((3, 4))  # radius axis 4 != len(rho) 5

--- a/tests/io_contracts/test_sfincs_flux.py
+++ b/tests/io_contracts/test_sfincs_flux.py
@@ -51,6 +51,12 @@ def test_missing_attr_flagged() -> None:
     assert "missing required root attribute 'axis_zero_padded'" in _check_sfincs_flux(_valid_data(), {})
 
 
+def test_nonfinite_gamma_flagged() -> None:
+    data = _valid_data()
+    data["Gamma"][0, 0] = np.nan
+    assert "'Gamma' contains non-finite values" in _check_sfincs_flux(data, {"axis_zero_padded": True})
+
+
 def test_valid_file_passes(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     flux = np.ones((3, 5))

--- a/tests/io_contracts/test_signal.py
+++ b/tests/io_contracts/test_signal.py
@@ -17,10 +17,15 @@ def test_valid_signal_passes() -> None:
     assert validate_signal({"converged": True, "halt": False}) is None
 
 
+# Gives `converged` the integer 1 instead of a real bool and asserts the inner checker returns exactly the "must be
+# bool, got int" problem. Checking the full returned list (with ==) pins both the wording and that no other spurious
+# problems appear.
 def test_check_signal_wrong_type() -> None:
     assert _check_signal({"converged": 1, "halt": False}) == ["key 'converged' must be bool, got int"]
 
 
+# Passes a list instead of a dict and asserts the checker returns the single "signal must be a dict" problem, confirming
+# it rejects the wrong top-level type before checking any keys.
 def test_check_signal_not_a_dict() -> None:
     assert _check_signal(["converged", "halt"]) == ["signal must be a dict, got list"]
 
@@ -30,6 +35,9 @@ def test_validate_signal_raises_on_missing_key() -> None:
         validate_signal({"converged": True})
 
 
+# Passes an empty dict (both required keys missing) and asserts the raised error message mentions both `converged` and
+# `halt`. This proves the validator reports every problem at once rather than stopping at the first one. `exc.value` is
+# the captured exception object.
 def test_validate_signal_reports_all_problems() -> None:
     with pytest.raises(ContractError) as exc:
         validate_signal({})

--- a/tests/io_contracts/test_signal.py
+++ b/tests/io_contracts/test_signal.py
@@ -17,10 +17,6 @@ def test_valid_signal_passes() -> None:
     assert validate_signal({"converged": True, "halt": False}) is None
 
 
-def test_check_signal_missing_key() -> None:
-    assert _check_signal({"converged": True}) == ["missing required key 'halt'"]
-
-
 def test_check_signal_wrong_type() -> None:
     assert _check_signal({"converged": 1, "halt": False}) == ["key 'converged' must be bool, got int"]
 

--- a/tests/io_contracts/test_signal.py
+++ b/tests/io_contracts/test_signal.py
@@ -1,0 +1,41 @@
+"""Tests for the closed-loop signal contract in ``src/io_contracts.py``.
+
+The signal is a parsed ``converge_status.json`` dict, so the validator has no file
+layer: ``validate_signal`` is the pure checker plus the raise. Invalid cases are
+exercised on the checker directly; the raise path and all-problems reporting are shown
+through the public ``validate_signal``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.io_contracts import ContractError, _check_signal, validate_signal
+
+
+def test_valid_signal_passes() -> None:
+    assert validate_signal({"converged": True, "halt": False}) is None
+
+
+def test_check_signal_missing_key() -> None:
+    assert _check_signal({"converged": True}) == ["missing required key 'halt'"]
+
+
+def test_check_signal_wrong_type() -> None:
+    assert _check_signal({"converged": 1, "halt": False}) == ["key 'converged' must be bool, got int"]
+
+
+def test_check_signal_not_a_dict() -> None:
+    assert _check_signal(["converged", "halt"]) == ["signal must be a dict, got list"]
+
+
+def test_validate_signal_raises_on_missing_key() -> None:
+    with pytest.raises(ContractError, match="halt"):
+        validate_signal({"converged": True})
+
+
+def test_validate_signal_reports_all_problems() -> None:
+    with pytest.raises(ContractError) as exc:
+        validate_signal({})
+    message = str(exc.value)
+    assert "converged" in message and "halt" in message

--- a/tests/io_contracts/test_transport_solution.py
+++ b/tests/io_contracts/test_transport_solution.py
@@ -1,9 +1,12 @@
 """Tests for the ``transport_solution.h5`` contract in ``src/io_contracts.py``.
 
-The contract is the union of the Stage 3/4/5 transport-snapshot loaders: required
-``rho``/``density``/``temperature``/``Er`` (``Er`` with no species axis), optional
-``pressure``/``ts``. Malformed cases run on the inner checker; the valid and missing-Er
-files exercise the h5 read plus the raise.
+The contract covers the fields read by the Stage 3/4/5 transport-snapshot loaders:
+required ``rho``/``density``/``temperature``/``Er`` (``Er`` with no species axis),
+optional ``pressure``/``ts``. ``temperature`` is required and ``pressure`` optional
+because the Stage 3 loader accepts either and derives the missing one, while the
+Stage 4 loader hard-requires ``temperature`` with no pressure fallback. Malformed
+cases run on the inner checker; the valid and missing-Er files exercise the h5 read
+plus the raise.
 """
 
 from __future__ import annotations

--- a/tests/io_contracts/test_transport_solution.py
+++ b/tests/io_contracts/test_transport_solution.py
@@ -57,6 +57,43 @@ def test_rho_axis_mismatch_flagged() -> None:
     assert any("density" in problem and "trailing axis" in problem for problem in _check_transport_solution(data))
 
 
+def test_nonfinite_density_flagged() -> None:
+    data = _valid_data()
+    data["density"][0, 0] = np.nan
+    assert "'density' contains non-finite values" in _check_transport_solution(data)
+
+
+def test_rho_not_1d_flagged() -> None:
+    data = _valid_data()
+    data["rho"] = np.ones((2, 3))  # rho must be a 1D radial coordinate
+    assert any("rho" in problem and "must be 1D" in problem for problem in _check_transport_solution(data))
+
+
+def test_pressure_rank_mismatch_flagged() -> None:
+    data = _valid_data(n_species=3, n_rho=5)
+    data["pressure"] = np.ones((4, 3, 5))  # 3D pressure while density is 2D
+    assert any(
+        "pressure" in problem and "density" in problem and "ndim" in problem
+        for problem in _check_transport_solution(data)
+    )
+
+
+def test_er_trailing_axis_mismatch_flagged() -> None:
+    data = _valid_data(n_rho=5)
+    data["Er"] = np.ones(4)  # trailing axis 4 != len(rho) 5
+    assert any("Er" in problem and "trailing axis" in problem for problem in _check_transport_solution(data))
+
+
+def test_ts_length_mismatch_flagged() -> None:
+    n_time, n_species, n_rho = 4, 3, 5
+    data = _valid_data(n_species=n_species, n_rho=n_rho)
+    data["density"] = np.ones((n_time, n_species, n_rho))
+    data["temperature"] = np.ones((n_time, n_species, n_rho))
+    data["Er"] = np.ones((n_time, n_rho))
+    data["ts"] = np.arange(n_time - 1, dtype=float)  # length 3 != time axis 4
+    assert any("ts" in problem and "time axis" in problem for problem in _check_transport_solution(data))
+
+
 def test_valid_file_passes(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     profile = np.ones((3, 5))

--- a/tests/io_contracts/test_transport_solution.py
+++ b/tests/io_contracts/test_transport_solution.py
@@ -45,12 +45,17 @@ def test_missing_er_flagged() -> None:
     assert "missing required field 'Er'" in _check_transport_solution(data)
 
 
+# `Er` is a per-radius field with no species axis, so it must have one fewer dimension than the species-resolved
+# `density`. This wrongly gives `Er` a (species, radius) 2D shape and asserts the checker flags that `Er`'s rank should
+# be "one less" than density's.
 def test_er_with_species_axis_flagged() -> None:
     data = _valid_data(n_species=3, n_rho=5)
     data["Er"] = np.ones((3, 5))  # wrongly given a species axis
     assert any("Er" in problem and "one less" in problem for problem in _check_transport_solution(data))
 
 
+# Every profile's last axis must span the radial grid `rho`. This gives `density` a trailing axis of 4 while `rho` has
+# length 5, and asserts the checker flags the "trailing axis" mismatch.
 def test_rho_axis_mismatch_flagged() -> None:
     data = _valid_data(n_rho=5)
     data["density"] = np.ones((3, 4))  # trailing axis 4 != len(rho) 5
@@ -63,12 +68,15 @@ def test_nonfinite_density_flagged() -> None:
     assert "'density' contains non-finite values" in _check_transport_solution(data)
 
 
+# `rho` is the 1D radial coordinate. This gives it a 2D shape and asserts the checker flags that `rho` "must be 1D".
 def test_rho_not_1d_flagged() -> None:
     data = _valid_data()
     data["rho"] = np.ones((2, 3))  # rho must be a 1D radial coordinate
     assert any("rho" in problem and "must be 1D" in problem for problem in _check_transport_solution(data))
 
 
+# `pressure` is optional, but when present it must share `density`'s rank (static vs time-resolved). This gives a 3D
+# (time-resolved) pressure while density is 2D (static) and asserts the checker flags the ndim mismatch between the two.
 def test_pressure_rank_mismatch_flagged() -> None:
     data = _valid_data(n_species=3, n_rho=5)
     data["pressure"] = np.ones((4, 3, 5))  # 3D pressure while density is 2D
@@ -84,6 +92,9 @@ def test_er_trailing_axis_mismatch_flagged() -> None:
     assert any("Er" in problem and "trailing axis" in problem for problem in _check_transport_solution(data))
 
 
+# Sets up a time-resolved solution (density/temperature are 3D and `Er` 2D over 4 time steps) but makes the time axis
+# `ts` length 3 instead of 4. Asserts the checker flags that `ts`'s length disagrees with the profiles' time axis, so
+# the timestamps and the data stay in sync.
 def test_ts_length_mismatch_flagged() -> None:
     n_time, n_species, n_rho = 4, 3, 5
     data = _valid_data(n_species=n_species, n_rho=n_rho)
@@ -101,6 +112,8 @@ def test_valid_file_passes(tmp_path: Path) -> None:
     assert validate_transport_solution(written) is None
 
 
+# End-to-end failure path: writes a real file omitting the `er` argument (so `Er` is absent) and asserts
+# `validate_transport_solution` raises a ContractError mentioning `Er`.
 def test_file_missing_er_raises(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     profile = np.ones((3, 5))

--- a/tests/io_contracts/test_transport_solution.py
+++ b/tests/io_contracts/test_transport_solution.py
@@ -1,0 +1,72 @@
+"""Tests for the ``transport_solution.h5`` contract in ``src/io_contracts.py``.
+
+The contract is the union of the Stage 3/4/5 transport-snapshot loaders: required
+``rho``/``density``/``temperature``/``Er`` (``Er`` with no species axis), optional
+``pressure``/``ts``. Malformed cases run on the inner checker; the valid and missing-Er
+files exercise the h5 read plus the raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.io_contracts import ContractError, _check_transport_solution, validate_transport_solution
+from tests.helpers.synthetic import write_transport_solution
+
+
+def _valid_data(n_species: int = 3, n_rho: int = 5) -> dict[str, np.ndarray | None]:
+    profile = np.ones((n_species, n_rho))
+    return {
+        "rho": np.linspace(0.0, 1.0, n_rho),
+        "density": profile.copy(),
+        "temperature": profile.copy(),
+        "pressure": None,
+        "Er": np.ones(n_rho),
+        "ts": None,
+    }
+
+
+def test_valid_inner_passes() -> None:
+    assert _check_transport_solution(_valid_data()) == []
+
+
+def test_missing_temperature_flagged() -> None:
+    data = _valid_data()
+    data["temperature"] = None
+    assert "missing required field 'temperature'" in _check_transport_solution(data)
+
+
+def test_missing_er_flagged() -> None:
+    data = _valid_data()
+    data["Er"] = None
+    assert "missing required field 'Er'" in _check_transport_solution(data)
+
+
+def test_er_with_species_axis_flagged() -> None:
+    data = _valid_data(n_species=3, n_rho=5)
+    data["Er"] = np.ones((3, 5))  # wrongly given a species axis
+    assert any("Er" in problem and "one less" in problem for problem in _check_transport_solution(data))
+
+
+def test_rho_axis_mismatch_flagged() -> None:
+    data = _valid_data(n_rho=5)
+    data["density"] = np.ones((3, 4))  # trailing axis 4 != len(rho) 5
+    assert any("density" in problem and "trailing axis" in problem for problem in _check_transport_solution(data))
+
+
+def test_valid_file_passes(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    profile = np.ones((3, 5))
+    written = write_transport_solution(tmp_path / "t.h5", rho=rho, density=profile, temperature=profile, er=np.ones(5))
+    assert validate_transport_solution(written) is None
+
+
+def test_file_missing_er_raises(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    profile = np.ones((3, 5))
+    written = write_transport_solution(tmp_path / "t.h5", rho=rho, density=profile, temperature=profile)
+    with pytest.raises(ContractError, match="Er"):
+        validate_transport_solution(written)

--- a/tests/io_contracts/test_wout.py
+++ b/tests/io_contracts/test_wout.py
@@ -1,0 +1,64 @@
+"""Tests for the VMEC ``wout`` NetCDF contract in ``src/io_contracts.py``.
+
+The Stage-2-consumed subset is the 2D geometry coefficients, the 1D profiles, and the
+``xm``/``xn``/``nfp`` mode information the coefficients are indexed by. Shape-mismatch
+cases run on the inner checker (NetCDF cannot store an inconsistent file); the valid and
+missing-``xm`` files exercise the NetCDF read plus the raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.io_contracts import ContractError, _check_wout, validate_wout
+from tests.helpers.synthetic import write_wout
+
+
+def _valid(ns: int = 4, mnmax: int = 3) -> dict[str, np.ndarray | None]:
+    two_d = np.ones((ns, mnmax))
+    one_d = np.linspace(0.0, 1.0, ns)
+    data: dict[str, np.ndarray | None] = {name: two_d.copy() for name in ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc")}
+    data.update({name: one_d.copy() for name in ("iotas", "phi", "phipf")})
+    data.update({"xm": np.arange(mnmax, dtype=float), "xn": np.zeros(mnmax), "nfp": np.array(1)})
+    return data
+
+
+def test_valid_inner_passes() -> None:
+    assert _check_wout(_valid()) == []
+
+
+def test_missing_rmnc_flagged() -> None:
+    data = _valid()
+    data["rmnc"] = None
+    assert "missing required field 'rmnc'" in _check_wout(data)
+
+
+def test_mode_axis_mismatch_flagged() -> None:
+    data = _valid(ns=4, mnmax=3)
+    data["bmnc"] = np.ones((4, 2))  # mode axis 2 != mnmax 3 (from xm)
+    assert any("bmnc" in problem and "mode axis" in problem for problem in _check_wout(data))
+
+
+def test_missing_xm_flagged() -> None:
+    data = _valid()
+    data["xm"] = None
+    assert "missing required field 'xm'" in _check_wout(data)
+
+
+def test_missing_nfp_flagged() -> None:
+    data = _valid()
+    data["nfp"] = None
+    assert "missing required field 'nfp'" in _check_wout(data)
+
+
+def test_valid_file_passes(tmp_path: Path) -> None:
+    assert validate_wout(write_wout(tmp_path / "wout.nc")) is None
+
+
+def test_file_missing_xm_raises(tmp_path: Path) -> None:
+    written = write_wout(tmp_path / "wout.nc", omit=("xm",))
+    with pytest.raises(ContractError, match="xm"):
+        validate_wout(written)

--- a/tests/io_contracts/test_wout.py
+++ b/tests/io_contracts/test_wout.py
@@ -48,6 +48,18 @@ def test_nyq_mode_axis_mismatch_flagged() -> None:
     assert any("bmnc" in problem and "mode axis" in problem for problem in _check_wout(data))
 
 
+def test_nonfinite_rmnc_flagged() -> None:
+    data = _valid()
+    data["rmnc"][0, 0] = np.nan
+    assert "'rmnc' contains non-finite values" in _check_wout(data)
+
+
+def test_1d_profile_length_mismatch_flagged() -> None:
+    data = _valid(ns=4, mnmax=3, mnmax_nyq=5)
+    data["phi"] = np.ones(3)  # length 3 != ns 4 (ns inferred from iotas)
+    assert any("phi" in problem and "length" in problem for problem in _check_wout(data))
+
+
 def test_missing_xm_flagged() -> None:
     data = _valid()
     data["xm"] = None

--- a/tests/io_contracts/test_wout.py
+++ b/tests/io_contracts/test_wout.py
@@ -1,9 +1,11 @@
 """Tests for the VMEC ``wout`` NetCDF contract in ``src/io_contracts.py``.
 
-The Stage-2-consumed subset is the 2D geometry coefficients, the 1D profiles, and the
-``xm``/``xn``/``nfp`` mode information the coefficients are indexed by. Shape-mismatch
-cases run on the inner checker (NetCDF cannot store an inconsistent file); the valid and
-missing-``xm`` files exercise the NetCDF read plus the raise.
+The Stage-2-consumed subset is two Fourier-coefficient families: the shape coefficients on
+the ``mn_mode`` grid indexed by ``xm``/``xn``, and the field-strength coefficients on the
+denser Nyquist grid indexed by ``xm_nyq``/``xn_nyq``. It also covers the 1D profiles,
+``nfp``, and the minor-radius scalars (``Aminor_p``, or ``volume_p`` with ``Rmajor_p``) the
+Stage 4 reader needs. Shape-mismatch cases run on the inner checker (NetCDF cannot store an
+inconsistent file); the valid and missing-``xm`` files exercise the NetCDF read plus the raise.
 """
 
 from __future__ import annotations
@@ -17,12 +19,16 @@ from src.io_contracts import ContractError, _check_wout, validate_wout
 from tests.helpers.synthetic import write_wout
 
 
-def _valid(ns: int = 4, mnmax: int = 3) -> dict[str, np.ndarray | None]:
+def _valid(ns: int = 4, mnmax: int = 3, mnmax_nyq: int = 5) -> dict[str, np.ndarray | None]:
     two_d = np.ones((ns, mnmax))
+    two_d_nyq = np.ones((ns, mnmax_nyq))
     one_d = np.linspace(0.0, 1.0, ns)
-    data: dict[str, np.ndarray | None] = {name: two_d.copy() for name in ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc")}
+    data: dict[str, np.ndarray | None] = {name: two_d.copy() for name in ("rmnc", "zmns", "lmns")}
+    data.update({name: two_d_nyq.copy() for name in ("bmnc", "bsubumnc", "bsubvmnc")})
     data.update({name: one_d.copy() for name in ("iotas", "phi", "phipf")})
-    data.update({"xm": np.arange(mnmax, dtype=float), "xn": np.zeros(mnmax), "nfp": np.array(1)})
+    data.update({"xm": np.arange(mnmax, dtype=float), "xn": np.zeros(mnmax)})
+    data.update({"xm_nyq": np.arange(mnmax_nyq, dtype=float), "xn_nyq": np.zeros(mnmax_nyq)})
+    data.update({"nfp": np.array(1), "Aminor_p": np.array(0.3)})
     return data
 
 
@@ -36,9 +42,9 @@ def test_missing_rmnc_flagged() -> None:
     assert "missing required field 'rmnc'" in _check_wout(data)
 
 
-def test_mode_axis_mismatch_flagged() -> None:
-    data = _valid(ns=4, mnmax=3)
-    data["bmnc"] = np.ones((4, 2))  # mode axis 2 != mnmax 3 (from xm)
+def test_nyq_mode_axis_mismatch_flagged() -> None:
+    data = _valid(ns=4, mnmax=3, mnmax_nyq=5)
+    data["bmnc"] = np.ones((4, 3))  # mode axis 3 != mnmax_nyq 5 (from xm_nyq)
     assert any("bmnc" in problem and "mode axis" in problem for problem in _check_wout(data))
 
 
@@ -48,10 +54,25 @@ def test_missing_xm_flagged() -> None:
     assert "missing required field 'xm'" in _check_wout(data)
 
 
+def test_missing_xm_nyq_flagged() -> None:
+    data = _valid()
+    data["xm_nyq"] = None
+    assert "missing required field 'xm_nyq'" in _check_wout(data)
+
+
 def test_missing_nfp_flagged() -> None:
     data = _valid()
     data["nfp"] = None
     assert "missing required field 'nfp'" in _check_wout(data)
+
+
+def test_missing_minor_radius_flagged() -> None:
+    data = _valid()
+    data["Aminor_p"] = None  # volume_p / Rmajor_p are absent from the valid dict too
+    assert (
+        "missing required minor-radius scalars: 'Aminor_p' or both 'volume_p' and 'Rmajor_p'"
+        in _check_wout(data)
+    )
 
 
 def test_valid_file_passes(tmp_path: Path) -> None:

--- a/tests/io_contracts/test_wout.py
+++ b/tests/io_contracts/test_wout.py
@@ -42,6 +42,9 @@ def test_missing_rmnc_flagged() -> None:
     assert "missing required field 'rmnc'" in _check_wout(data)
 
 
+# Gives `bmnc` a mode axis of 3 while the Nyquist mode-number array `xm_nyq` says there should be 5 modes. Asserts the
+# checker flags this "mode axis" mismatch, since a coefficient array and the mode list that indexes it must agree in
+# length.
 def test_nyq_mode_axis_mismatch_flagged() -> None:
     data = _valid(ns=4, mnmax=3, mnmax_nyq=5)
     data["bmnc"] = np.ones((4, 3))  # mode axis 3 != mnmax_nyq 5 (from xm_nyq)
@@ -54,6 +57,8 @@ def test_nonfinite_rmnc_flagged() -> None:
     assert "'rmnc' contains non-finite values" in _check_wout(data)
 
 
+# Makes the 1D radial profile `phi` length 3 while the number of radial surfaces `ns` is 4 (inferred from `iotas`).
+# Asserts the checker flags the length mismatch, since every per-surface profile must have one value per surface.
 def test_1d_profile_length_mismatch_flagged() -> None:
     data = _valid(ns=4, mnmax=3, mnmax_nyq=5)
     data["phi"] = np.ones(3)  # length 3 != ns 4 (ns inferred from iotas)
@@ -78,6 +83,9 @@ def test_missing_nfp_flagged() -> None:
     assert "missing required field 'nfp'" in _check_wout(data)
 
 
+# The minor radius can be supplied either directly as `Aminor_p` or derived from `volume_p` + `Rmajor_p`. This removes
+# `Aminor_p` when the other two are also absent, and asserts the checker reports that none of the accepted ways to give
+# the minor radius are present.
 def test_missing_minor_radius_flagged() -> None:
     data = _valid()
     data["Aminor_p"] = None  # volume_p / Rmajor_p are absent from the valid dict too
@@ -87,10 +95,15 @@ def test_missing_minor_radius_flagged() -> None:
     )
 
 
+# `write_wout` writes a real, valid NetCDF file to a temporary directory, then the public `validate_wout` reads it back
+# and returns None (no exception), proving the file-reading layer accepts a good file.
 def test_valid_file_passes(tmp_path: Path) -> None:
     assert validate_wout(write_wout(tmp_path / "wout.nc")) is None
 
 
+# The end-to-end failure path. Writes a real NetCDF file but omits the `xm` variable, then asserts `validate_wout`
+# raises a ContractError whose message mentions `xm`. `pytest.raises` fails the test if no such error is raised, so this
+# confirms bad files are rejected loudly, not silently.
 def test_file_missing_xm_raises(tmp_path: Path) -> None:
     written = write_wout(tmp_path / "wout.nc", omit=("xm",))
     with pytest.raises(ContractError, match="xm"):

--- a/tests/orchestration/test_config_edit.py
+++ b/tests/orchestration/test_config_edit.py
@@ -30,6 +30,9 @@ def test_multiple_keys() -> None:
     assert apply_assignments(text, {"a": "10", "c": "30"}) == "a = 10\nb = 2\nc = 30\n"
 
 
+# The value is inserted exactly as the caller supplies it, with no quoting added. Here a value that already includes
+# quotes and slashes (a quoted relative path) must land verbatim, which is exactly what Stage 5's prepare_neopax_config
+# relies on.
 def test_inserts_caller_value_verbatim() -> None:
     # The real prepare_neopax_config case: a caller-quoted relative path is inserted
     # exactly as given (no quoting added, quotes and slashes preserved).
@@ -37,11 +40,16 @@ def test_inserts_caller_value_verbatim() -> None:
     assert out == 'vmec_file = "../stage1_equilibrium/wout.nc"'
 
 
+# Only keys starting at the very beginning of a line (column 0) are rewritten. An indented `  a = 1` is left untouched,
+# so nested/section keys are never accidentally rewritten alongside the top-level ones this helper targets.
 def test_only_column_zero_keys_match() -> None:
     # Indented keys are left untouched (TOML top-level keys sit at column 0).
     assert apply_assignments("  a = 1\n", {"a": "9"}) == "  a = 1\n"
 
 
+# A key must match as a whole word, not as a prefix of a longer key. Rewriting `transport_output` must not touch a
+# `transport_output_dir` line, so this asserts the text is unchanged. Without this guarantee the helper could corrupt a
+# similarly-named neighbouring key.
 def test_prefix_collision_safety() -> None:
     # Rewriting "transport_output" must not touch "transport_output_dir".
     text = 'transport_output_dir = "old"\n'

--- a/tests/orchestration/test_config_edit.py
+++ b/tests/orchestration/test_config_edit.py
@@ -1,0 +1,48 @@
+"""Tests for ``src.utils.config_edit.apply_assignments``.
+
+``apply_assignments`` rewrites ``key = value`` lines in upstream config text.
+Stage 5's ``prepare_neopax_config`` depends on it to point NEOPAX at the right
+artifacts, so the exact rewrite semantics are pinned here: the ``key =`` prefix is
+preserved, no quoting is added, only column-0 keys match, and a key is never
+mistaken for a longer key sharing its prefix.
+"""
+
+from __future__ import annotations
+
+from src.utils import apply_assignments
+
+
+def test_replaces_value_only() -> None:
+    assert apply_assignments("a = 1\nb = 2\n", {"a": "9"}) == "a = 9\nb = 2\n"
+
+
+def test_preserves_prefix_spacing() -> None:
+    assert apply_assignments("x=1", {"x": "2"}) == "x=2"
+    assert apply_assignments("x  =  1", {"x": "2"}) == "x  =  2"
+
+
+def test_absent_key_unchanged() -> None:
+    assert apply_assignments("a = 1\n", {"c": "3"}) == "a = 1\n"
+
+
+def test_multiple_keys() -> None:
+    text = "a = 1\nb = 2\nc = 3\n"
+    assert apply_assignments(text, {"a": "10", "c": "30"}) == "a = 10\nb = 2\nc = 30\n"
+
+
+def test_inserts_caller_value_verbatim() -> None:
+    # The real prepare_neopax_config case: a caller-quoted relative path is inserted
+    # exactly as given (no quoting added, quotes and slashes preserved).
+    out = apply_assignments("vmec_file = OLD", {"vmec_file": '"../stage1_equilibrium/wout.nc"'})
+    assert out == 'vmec_file = "../stage1_equilibrium/wout.nc"'
+
+
+def test_only_column_zero_keys_match() -> None:
+    # Indented keys are left untouched (TOML top-level keys sit at column 0).
+    assert apply_assignments("  a = 1\n", {"a": "9"}) == "  a = 1\n"
+
+
+def test_prefix_collision_safety() -> None:
+    # Rewriting "transport_output" must not touch "transport_output_dir".
+    text = 'transport_output_dir = "old"\n'
+    assert apply_assignments(text, {"transport_output": "x"}) == text

--- a/tests/orchestration/test_ouroboros.py
+++ b/tests/orchestration/test_ouroboros.py
@@ -1,0 +1,133 @@
+"""Tests for ``src.ouroboros`` (the closed-loop driver).
+
+The driver runs repeated Snakemake forward passes, feeding each iteration's
+evolved Stage 1 boundary into the next. These tests pin the orchestration logic
+without running Snakemake or copying real files, using two isolation tricks:
+
+- Paths stay in tmp. ``resolve_pipeline_paths`` builds every path as
+  ``f"{output_dir}/..."`` and ``ouroboros._abs`` passes absolute paths through
+  unchanged, so giving the config an absolute ``tmp_path`` ``output_dir`` makes
+  every signal file the loop reads and writes land under tmp, never the repo.
+- I/O stays mocked. Monkeypatching the two file-touching collaborators
+  (``_seed_iteration_inputs``, ``run_forward_pass``) isolates the pure
+  control-flow logic, while the fake ``run_forward_pass`` still writes the signal
+  JSON the loop reads back, so the halt/converged branch is genuinely exercised.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import src.ouroboros as ouroboros
+from src.utils import resolve_pipeline_paths
+
+
+def _write_config(tmp_path: Path) -> Path:
+    """Write a run config whose input/output dirs are absolute under tmp_path."""
+    config = {
+        "run_name": "testrun",
+        "input_dir": str(tmp_path / "in"),
+        "output_dir": str(tmp_path / "out"),
+        "filenames": {
+            "s1_input": "vmec_input.{run_name}",
+            "s1_output": "wout_{run_name}.nc",
+            "s2_output": "boozmn_{run_name}.nc",
+            "s3_config": "sfincs_input.{run_name}",
+            "s3_output": "sfincs_flux.h5",
+            "s4_config": "{run_name}.toml",
+            "s4_output": "neopax_fluxes.h5",
+            "s5_config": "common_input.toml",
+            "s5_output": "transport_solution.h5",
+            "s5_signal": "converge_status.json",
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return path
+
+
+def test_run_forward_pass_builds_snakemake_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_subprocess_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(ouroboros.subprocess, "run", fake_subprocess_run)
+    ouroboros.run_forward_pass(
+        target="out/converge_status.json",
+        input_dir="in",
+        output_dir="out",
+        cores=4,
+        config_path=Path("cfg.yaml"),
+        repo_root=Path("/repo"),
+    )
+    assert captured["cmd"] == [
+        "snakemake", "out/converge_status.json", "--cores", "4",
+        "--configfile", "cfg.yaml",
+        "--config", "input_dir=in", "output_dir=out",
+    ]
+    assert captured["kwargs"]["cwd"] == Path("/repo")
+    assert captured["kwargs"]["check"] is True
+
+
+def test_main_rejects_nonpositive_max_iters(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The guard fires before any config read or forward pass.
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--max-iters", "0"])
+    with pytest.raises(ValueError, match="max-iters"):
+        ouroboros.main()
+
+
+def test_loop_seeds_from_previous_feedback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    config = yaml.safe_load(config_path.read_text())
+    base_p = resolve_pipeline_paths(config)
+    base_out = config["output_dir"]
+    iter1_p = resolve_pipeline_paths(
+        config,
+        input_dir=f"{base_out}/loop/iter_1/input",
+        output_dir=f"{base_out}/loop/iter_1/output",
+    )
+
+    seeded: list[str] = []
+    monkeypatch.setattr(ouroboros, "_seed_iteration_inputs",
+                        lambda **kw: seeded.append(kw["s1_source"]))
+
+    def fake_run(*, target, **kw):
+        signal = Path(target)
+        signal.parent.mkdir(parents=True, exist_ok=True)
+        signal.write_text(json.dumps({}))  # neither halt nor converged -> keep looping
+
+    monkeypatch.setattr(ouroboros, "run_forward_pass", fake_run)
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path), "--max-iters", "2"])
+    ouroboros.main()
+
+    # Iteration 1 seeds the base boundary; iteration 2 seeds the prior iteration's feedback.
+    assert seeded == [base_p["s1_input"], iter1_p["s1_feedback"]]
+
+
+@pytest.mark.parametrize("signal", [{"halt": True}, {"converged": True}])
+def test_loop_short_circuits_on_terminal_signal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, signal: dict
+) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setattr(ouroboros, "_seed_iteration_inputs", lambda **kw: None)
+
+    calls: list[str] = []
+
+    def fake_run(*, target, **kw):
+        calls.append(target)
+        p = Path(target)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(signal))
+
+    monkeypatch.setattr(ouroboros, "run_forward_pass", fake_run)
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path), "--max-iters", "3"])
+    ouroboros.main()
+
+    # A halt or converged signal after iteration 1 stops the loop despite max-iters=3.
+    assert len(calls) == 1

--- a/tests/orchestration/test_ouroboros.py
+++ b/tests/orchestration/test_ouroboros.py
@@ -76,8 +76,9 @@ def test_run_forward_pass_builds_snakemake_argv(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_main_rejects_nonpositive_max_iters(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The guard fires before any config read or forward pass.
-    monkeypatch.setattr("sys.argv", ["ouroboros", "--max-iters", "0"])
+    # A nonexistent --config pins the ordering: the max-iters guard must fire before any
+    # config read, so main() raises ValueError here rather than FileNotFoundError.
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--max-iters", "0", "--config", "/no/such/config.yaml"])
     with pytest.raises(ValueError, match="max-iters"):
         ouroboros.main()
 

--- a/tests/orchestration/test_ouroboros.py
+++ b/tests/orchestration/test_ouroboros.py
@@ -50,6 +50,10 @@ def _write_config(tmp_path: Path) -> Path:
     return path
 
 
+# `run_forward_pass` should shell out to Snakemake with a specific command. Rather than actually run it, this uses
+# monkeypatch to replace `subprocess.run` with a fake that records the command it was handed, then asserts the exact
+# argument list (target, cores, config file, dir overrides) and that it runs in the repo root with `check=True` (so a
+# failing Snakemake call raises).
 def test_run_forward_pass_builds_snakemake_argv(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict = {}
 
@@ -75,6 +79,9 @@ def test_run_forward_pass_builds_snakemake_argv(monkeypatch: pytest.MonkeyPatch)
     assert captured["kwargs"]["check"] is True
 
 
+# Checks input validation and its ordering. It runs `main()` with `--max-iters 0` and a config path that doesn't exist.
+# The test asserts it raises ValueError about max-iters (not a file-not-found error), proving the loop-count guard runs
+# before the config is ever read.
 def test_main_rejects_nonpositive_max_iters(monkeypatch: pytest.MonkeyPatch) -> None:
     # A nonexistent --config pins the ordering: the max-iters guard must fire before any
     # config read, so main() raises ValueError here rather than FileNotFoundError.
@@ -83,6 +90,10 @@ def test_main_rejects_nonpositive_max_iters(monkeypatch: pytest.MonkeyPatch) -> 
         ouroboros.main()
 
 
+# Verifies the "ouroboros" feedback: each iteration should start from the previous iteration's evolved boundary. It
+# monkeypatches the two file-touching helpers (so no solver runs, but a signal file is still written), records which
+# boundary file each iteration is seeded from, and asserts iteration 1 seeds from the base input while iteration 2 seeds
+# from iteration 1's feedback output.
 def test_loop_seeds_from_previous_feedback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = _write_config(tmp_path)
     config = yaml.safe_load(config_path.read_text())
@@ -111,6 +122,10 @@ def test_loop_seeds_from_previous_feedback(monkeypatch: pytest.MonkeyPatch, tmp_
     assert seeded == [base_p["s1_input"], iter1_p["s1_feedback"]]
 
 
+# The loop should stop early when a run reports it has converged or been told to halt. `@pytest.mark.parametrize` runs
+# this twice, once with a `halt` signal and once with a `converged` signal. Each fake run writes that signal, and the
+# test asserts only one iteration happened even though max-iters was 3, proving the terminal signal short-circuits the
+# loop.
 @pytest.mark.parametrize("signal", [{"halt": True}, {"converged": True}])
 def test_loop_short_circuits_on_terminal_signal(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, signal: dict

--- a/tests/orchestration/test_paths.py
+++ b/tests/orchestration/test_paths.py
@@ -1,0 +1,92 @@
+"""Tests for ``src.utils.paths.resolve_pipeline_paths``.
+
+``resolve_pipeline_paths`` is the single source of truth the Snakefile and the
+closed-loop driver both use to turn one run's config into concrete file paths.
+A change that silently alters a derived path would mis-wire the stages, so these
+tests pin the path contract against the committed quick_run config and against a
+minimal synthetic config that exercises the ``{run_name}`` templating in isolation.
+"""
+
+from __future__ import annotations
+
+from src.utils import RESOLVED_COMMON_CONFIG, resolve_pipeline_paths
+
+EXPECTED_KEYS = {
+    "input_dir",
+    "output_dir",
+    "s1_input",
+    "s3_config",
+    "s4_config",
+    "s5_config",
+    "s1_output",
+    "s2_output",
+    "s3_output",
+    "s4_output",
+    "s5_output",
+    "s5_signal",
+    "stage1_dir",
+    "stage2_dir",
+    "stage3_dir",
+    "stage4_dir",
+    "stage5_dir",
+    "stage5_post_dir",
+    "s5_resolved_config",
+    "s1_feedback",
+}
+
+
+def test_quick_run_paths_match_contract(paths: dict) -> None:
+    assert set(paths) == EXPECTED_KEYS
+    assert paths["s1_input"] == "inputs/quick_run/vmec_input.HSX_vacuum_ns201_quickrun"
+    assert paths["s1_output"] == "outputs/quick_run/stage1_equilibrium/wout_HSX_vacuum_ns201_quickrun.nc"
+    assert paths["s2_output"] == "outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc"
+    assert paths["s3_config"] == "inputs/quick_run/sfincs_input.HSX_vacuum_ns201_quickrun"
+    assert paths["s4_config"] == "inputs/quick_run/HSX_vacuum_ns201_quickrun.toml"
+    assert paths["s5_config"] == "inputs/quick_run/common_input.toml"
+    assert paths["s5_output"] == "outputs/quick_run/stage5_transport/transport_solution.h5"
+    assert paths["s5_signal"] == "outputs/quick_run/stage5_post_processing/converge_status.json"
+
+
+def test_quick_run_generated_paths(paths: dict) -> None:
+    assert paths["s5_resolved_config"].endswith(RESOLVED_COMMON_CONFIG)
+    assert paths["s5_resolved_config"] == "outputs/quick_run/stage5_transport/common_input_updated.toml"
+    # The evolved Stage 1 boundary the loop feeds back lives under the post-processing dir.
+    assert paths["s1_feedback"] == "outputs/quick_run/stage5_post_processing/vmec_input.HSX_vacuum_ns201_quickrun"
+
+
+def test_no_unsubstituted_run_name(paths: dict) -> None:
+    assert all("{run_name}" not in value for value in paths.values())
+
+
+def test_dir_overrides_take_precedence(config: dict) -> None:
+    p = resolve_pipeline_paths(config, input_dir="/sandbox/in", output_dir="/sandbox/out")
+    assert p["input_dir"] == "/sandbox/in"
+    assert p["output_dir"] == "/sandbox/out"
+    assert p["s1_input"].startswith("/sandbox/in/")
+    assert p["s1_output"].startswith("/sandbox/out/stage1_equilibrium/")
+    assert p["s5_resolved_config"].startswith("/sandbox/out/stage5_transport/")
+
+
+def test_templating_in_isolation() -> None:
+    cfg = {
+        "run_name": "demo",
+        "input_dir": "IN",
+        "output_dir": "OUT",
+        "filenames": {
+            "s1_input": "vmec_input.{run_name}",
+            "s1_output": "wout_{run_name}.nc",
+            "s2_output": "boozmn_{run_name}.nc",
+            "s3_config": "sfincs_input.{run_name}",
+            "s3_output": "flux.h5",
+            "s4_config": "{run_name}.toml",
+            "s4_output": "neopax_fluxes.h5",
+            "s5_config": "common_input.toml",
+            "s5_output": "transport_solution.h5",
+            "s5_signal": "converge_status.json",
+        },
+    }
+    p = resolve_pipeline_paths(cfg)
+    assert p["s1_input"] == "IN/vmec_input.demo"
+    assert p["s1_output"] == "OUT/stage1_equilibrium/wout_demo.nc"
+    assert p["s4_config"] == "IN/demo.toml"
+    assert p["s5_signal"] == "OUT/stage5_post_processing/converge_status.json"

--- a/tests/orchestration/test_paths.py
+++ b/tests/orchestration/test_paths.py
@@ -35,6 +35,10 @@ EXPECTED_KEYS = {
 }
 
 
+# `resolve_pipeline_paths` turns one run's config into a dict of every concrete file path the pipeline uses. The `paths`
+# argument is a fixture (defined in conftest.py) holding that dict for the committed quick_run config. This asserts the
+# dict has exactly the expected set of keys and pins each stage's input/output path to its precise string, so an
+# accidental path change is caught.
 def test_quick_run_paths_match_contract(paths: dict) -> None:
     assert set(paths) == EXPECTED_KEYS
     assert paths["s1_input"] == "inputs/quick_run/vmec_input.HSX_vacuum_ns201_quickrun"
@@ -49,6 +53,9 @@ def test_quick_run_paths_match_contract(paths: dict) -> None:
     assert paths["s5_signal"] == "outputs/quick_run/stage5_post_processing/converge_status.json"
 
 
+# Pins the two paths that are derived for generated artifacts rather than user inputs: the path-resolved NEOPAX config
+# copy, and the evolved Stage 1 boundary the closed loop feeds back. Both must land under the output tree, not the input
+# tree.
 def test_quick_run_generated_paths(paths: dict) -> None:
     assert paths["s5_resolved_config"] == "outputs/quick_run/stage5_transport/common_input_updated.toml"
     # The evolved Stage 1 boundary the loop feeds back lives under the post-processing dir.
@@ -59,6 +66,10 @@ def test_no_unsubstituted_run_name(paths: dict) -> None:
     assert all("{run_name}" not in value for value in paths.values())
 
 
+# Callers (like the closed-loop driver) can override the input/output base directories. The `config` fixture is the
+# quick_run config; here it is resolved with explicit sandbox dirs, and the test asserts those override the config's own
+# dirs and that every derived path is rebuilt under them. This is what lets each loop iteration write into its own
+# folder.
 def test_dir_overrides_take_precedence(config: dict) -> None:
     p = resolve_pipeline_paths(config, input_dir="/sandbox/in", output_dir="/sandbox/out")
     assert p["input_dir"] == "/sandbox/in"
@@ -68,6 +79,10 @@ def test_dir_overrides_take_precedence(config: dict) -> None:
     assert p["s5_resolved_config"].startswith("/sandbox/out/stage5_transport/")
 
 
+# Instead of the real quick_run config, this builds a tiny handmade config with a `run_name` of "demo" and simple
+# template strings, then checks the `{run_name}` substitution and the input-vs-output directory routing in isolation.
+# Testing the templating on a minimal input makes the expected results easy to read and independent of the committed
+# config.
 def test_templating_in_isolation() -> None:
     cfg = {
         "run_name": "demo",

--- a/tests/orchestration/test_paths.py
+++ b/tests/orchestration/test_paths.py
@@ -9,7 +9,7 @@ minimal synthetic config that exercises the ``{run_name}`` templating in isolati
 
 from __future__ import annotations
 
-from src.utils import RESOLVED_COMMON_CONFIG, resolve_pipeline_paths
+from src.utils import resolve_pipeline_paths
 
 EXPECTED_KEYS = {
     "input_dir",
@@ -40,6 +40,8 @@ def test_quick_run_paths_match_contract(paths: dict) -> None:
     assert paths["s1_input"] == "inputs/quick_run/vmec_input.HSX_vacuum_ns201_quickrun"
     assert paths["s1_output"] == "outputs/quick_run/stage1_equilibrium/wout_HSX_vacuum_ns201_quickrun.nc"
     assert paths["s2_output"] == "outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc"
+    assert paths["s3_output"] == "outputs/quick_run/stage3_neoclassical/sfincs_jax_flux_profiles.h5"
+    assert paths["s4_output"] == "outputs/quick_run/stage4_turbulence/neopax_fluxes.h5"
     assert paths["s3_config"] == "inputs/quick_run/sfincs_input.HSX_vacuum_ns201_quickrun"
     assert paths["s4_config"] == "inputs/quick_run/HSX_vacuum_ns201_quickrun.toml"
     assert paths["s5_config"] == "inputs/quick_run/common_input.toml"
@@ -48,7 +50,6 @@ def test_quick_run_paths_match_contract(paths: dict) -> None:
 
 
 def test_quick_run_generated_paths(paths: dict) -> None:
-    assert paths["s5_resolved_config"].endswith(RESOLVED_COMMON_CONFIG)
     assert paths["s5_resolved_config"] == "outputs/quick_run/stage5_transport/common_input_updated.toml"
     # The evolved Stage 1 boundary the loop feeds back lives under the post-processing dir.
     assert paths["s1_feedback"] == "outputs/quick_run/stage5_post_processing/vmec_input.HSX_vacuum_ns201_quickrun"

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -10,9 +10,18 @@ gpu-only ``--gpu-ids`` flag.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from src.stage3_helper import radial_scan_cmd
+from tests.helpers.stage_import import load_stage_module
+
+_STAGE3_SCRIPT = "stages/stage3-neoclassical/sfincs_jax_radial_scan.py"
+# Snakemake substitutes {input.*}/{output.*} at run time; swap them for literal path
+# tokens so the emitted command parses as a plain argument vector here.
+_PLACEHOLDER = re.compile(r"\{(?:input|output)\.[A-Za-z0-9_]+\}")
+_scan = load_stage_module(_STAGE3_SCRIPT)
 
 
 def cmd(**overrides) -> str:
@@ -72,3 +81,30 @@ def test_gpu_ids_only_on_gpu() -> None:
     assert "--gpu-ids 0,1" in on_gpu
     assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
     assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
+
+
+def test_emitted_flags_parse_with_stage_script() -> None:
+    # Cross-check: every flag radial_scan_cmd can emit must be one the stage script's own
+    # parser accepts. Populate all optionals/toggles, then feed the argument vector to the
+    # script's build_parser. A helper flag the script renamed or dropped makes argparse
+    # sys.exit(2); this catches helper-vs-script drift the exact-string tests cannot.
+    stage_cfg = {
+        "profiles_source": "analytical",
+        "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",
+        "ntheta": 31,
+        "nzeta": 15,
+        "nxi": 12,
+        "nx": 64,
+        "solver_tolerance": 1.0e-6,
+        "max_parallel": 8,
+        "gpu_ids": "0,1",
+        "plot": False,            # emits --no-plot
+        "verbose_workers": True,  # emits --verbose-workers
+    }
+    concrete = _PLACEHOLDER.sub("placeholder_path", cmd(stage_cfg=stage_cfg, device="gpu"))
+    tokens = concrete.split()
+    argv = tokens[tokens.index(_STAGE3_SCRIPT) + 1:]
+    try:
+        _scan.build_parser().parse_args(argv)
+    except SystemExit as exc:
+        pytest.fail(f"stage script parser rejected a helper-emitted flag: argv={argv} (exit {exc.code})")

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -37,6 +37,9 @@ def cmd(**overrides) -> str:
     return radial_scan_cmd(**base)
 
 
+# `radial_scan_cmd` builds the shell command the Snakefile runs for Stage 3. With an empty config and cpu device, it
+# should emit just the fixed base command. This pins that exact string, including the literal `{input.*}` placeholders
+# that Snakemake fills in with real file paths at run time.
 def test_base_command_with_empty_config() -> None:
     # Empty config + cpu emits exactly the static base parts; this equality also
     # pins the literal {input.*} placeholders, which must survive verbatim so
@@ -60,6 +63,9 @@ def test_only_non_none_optionals_appear() -> None:
     assert "--profiles-source" not in out   # absent key -> omitted
 
 
+# Boolean toggles are tri-state: True emits `--flag`, False emits `--no-flag`, and an absent key emits neither.
+# Parametrized over two such toggles, this checks all three cases. It splits the command into tokens and checks
+# membership so, e.g., `--plot` isn't falsely "found" inside `--no-plot`.
 @pytest.mark.parametrize(
     "key, on, off",
     [
@@ -83,11 +89,11 @@ def test_gpu_ids_only_on_gpu() -> None:
     assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
 
 
+# A drift guard. The exact-string tests only check the helper against itself; this checks it against the real stage
+# script. It configures every optional and toggle, strips out the Snakemake placeholders, and feeds the resulting flags
+# into the stage script's own argparse parser (`build_parser`). If the script ever renames or drops a flag, argparse
+# exits (`sys.exit(2)`) and this test fails, catching the mismatch.
 def test_emitted_flags_parse_with_stage_script() -> None:
-    # Cross-check: every flag radial_scan_cmd can emit must be one the stage script's own
-    # parser accepts. Populate all optionals/toggles, then feed the argument vector to the
-    # script's build_parser. A helper flag the script renamed or dropped makes argparse
-    # sys.exit(2); this catches helper-vs-script drift the exact-string tests cannot.
     stage_cfg = {
         "profiles_source": "analytical",
         "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -1,0 +1,74 @@
+"""Tests for ``src.stage3_helper.radial_scan_cmd``.
+
+``radial_scan_cmd`` turns the ``stage3.sfincs_jax`` config block into the single
+shell command that the Snakefile's ``rule stage3_sfincs`` runs. The exact string
+it builds is the contract with that rule, so this pins it: the static base flags
+(including the literal ``{input.*}`` placeholders Snakemake substitutes at run
+time), the not-None-only optional flags, the tri-state booleans, and the
+gpu-only ``--gpu-ids`` flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.stage3_helper import radial_scan_cmd
+
+
+def cmd(**overrides) -> str:
+    """Build a command with quick-run-like defaults, overriding only what a test varies."""
+    base = dict(
+        docker_prefix="docker run --rm",
+        image="ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu",
+        stage_cfg={},
+        output_dir="outputs/quick_run/stage3_neoclassical",
+        device="cpu",
+    )
+    base.update(overrides)
+    return radial_scan_cmd(**base)
+
+
+def test_base_command_with_empty_config() -> None:
+    # Empty config + cpu emits exactly the static base parts; this equality also
+    # pins the literal {input.*} placeholders, which must survive verbatim so
+    # Snakemake can substitute them at rule-execution time.
+    assert cmd() == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu "
+        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py "
+        "--common-config {input.common_config} "
+        "--sfincs-template {input.config_file} "
+        "--wout-path {input.wout} "
+        "--output-dir outputs/quick_run/stage3_neoclassical "
+        "--backend cpu"
+    )
+
+
+def test_only_non_none_optionals_appear() -> None:
+    out = cmd(stage_cfg={"ntheta": 31, "nx": 64, "nzeta": None})
+    assert "--ntheta 31" in out
+    assert "--nx 64" in out
+    assert "--nzeta" not in out             # explicit None -> omitted
+    assert "--profiles-source" not in out   # absent key -> omitted
+
+
+@pytest.mark.parametrize(
+    "key, on, off",
+    [
+        ("plot", "--plot", "--no-plot"),
+        ("verbose_workers", "--verbose-workers", "--no-verbose-workers"),
+    ],
+)
+def test_tristate_bools(key: str, on: str, off: str) -> None:
+    # Token membership (not substring) so --plot does not match inside --no-plot.
+    assert on in cmd(stage_cfg={key: True}).split()
+    assert off in cmd(stage_cfg={key: False}).split()
+    absent = cmd(stage_cfg={}).split()
+    assert on not in absent and off not in absent
+
+
+def test_gpu_ids_only_on_gpu() -> None:
+    cfg = {"gpu_ids": "0,1"}
+    on_gpu = cmd(stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids 0,1" in on_gpu
+    assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
+    assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -38,6 +38,9 @@ def cmd(**overrides) -> str:
     return radial_scan_cmd(**base)
 
 
+# `radial_scan_cmd` builds the shell command the Snakefile runs for Stage 4. With an empty config and cpu device, this
+# pins the exact base command string, including the two geometry-input overrides and the literal `{input.*}`
+# placeholders Snakemake fills in with real paths at run time.
 def test_base_command_with_empty_config() -> None:
     # Empty config + cpu emits exactly the static base parts; this equality also
     # pins the literal {input.*} placeholders (including the two geometry
@@ -54,6 +57,9 @@ def test_base_command_with_empty_config() -> None:
     )
 
 
+# Optional flags appear only when set. This also checks a rename: the config key `t_max` is emitted as the `--t-final`
+# flag. It asserts the two set values appear (with the rename applied), the None-valued key is omitted, and a key absent
+# from the config is omitted.
 def test_only_non_none_optionals_appear() -> None:
     out = cmd(stage_cfg={"t_max": 250.0, "ntheta": 16, "ny": None})
     assert "--t-final 250.0" in out          # t_max is renamed to --t-final
@@ -62,6 +68,9 @@ def test_only_non_none_optionals_appear() -> None:
     assert "--profiles-source" not in out    # absent key -> omitted
 
 
+# Boolean toggles are tri-state: True emits `--flag`, False emits `--no-flag`, absent emits neither. Parametrized over
+# Stage 4's four toggles, this verifies all three cases. It compares whole tokens so a short flag like `--plot` isn't
+# falsely matched inside `--no-plot` or `--plot-run-heat-traces`.
 @pytest.mark.parametrize(
     "key, on, off",
     [
@@ -88,11 +97,11 @@ def test_gpu_ids_only_on_gpu() -> None:
     assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
 
 
+# A drift guard. The exact-string tests only check the helper against itself; this checks it against the real stage
+# script. It configures every optional and toggle (including the `t_max` -> `--t-final` rename), strips out the
+# Snakemake placeholders, and feeds the resulting flags into the stage script's own argparse parser (`build_parser`). If
+# the script ever renames or drops a flag, argparse exits (`sys.exit(2)`) and this test fails, catching the mismatch.
 def test_emitted_flags_parse_with_stage_script() -> None:
-    # Cross-check: every flag radial_scan_cmd can emit must be one the stage script's own
-    # parser accepts. Populate all optionals/toggles (t_max emits as --t-final), then feed the
-    # argument vector to the script's build_parser. A helper flag the script renamed or dropped
-    # makes argparse sys.exit(2); this catches helper-vs-script drift the exact-string tests cannot.
     stage_cfg = {
         "profiles_source": "analytical",
         "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -1,0 +1,79 @@
+"""Tests for ``src.stage4_helper.radial_scan_cmd``.
+
+``radial_scan_cmd`` turns the ``stage4.spectrax_gk`` config block into the single
+shell command that the Snakefile's ``rule stage4_spectrax`` runs. The exact string
+it builds is the contract with that rule, so this pins it: the static base flags
+(the ``--vmec-file-override`` and ``--boozer-file-override`` geometry inputs plus
+the literal ``{input.*}`` placeholders Snakemake substitutes at run time), the
+not-None-only optional flags (where ``t_max`` is emitted as ``--t-final``), the
+four tri-state bool toggles, and the gpu-only ``--gpu-ids`` flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.stage4_helper import radial_scan_cmd
+
+
+def cmd(**overrides) -> str:
+    """Build a command with quick-run-like defaults, overriding only what a test varies."""
+    base = dict(
+        docker_prefix="docker run --rm",
+        image="ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu",
+        stage_cfg={},
+        output_dir="outputs/quick_run/stage4_turbulence",
+        device="cpu",
+    )
+    base.update(overrides)
+    return radial_scan_cmd(**base)
+
+
+def test_base_command_with_empty_config() -> None:
+    # Empty config + cpu emits exactly the static base parts; this equality also
+    # pins the literal {input.*} placeholders (including the two geometry
+    # overrides) that Snakemake substitutes at rule-execution time.
+    assert cmd() == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu "
+        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py "
+        "--common-config {input.common_config} "
+        "--spectrax-template {input.config_file} "
+        "--vmec-file-override {input.wout} "
+        "--boozer-file-override {input.boozer} "
+        "--output-dir outputs/quick_run/stage4_turbulence "
+        "--backend cpu"
+    )
+
+
+def test_only_non_none_optionals_appear() -> None:
+    out = cmd(stage_cfg={"t_max": 250.0, "ntheta": 16, "ny": None})
+    assert "--t-final 250.0" in out          # t_max is renamed to --t-final
+    assert "--ntheta 16" in out
+    assert "--ny" not in out                 # explicit None -> omitted
+    assert "--profiles-source" not in out    # absent key -> omitted
+
+
+@pytest.mark.parametrize(
+    "key, on, off",
+    [
+        ("plot", "--plot", "--no-plot"),
+        ("plot_run_heat_traces", "--plot-run-heat-traces", "--no-plot-run-heat-traces"),
+        ("verbose_workers", "--verbose-workers", "--no-verbose-workers"),
+        ("collect_even_if_failures", "--collect-even-if-failures", "--no-collect-even-if-failures"),
+    ],
+)
+def test_tristate_bools(key: str, on: str, off: str) -> None:
+    # Token membership (not substring) so --plot does not match inside --no-plot
+    # or --plot-run-heat-traces.
+    assert on in cmd(stage_cfg={key: True}).split()
+    assert off in cmd(stage_cfg={key: False}).split()
+    absent = cmd(stage_cfg={}).split()
+    assert on not in absent and off not in absent
+
+
+def test_gpu_ids_only_on_gpu() -> None:
+    cfg = {"gpu_ids": "0,1"}
+    on_gpu = cmd(stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids 0,1" in on_gpu
+    assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
+    assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -11,9 +11,18 @@ four tri-state bool toggles, and the gpu-only ``--gpu-ids`` flag.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from src.stage4_helper import radial_scan_cmd
+from tests.helpers.stage_import import load_stage_module
+
+_STAGE4_SCRIPT = "stages/stage4-turbulence/spectrax_gk_radial_scan.py"
+# Snakemake substitutes {input.*}/{output.*} at run time; swap them for literal path
+# tokens so the emitted command parses as a plain argument vector here.
+_PLACEHOLDER = re.compile(r"\{(?:input|output)\.[A-Za-z0-9_]+\}")
+_scan = load_stage_module(_STAGE4_SCRIPT)
 
 
 def cmd(**overrides) -> str:
@@ -77,3 +86,34 @@ def test_gpu_ids_only_on_gpu() -> None:
     assert "--gpu-ids 0,1" in on_gpu
     assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
     assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
+
+
+def test_emitted_flags_parse_with_stage_script() -> None:
+    # Cross-check: every flag radial_scan_cmd can emit must be one the stage script's own
+    # parser accepts. Populate all optionals/toggles (t_max emits as --t-final), then feed the
+    # argument vector to the script's build_parser. A helper flag the script renamed or dropped
+    # makes argparse sys.exit(2); this catches helper-vs-script drift the exact-string tests cannot.
+    stage_cfg = {
+        "profiles_source": "analytical",
+        "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",
+        "nx": 12,
+        "ny": 12,
+        "ntheta": 16,
+        "t_max": 250.0,
+        "average_window": 1.0,
+        "sample_stride": 50,
+        "diagnostics_stride": 1,
+        "max_parallel": 1,
+        "gpu_ids": "0,1",
+        "plot": False,                     # emits --no-plot
+        "plot_run_heat_traces": True,      # emits --plot-run-heat-traces
+        "verbose_workers": False,          # emits --no-verbose-workers
+        "collect_even_if_failures": True,  # emits --collect-even-if-failures
+    }
+    concrete = _PLACEHOLDER.sub("placeholder_path", cmd(stage_cfg=stage_cfg, device="gpu"))
+    tokens = concrete.split()
+    argv = tokens[tokens.index(_STAGE4_SCRIPT) + 1:]
+    try:
+        _scan.build_parser().parse_args(argv)
+    except SystemExit as exc:
+        pytest.fail(f"stage script parser rejected a helper-emitted flag: argv={argv} (exit {exc.code})")

--- a/tests/orchestration/test_stage5_helper.py
+++ b/tests/orchestration/test_stage5_helper.py
@@ -42,6 +42,10 @@ def _prepare(tmp_path: Path) -> tuple[Path, Path]:
     return template, resolved
 
 
+# NEOPAX (Stage 5) is configured by a TOML file, not CLI flags. `prepare_neopax_config` writes a copy of the template
+# into the Stage 5 output dir and rewrites its five input-path fields so each points at the right upstream artifact,
+# relative to that copy's own location. This reads the copy and asserts all five fields now hold the expected
+# `../stageN/...` relative path, and that the output dir field resolves to `./` (the copy's own directory).
 def test_rewrites_five_paths_relative_and_quoted(tmp_path: Path) -> None:
     _, resolved = _prepare(tmp_path)
     text = resolved.read_text()  # also asserts the parent dir was created
@@ -53,6 +57,9 @@ def test_rewrites_five_paths_relative_and_quoted(tmp_path: Path) -> None:
     assert 'transport_output_dir = "./"' in text
 
 
+# The rewrite must happen on the copy, never the shared template. After running the same preparation, this reads the
+# original template file back and asserts its contents are byte-for-byte unchanged, proving the committed template is
+# never mutated by a run.
 def test_template_left_unmodified(tmp_path: Path) -> None:
     template, _ = _prepare(tmp_path)
     assert template.read_text() == _TEMPLATE

--- a/tests/orchestration/test_stage5_helper.py
+++ b/tests/orchestration/test_stage5_helper.py
@@ -1,0 +1,58 @@
+"""Tests for ``src.stage5_helper.prepare_neopax_config``.
+
+NEOPAX is configured by a TOML file, not CLI flags. ``prepare_neopax_config``
+writes a path-resolved copy of the shared template under the run's Stage 5 output
+dir, rewriting its five path fields *relative to that copy's own directory* (NEOPAX
+runs there) and never touching the committed template. These tests pin the rewrite
+targets, the trailing slash on ``transport_output_dir``, and template immutability.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.stage5_helper import prepare_neopax_config
+
+_TEMPLATE = (
+    'vmec_file = "PLACEHOLDER"\n'
+    'boozer_file = "PLACEHOLDER"\n'
+    'neoclassical_file = "PLACEHOLDER"\n'
+    'turbulence_file = "PLACEHOLDER"\n'
+    'transport_output_dir = "PLACEHOLDER"\n'
+)
+
+
+def _prepare(tmp_path: Path) -> tuple[Path, Path]:
+    """Lay out a tmp run and resolve the NEOPAX config; return (template, resolved)."""
+    template = tmp_path / "inputs" / "common_input.toml"
+    template.parent.mkdir(parents=True)
+    template.write_text(_TEMPLATE)
+
+    out = tmp_path / "out"
+    resolved = out / "stage5_transport" / "common_input_updated.toml"  # parent not pre-created
+    prepare_neopax_config(
+        s5_config_template=str(template),
+        s5_resolved_config=str(resolved),
+        s1_output=str(out / "stage1_equilibrium" / "wout.nc"),
+        s2_output=str(out / "stage2_boozer" / "boozmn.nc"),
+        s3_output=str(out / "stage3_neoclassical" / "sfincs_flux.h5"),
+        s4_output=str(out / "stage4_turbulence" / "neopax_fluxes.h5"),
+        s5_output_dir=str(out / "stage5_transport"),
+    )
+    return template, resolved
+
+
+def test_rewrites_five_paths_relative_and_quoted(tmp_path: Path) -> None:
+    _, resolved = _prepare(tmp_path)
+    text = resolved.read_text()  # also asserts the parent dir was created
+    assert 'vmec_file = "../stage1_equilibrium/wout.nc"' in text
+    assert 'boozer_file = "../stage2_boozer/boozmn.nc"' in text
+    assert 'neoclassical_file = "../stage3_neoclassical/sfincs_flux.h5"' in text
+    assert 'turbulence_file = "../stage4_turbulence/neopax_fluxes.h5"' in text
+    # The output dir is the copy's own dir, so it resolves to "./" with a trailing slash.
+    assert 'transport_output_dir = "./"' in text
+
+
+def test_template_left_unmodified(tmp_path: Path) -> None:
+    template, _ = _prepare(tmp_path)
+    assert template.read_text() == _TEMPLATE

--- a/tests/stage2-boozer/test_run_boozer_parser.py
+++ b/tests/stage2-boozer/test_run_boozer_parser.py
@@ -1,0 +1,29 @@
+"""Tests for the Stage 2 ``run_boozer`` CLI parser.
+
+``run_boozer.py`` runs as a standalone script and imports ``booz_xform_jax``
+lazily inside the transform, so its argument parser loads with no solver present.
+The Snakefile's ``rule stage2_boozer`` invokes the script with ``--wout`` and
+``--output``, so both must stay required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers.stage_import import load_stage_module
+
+run_boozer = load_stage_module("stages/stage2-boozer/run_boozer.py")
+
+
+def test_parser_accepts_wout_and_output() -> None:
+    args = run_boozer.build_parser().parse_args(["--wout", "w.nc", "--output", "b.nc"])
+    assert str(args.wout) == "w.nc"
+    assert str(args.output) == "b.nc"
+
+
+def test_parser_requires_both_flags() -> None:
+    parser = run_boozer.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])                  # neither flag
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--wout", "w.nc"])  # missing --output

--- a/tests/stage2-boozer/test_run_boozer_parser.py
+++ b/tests/stage2-boozer/test_run_boozer_parser.py
@@ -21,6 +21,9 @@ def test_parser_accepts_wout_and_output() -> None:
     assert str(args.output) == "b.nc"
 
 
+# Both flags are required, because the Snakefile always passes them. argparse exits the program (raising SystemExit)
+# when a required flag is missing, so this asserts SystemExit is raised both with no flags at all and with only
+# `--wout`, confirming neither can be omitted.
 def test_parser_requires_both_flags() -> None:
     parser = run_boozer.build_parser()
     with pytest.raises(SystemExit):

--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -1,0 +1,77 @@
+"""Tests for the Stage 3 sfincs_jax radial-scan helpers.
+
+These reuse the pure functions from ``sfincs_jax_radial_scan.py``, loaded by path.
+``_choose_radius_indices`` selects which flux surfaces to solve; the analytical
+snapshot builder synthesises species-resolved profiles from config. The solver is
+imported lazily inside the worker, so loading the module and calling these helpers
+needs no solver.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from tests.helpers.stage_import import load_stage_module
+
+scan = load_stage_module("stages/stage3-neoclassical/sfincs_jax_radial_scan.py")
+
+
+# --- _choose_radius_indices ---
+
+def test_choose_radius_default_skips_axis() -> None:
+    rho = np.linspace(0.0, 1.0, 5)  # index 0 is rho = 0
+    idxs = scan._choose_radius_indices(rho, explicit=None, rho_min=None, rho_max=None, num_radii=None)
+    assert idxs == [1, 2, 3, 4]
+
+
+def test_choose_radius_explicit_sorted_and_deduped() -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    idxs = scan._choose_radius_indices(rho, explicit=[3, 1, 1], rho_min=None, rho_max=None, num_radii=None)
+    assert idxs == [1, 3]
+
+
+def test_choose_radius_explicit_out_of_range_raises() -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    with pytest.raises(IndexError):
+        scan._choose_radius_indices(rho, explicit=[7], rho_min=None, rho_max=None, num_radii=None)
+
+
+def test_choose_radius_num_radii_subsamples() -> None:
+    rho = np.linspace(0.0, 1.0, 5)  # candidates after axis skip: [1, 2, 3, 4]
+    idxs = scan._choose_radius_indices(rho, explicit=None, rho_min=None, rho_max=None, num_radii=2)
+    assert idxs == [1, 4]  # endpoints of the candidate span
+
+
+def test_choose_radius_empty_filter_raises() -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    with pytest.raises(ValueError):
+        scan._choose_radius_indices(rho, explicit=None, rho_min=2.0, rho_max=None, num_radii=None)
+
+
+# --- _build_standard_analytical_snapshot ---
+
+def test_snapshot_shapes() -> None:
+    snap = scan._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
+    assert snap.rho.shape == (5,)
+    assert snap.density.shape == (3, 5)
+    assert snap.temperature.shape == (3, 5)
+    assert snap.er.shape == (5,)
+    assert snap.time_value is None
+
+
+def test_snapshot_core_and_edge_values() -> None:
+    snap = scan._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
+    # defaults: n0 = 4.21, n_edge = 0.6, T0 = 17.8, T_edge = 0.7; electron scale = 1.0
+    assert_allclose(snap.density[0, 0], 4.21)
+    assert_allclose(snap.density[0, -1], 0.6)
+    assert_allclose(snap.temperature[:, 0], 17.8)
+    assert_allclose(snap.temperature[:, -1], 0.7)
+
+
+def test_snapshot_species_density_ratios() -> None:
+    cfg = {"profiles": {"deuterium_ratio": 0.6, "tritium_ratio": 0.4}}
+    snap = scan._build_standard_analytical_snapshot(cfg, n_species=3, n_radial=5)
+    assert_allclose(snap.density[1], 0.6 * snap.density[0])
+    assert_allclose(snap.density[2], 0.4 * snap.density[0])

--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -22,6 +22,9 @@ scan = load_stage_module("stages/stage3-neoclassical/sfincs_jax_radial_scan.py")
 
 # --- _choose_radius_indices ---
 
+# `_choose_radius_indices` picks which flux surfaces the scan will solve. With no options given, it should skip the
+# magnetic axis (rho = 0, at index 0) because a solve there is rarely useful. Given 5 radii, this asserts it returns
+# indices [1, 2, 3, 4], i.e. everything except the axis.
 def test_choose_radius_default_skips_axis() -> None:
     rho = np.linspace(0.0, 1.0, 5)  # index 0 is rho = 0
     idxs = scan._choose_radius_indices(rho, explicit=None, rho_min=None, rho_max=None, num_radii=None)
@@ -40,12 +43,17 @@ def test_choose_radius_explicit_out_of_range_raises() -> None:
         scan._choose_radius_indices(rho, explicit=[7], rho_min=None, rho_max=None, num_radii=None)
 
 
+# `num_radii` thins the candidate surfaces down to a smaller evenly-spaced sample. After skipping the axis the
+# candidates are [1, 2, 3, 4]; asking for 2 should keep the two endpoints, so this asserts the result is [1, 4]. This
+# lets a user run a cheaper, coarser scan.
 def test_choose_radius_num_radii_subsamples() -> None:
     rho = np.linspace(0.0, 1.0, 5)  # candidates after axis skip: [1, 2, 3, 4]
     idxs = scan._choose_radius_indices(rho, explicit=None, rho_min=None, rho_max=None, num_radii=2)
     assert idxs == [1, 4]  # endpoints of the candidate span
 
 
+# The rho range is 0 to 1, so a `rho_min` of 2.0 filters out every surface. Rather than return an empty list (which
+# would make the scan do nothing), this asserts it raises ValueError so the impossible filter is reported clearly.
 def test_choose_radius_empty_filter_raises() -> None:
     rho = np.linspace(0.0, 1.0, 5)
     with pytest.raises(ValueError):
@@ -66,6 +74,10 @@ SNAPSHOT_MODULES = [
 ]
 
 
+# `_build_standard_analytical_snapshot` synthesises test profiles (density, temperature, etc.) from config, used when no
+# real upstream profiles are available. This builds a 3-species, 5-radius snapshot and asserts every array has the
+# expected shape and that a static (non-time-resolved) snapshot has no time value. Parametrized to run against both
+# Stage 3's and Stage 4's copy of the function.
 @pytest.mark.parametrize("module", SNAPSHOT_MODULES)
 def test_snapshot_shapes(module: ModuleType) -> None:
     snap = module._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
@@ -86,6 +98,9 @@ def test_snapshot_core_and_edge_values(module: ModuleType) -> None:
     assert_allclose(snap.temperature[:, -1], 0.7, rtol=1e-12)
 
 
+# The ion densities are set as fractions of the electron density (species 0). Configuring deuterium at 0.6 and tritium
+# at 0.4, this asserts species 1's density equals 0.6x and species 2's equals 0.4x the electron density at every radius,
+# confirming the ratio config is applied correctly.
 @pytest.mark.parametrize("module", SNAPSHOT_MODULES)
 def test_snapshot_species_density_ratios(module: ModuleType) -> None:
     cfg = {"profiles": {"deuterium_ratio": 0.6, "tritium_ratio": 0.4}}

--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -9,6 +9,8 @@ needs no solver.
 
 from __future__ import annotations
 
+from types import ModuleType
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -52,8 +54,21 @@ def test_choose_radius_empty_filter_raises() -> None:
 
 # --- _build_standard_analytical_snapshot ---
 
-def test_snapshot_shapes() -> None:
-    snap = scan._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
+# The Stage 3 and Stage 4 scan scripts each carry their own copy of
+# _build_standard_analytical_snapshot. Running the snapshot tests against both copies
+# guards against the duplicated helpers silently drifting apart. The Stage 4 module is
+# also loaded by the Stage 4 test file; load_stage_module caches by file, so this reuses it.
+spectrax_scan = load_stage_module("stages/stage4-turbulence/spectrax_gk_radial_scan.py")
+
+SNAPSHOT_MODULES = [
+    pytest.param(scan, id="sfincs_jax"),
+    pytest.param(spectrax_scan, id="spectrax_gk"),
+]
+
+
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_shapes(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
     assert snap.rho.shape == (5,)
     assert snap.density.shape == (3, 5)
     assert snap.temperature.shape == (3, 5)
@@ -61,17 +76,19 @@ def test_snapshot_shapes() -> None:
     assert snap.time_value is None
 
 
-def test_snapshot_core_and_edge_values() -> None:
-    snap = scan._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_core_and_edge_values(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot({}, n_species=3, n_radial=5)
     # defaults: n0 = 4.21, n_edge = 0.6, T0 = 17.8, T_edge = 0.7; electron scale = 1.0
-    assert_allclose(snap.density[0, 0], 4.21)
-    assert_allclose(snap.density[0, -1], 0.6)
-    assert_allclose(snap.temperature[:, 0], 17.8)
-    assert_allclose(snap.temperature[:, -1], 0.7)
+    assert_allclose(snap.density[0, 0], 4.21, rtol=1e-12)
+    assert_allclose(snap.density[0, -1], 0.6, rtol=1e-12)
+    assert_allclose(snap.temperature[:, 0], 17.8, rtol=1e-12)
+    assert_allclose(snap.temperature[:, -1], 0.7, rtol=1e-12)
 
 
-def test_snapshot_species_density_ratios() -> None:
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_species_density_ratios(module: ModuleType) -> None:
     cfg = {"profiles": {"deuterium_ratio": 0.6, "tritium_ratio": 0.4}}
-    snap = scan._build_standard_analytical_snapshot(cfg, n_species=3, n_radial=5)
-    assert_allclose(snap.density[1], 0.6 * snap.density[0])
-    assert_allclose(snap.density[2], 0.4 * snap.density[0])
+    snap = module._build_standard_analytical_snapshot(cfg, n_species=3, n_radial=5)
+    assert_allclose(snap.density[1], 0.6 * snap.density[0], rtol=1e-12)
+    assert_allclose(snap.density[2], 0.4 * snap.density[0], rtol=1e-12)

--- a/tests/stage4-turbulence/test_spectrax_scan_helpers.py
+++ b/tests/stage4-turbulence/test_spectrax_scan_helpers.py
@@ -1,0 +1,92 @@
+"""Tests for the Stage 4 SPECTRAX-GK radial-scan helpers.
+
+These reuse the pure functions from ``spectrax_gk_radial_scan.py``, loaded by path.
+``_spectrax_flux_to_neopax_units`` converts a gyro-Bohm flux to NEOPAX physical
+units; ``_expand_axis_zero_if_needed`` prepends the magnetic-axis radius (rho=0,
+zero flux) when the scan skipped it. SPECTRAX-GK runs via subprocess, so loading
+the module and calling these helpers needs no solver.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from tests.helpers.stage_import import load_stage_module
+
+scan = load_stage_module("stages/stage4-turbulence/spectrax_gk_radial_scan.py")
+
+
+# --- _spectrax_flux_to_neopax_units ---
+
+def test_flux_units_q_over_gamma_is_temperature_in_ev() -> None:
+    kwargs = dict(density_ref_state=0.5, temperature_ref_keV=2.0, mass_ref_mp=2.0, rho_star_physical=0.01)
+    gamma = scan._spectrax_flux_to_neopax_units(3.0, kind="Gamma", **kwargs)
+    q = scan._spectrax_flux_to_neopax_units(3.0, kind="Q", **kwargs)
+    assert_allclose(q / gamma, 2.0 * 1.0e3)  # Q carries an extra factor of T expressed in eV
+
+
+def test_flux_units_scale_as_rho_star_squared() -> None:
+    base = dict(density_ref_state=1.0, temperature_ref_keV=1.0, mass_ref_mp=1.0, kind="Gamma")
+    small = scan._spectrax_flux_to_neopax_units(1.0, rho_star_physical=0.01, **base)
+    large = scan._spectrax_flux_to_neopax_units(1.0, rho_star_physical=0.02, **base)
+    assert_allclose(large / small, 4.0)  # gyro-Bohm scaling goes as rho_star^2
+
+
+def test_flux_units_unknown_kind_raises() -> None:
+    with pytest.raises(ValueError):
+        scan._spectrax_flux_to_neopax_units(
+            1.0, density_ref_state=1.0, temperature_ref_keV=1.0, mass_ref_mp=1.0, rho_star_physical=0.01, kind="bogus"
+        )
+
+
+# --- _expand_axis_zero_if_needed ---
+
+def _expand_inputs(n_species: int = 3, n: int = 2) -> dict:
+    return {
+        "rho": np.linspace(0.5, 1.0, n),
+        "r_physical": np.linspace(0.5, 1.0, n),
+        "rho_index": np.arange(1, n + 1),
+        "torflux": np.linspace(0.25, 1.0, n),
+        "er": np.linspace(1.0, 2.0, n),
+        "heat_flux": np.linspace(1.0, 2.0, n),
+        "particle_flux": np.linspace(1.0, 2.0, n),
+        "heat_flux_species": np.ones((n, n_species)),
+        "particle_flux_species": np.ones((n, n_species)),
+        "gamma_neopax": np.arange(1.0, n_species * n + 1.0).reshape(n_species, n),
+        "q_neopax": np.arange(1.0, n_species * n + 1.0).reshape(n_species, n) + 10.0,
+    }
+
+
+def test_expand_passthrough_without_source_rho() -> None:
+    arrays = _expand_inputs()
+    out = scan._expand_axis_zero_if_needed({}, **arrays)
+    # no source_rho -> arrays returned unchanged (radius axis stays length 2)
+    assert out[0].shape == (2,)
+    assert_allclose(out[0], arrays["rho"])
+    assert out[9].shape == arrays["gamma_neopax"].shape
+
+
+def test_expand_prepends_axis_zero() -> None:
+    manifest = {"source_rho": [0.0, 0.5, 1.0], "geometry": {"a_minor": 2.0}}
+    arrays = _expand_inputs()  # rho size 2, rho_index [1, 2]
+    (full_rho, full_r, full_rho_index, full_torflux, _er, _heat, _particle,
+     _heat_s, _particle_s, full_gamma, full_q) = scan._expand_axis_zero_if_needed(manifest, **arrays)
+
+    assert_allclose(full_rho, [0.0, 0.5, 1.0])
+    assert_allclose(full_r, [0.0, 1.0, 2.0])            # a_minor * full_rho
+    assert full_rho_index.tolist() == [0, 1, 2]
+    assert_allclose(full_torflux, [0.0, 0.25, 1.0])     # full_rho ** 2
+    assert full_gamma.shape == (3, 3)
+    assert_allclose(full_gamma[:, 0], 0.0)              # prepended axis column is zero-filled
+    assert_allclose(full_gamma[:, 1:], arrays["gamma_neopax"])
+    assert_allclose(full_q[:, 1:], arrays["q_neopax"])
+
+
+def test_expand_passthrough_on_index_mismatch() -> None:
+    manifest = {"source_rho": [0.0, 0.5, 1.0], "geometry": {"a_minor": 2.0}}
+    arrays = _expand_inputs()
+    arrays["rho_index"] = np.array([0, 1])  # not [1, 2] -> guard trips, no expansion
+    out = scan._expand_axis_zero_if_needed(manifest, **arrays)
+    assert out[0].shape == (2,)

--- a/tests/stage4-turbulence/test_spectrax_scan_helpers.py
+++ b/tests/stage4-turbulence/test_spectrax_scan_helpers.py
@@ -21,6 +21,10 @@ scan = load_stage_module("stages/stage4-turbulence/spectrax_gk_radial_scan.py")
 
 # --- _spectrax_flux_to_neopax_units ---
 
+# `_spectrax_flux_to_neopax_units` converts a dimensionless (gyro-Bohm) flux into physical units. The heat flux Q
+# carries one extra factor of temperature (in eV) compared to the particle flux Gamma. Converting the same raw value
+# both ways, this asserts their ratio Q/Gamma equals the temperature expressed in eV (2 keV = 2000 eV), a cheap way to
+# check the extra-temperature factor without pinning the full absolute scale.
 def test_flux_units_q_over_gamma_is_temperature_in_ev() -> None:
     kwargs = dict(density_ref_state=0.5, temperature_ref_keV=2.0, mass_ref_mp=2.0, rho_star_physical=0.01)
     gamma = scan._spectrax_flux_to_neopax_units(3.0, kind="Gamma", **kwargs)
@@ -28,6 +32,10 @@ def test_flux_units_q_over_gamma_is_temperature_in_ev() -> None:
     assert_allclose(q / gamma, 2.0 * 1.0e3, rtol=1e-12)  # Q carries an extra factor of T expressed in eV
 
 
+# The absolute-value counterpart to the ratio test above. It recomputes the full expected Gamma from first principles
+# (reference density x thermal speed x rho_star squared, with the thermal speed built from physical constants) and
+# asserts the helper returns exactly that. Because the ratio tests only compare fluxes to each other, only this one
+# would catch a silent error in the overall unit convention.
 def test_flux_units_absolute_scale_matches_reference_convention() -> None:
     # Absolute pin for the reference-species convention: Gamma = gamma_hat * n_ref * vth_ref * rho_star^2
     # with vth_ref = sqrt(2 T e / m). Here gamma_hat=3, n=0.5e20 m^-3, T=2000 eV, mass=2 m_p,
@@ -41,6 +49,8 @@ def test_flux_units_absolute_scale_matches_reference_convention() -> None:
     assert_allclose(gamma, expected_gamma, rtol=1e-12)
 
 
+# Gyro-Bohm fluxes scale with the square of `rho_star`. Converting the same raw flux at two rho_star values differing by
+# 2x (0.01 vs 0.02), this asserts the results differ by 4x (2 squared), confirming the rho_star-squared dependence.
 def test_flux_units_scale_as_rho_star_squared() -> None:
     base = dict(density_ref_state=1.0, temperature_ref_keV=1.0, mass_ref_mp=1.0, kind="Gamma")
     small = scan._spectrax_flux_to_neopax_units(1.0, rho_star_physical=0.01, **base)
@@ -73,6 +83,9 @@ def _expand_inputs(n_species: int = 3, n: int = 2) -> dict:
     }
 
 
+# `_expand_axis_zero_if_needed` re-inserts the magnetic-axis point (rho = 0) that the scan skipped, but only when the
+# run manifest describes it. With an empty manifest (no `source_rho`), it should do nothing: this asserts the arrays
+# come back unchanged, still length 2 on the radius axis.
 def test_expand_passthrough_without_source_rho() -> None:
     arrays = _expand_inputs()
     out = scan._expand_axis_zero_if_needed({}, **arrays)
@@ -82,6 +95,10 @@ def test_expand_passthrough_without_source_rho() -> None:
     assert out[9].shape == arrays["gamma_neopax"].shape
 
 
+# The happy path where all guards pass. Given a manifest whose `source_rho` is the scanned radii plus a leading 0, it
+# prepends the axis point everywhere: the radial coordinate becomes [0, 0.5, 1.0], the physical radius is `a_minor *
+# rho`, toroidal flux is `rho^2`, `Er` is taken from the manifest, and the flux arrays gain a new zero-filled axis
+# column while their existing columns are preserved. Each assertion checks one of those reconstructed quantities.
 def test_expand_prepends_axis_zero() -> None:
     manifest = {"source_rho": [0.0, 0.5, 1.0], "source_er": [0.0, 1.5, 3.0], "geometry": {"a_minor": 2.0}}
     arrays = _expand_inputs()  # rho size 2, rho_index [1, 2]
@@ -99,6 +116,9 @@ def test_expand_prepends_axis_zero() -> None:
     assert_allclose(full_q[:, 1:], arrays["q_neopax"], rtol=1e-12)
 
 
+# The radius axis still expands, but here the manifest's `source_er` is the wrong length for the expanded axis. Rather
+# than misalign the electric field with the wrong radii, the helper fills `Er` with zeros. This asserts the radius axis
+# expanded correctly while `Er` came back all zeros.
 def test_expand_er_zero_filled_on_source_er_size_mismatch() -> None:
     manifest = {"source_rho": [0.0, 0.5, 1.0], "source_er": [0.0, 1.5], "geometry": {"a_minor": 2.0}}
     arrays = _expand_inputs()  # rho size 2, rho_index [1, 2]
@@ -109,6 +129,10 @@ def test_expand_er_zero_filled_on_source_er_size_mismatch() -> None:
     assert_allclose(out[4], 0.0)
 
 
+# Expansion is only safe if the scanned surfaces were exactly indices [1, 2] (i.e. the axis at index 0 really was the
+# only one skipped). Here `rho_index` is [0, 1] instead, so a guard trips and the helper refuses to expand. This asserts
+# the arrays are returned unchanged (radius axis stays 2), protecting against inserting an axis point when the data
+# doesn't line up.
 def test_expand_passthrough_on_index_mismatch() -> None:
     manifest = {"source_rho": [0.0, 0.5, 1.0], "geometry": {"a_minor": 2.0}}
     arrays = _expand_inputs()

--- a/tests/stage4-turbulence/test_spectrax_scan_helpers.py
+++ b/tests/stage4-turbulence/test_spectrax_scan_helpers.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from scipy.constants import elementary_charge, proton_mass
 
 from tests.helpers.stage_import import load_stage_module
 
@@ -24,14 +25,27 @@ def test_flux_units_q_over_gamma_is_temperature_in_ev() -> None:
     kwargs = dict(density_ref_state=0.5, temperature_ref_keV=2.0, mass_ref_mp=2.0, rho_star_physical=0.01)
     gamma = scan._spectrax_flux_to_neopax_units(3.0, kind="Gamma", **kwargs)
     q = scan._spectrax_flux_to_neopax_units(3.0, kind="Q", **kwargs)
-    assert_allclose(q / gamma, 2.0 * 1.0e3)  # Q carries an extra factor of T expressed in eV
+    assert_allclose(q / gamma, 2.0 * 1.0e3, rtol=1e-12)  # Q carries an extra factor of T expressed in eV
+
+
+def test_flux_units_absolute_scale_matches_reference_convention() -> None:
+    # Absolute pin for the reference-species convention: Gamma = gamma_hat * n_ref * vth_ref * rho_star^2
+    # with vth_ref = sqrt(2 T e / m). Here gamma_hat=3, n=0.5e20 m^-3, T=2000 eV, mass=2 m_p,
+    # rho_star=0.01, so the trailing rho_star^2 = 1e-4 factor is exercised end to end. The ratio-only
+    # tests below cannot see a silent drift in this overall unit convention.
+    vth_ref = np.sqrt(2.0 * 2000.0 * elementary_charge / (2.0 * proton_mass))
+    expected_gamma = 3.0 * 0.5e20 * vth_ref * 1.0e-4
+    gamma = scan._spectrax_flux_to_neopax_units(
+        3.0, density_ref_state=0.5, temperature_ref_keV=2.0, mass_ref_mp=2.0, rho_star_physical=0.01, kind="Gamma"
+    )
+    assert_allclose(gamma, expected_gamma, rtol=1e-12)
 
 
 def test_flux_units_scale_as_rho_star_squared() -> None:
     base = dict(density_ref_state=1.0, temperature_ref_keV=1.0, mass_ref_mp=1.0, kind="Gamma")
     small = scan._spectrax_flux_to_neopax_units(1.0, rho_star_physical=0.01, **base)
     large = scan._spectrax_flux_to_neopax_units(1.0, rho_star_physical=0.02, **base)
-    assert_allclose(large / small, 4.0)  # gyro-Bohm scaling goes as rho_star^2
+    assert_allclose(large / small, 4.0, rtol=1e-12)  # gyro-Bohm scaling goes as rho_star^2
 
 
 def test_flux_units_unknown_kind_raises() -> None:
@@ -69,19 +83,30 @@ def test_expand_passthrough_without_source_rho() -> None:
 
 
 def test_expand_prepends_axis_zero() -> None:
-    manifest = {"source_rho": [0.0, 0.5, 1.0], "geometry": {"a_minor": 2.0}}
+    manifest = {"source_rho": [0.0, 0.5, 1.0], "source_er": [0.0, 1.5, 3.0], "geometry": {"a_minor": 2.0}}
     arrays = _expand_inputs()  # rho size 2, rho_index [1, 2]
-    (full_rho, full_r, full_rho_index, full_torflux, _er, _heat, _particle,
+    (full_rho, full_r, full_rho_index, full_torflux, full_er, _heat, _particle,
      _heat_s, _particle_s, full_gamma, full_q) = scan._expand_axis_zero_if_needed(manifest, **arrays)
 
-    assert_allclose(full_rho, [0.0, 0.5, 1.0])
-    assert_allclose(full_r, [0.0, 1.0, 2.0])            # a_minor * full_rho
+    assert_allclose(full_rho, [0.0, 0.5, 1.0], rtol=1e-12)
+    assert_allclose(full_r, [0.0, 1.0, 2.0], rtol=1e-12)            # a_minor * full_rho
     assert full_rho_index.tolist() == [0, 1, 2]
-    assert_allclose(full_torflux, [0.0, 0.25, 1.0])     # full_rho ** 2
+    assert_allclose(full_torflux, [0.0, 0.25, 1.0], rtol=1e-12)     # full_rho ** 2
+    assert_allclose(full_er, [0.0, 1.5, 3.0], rtol=1e-12)  # Er from manifest source_er, not the per-run er
     assert full_gamma.shape == (3, 3)
     assert_allclose(full_gamma[:, 0], 0.0)              # prepended axis column is zero-filled
-    assert_allclose(full_gamma[:, 1:], arrays["gamma_neopax"])
-    assert_allclose(full_q[:, 1:], arrays["q_neopax"])
+    assert_allclose(full_gamma[:, 1:], arrays["gamma_neopax"], rtol=1e-12)
+    assert_allclose(full_q[:, 1:], arrays["q_neopax"], rtol=1e-12)
+
+
+def test_expand_er_zero_filled_on_source_er_size_mismatch() -> None:
+    manifest = {"source_rho": [0.0, 0.5, 1.0], "source_er": [0.0, 1.5], "geometry": {"a_minor": 2.0}}
+    arrays = _expand_inputs()  # rho size 2, rho_index [1, 2]
+    out = scan._expand_axis_zero_if_needed(manifest, **arrays)
+    # source_er length (2) does not match the expanded radius axis (3): the axis still expands,
+    # but Er drops to zeros rather than misaligning.
+    assert_allclose(out[0], [0.0, 0.5, 1.0], rtol=1e-12)
+    assert_allclose(out[4], 0.0)
 
 
 def test_expand_passthrough_on_index_mismatch() -> None:

--- a/tests/stage5-transport/test_convergence_signal.py
+++ b/tests/stage5-transport/test_convergence_signal.py
@@ -22,6 +22,9 @@ def _static(value: float, n_species: int = 3, n_rho: int = 5) -> np.ndarray:
     return np.full((n_species, n_rho), value)
 
 
+# `pressure_converged` decides whether the loop has settled by comparing the last two time slices of the pressure
+# profile. A static (single-slice) profile has no change to measure, so convergence cannot be confirmed: this writes
+# such a file and asserts the function returns False.
 def test_pressure_converged_false_for_static_profile(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     f = write_transport_solution(tmp_path / "static.h5", rho=rho, pressure=_static(2.0))
@@ -44,6 +47,9 @@ def test_pressure_converged_false_for_large_change(tmp_path: Path) -> None:
     assert not post.pressure_converged(f, rel_tol=1e-2)
 
 
+# `build_signal` produces the `{converged, halt}` dict the loop reads. A non-physical (non-positive) total pressure
+# means the run has gone bad and should stop. This forces the total pressure negative at one radius and asserts the
+# signal is halt=True (and converged=False), so the loop aborts.
 def test_build_signal_halts_on_nonpositive_pressure(tmp_path: Path) -> None:
     rho = np.linspace(0.0, 1.0, 5)
     pressure = _static(2.0)

--- a/tests/stage5-transport/test_convergence_signal.py
+++ b/tests/stage5-transport/test_convergence_signal.py
@@ -1,0 +1,60 @@
+"""Tests for the Stage 5 post-processing convergence signal.
+
+These reuse the real ``pressure_converged`` and ``build_signal`` from
+``stage5_post_processing.py``, loaded by path. That script imports its sibling
+``fit_vmec_pressure_from_transport_h5`` at module top, so loading it also exercises
+the sibling-import support in ``load_stage_module``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from tests.helpers.stage_import import load_stage_module
+from tests.helpers.synthetic import write_transport_solution
+
+post = load_stage_module("stages/stage5-post-processing/stage5_post_processing.py")
+
+
+def _static(value: float, n_species: int = 3, n_rho: int = 5) -> np.ndarray:
+    return np.full((n_species, n_rho), value)
+
+
+def test_pressure_converged_false_for_static_profile(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    f = write_transport_solution(tmp_path / "static.h5", rho=rho, pressure=_static(2.0))
+    assert not post.pressure_converged(f, rel_tol=1e-2)
+
+
+def test_pressure_converged_true_for_small_change(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    slice0 = _static(2.0)
+    pressure_3d = np.stack([slice0, slice0 * 1.0001])  # 0.01% change between slices
+    f = write_transport_solution(tmp_path / "small.h5", rho=rho, pressure=pressure_3d)
+    assert post.pressure_converged(f, rel_tol=1e-2)
+
+
+def test_pressure_converged_false_for_large_change(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    slice0 = _static(2.0)
+    pressure_3d = np.stack([slice0, slice0 * 2.0])  # 100% change between slices
+    f = write_transport_solution(tmp_path / "large.h5", rho=rho, pressure=pressure_3d)
+    assert not post.pressure_converged(f, rel_tol=1e-2)
+
+
+def test_build_signal_halts_on_nonpositive_pressure(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    pressure = _static(2.0)
+    pressure[:, 2] = -1.0  # summed total pressure is non-positive at one radius
+    f = write_transport_solution(tmp_path / "halt.h5", rho=rho, pressure=pressure)
+    assert post.build_signal(f, rel_tol=1e-2) == {"converged": False, "halt": True}
+
+
+def test_build_signal_converged_without_halt(tmp_path: Path) -> None:
+    rho = np.linspace(0.0, 1.0, 5)
+    slice0 = _static(2.0)
+    pressure_3d = np.stack([slice0, slice0 * 1.0001])
+    f = write_transport_solution(tmp_path / "ok.h5", rho=rho, pressure=pressure_3d)
+    assert post.build_signal(f, rel_tol=1e-2) == {"converged": True, "halt": False}

--- a/tests/stage5-transport/test_pressure_fit.py
+++ b/tests/stage5-transport/test_pressure_fit.py
@@ -1,0 +1,92 @@
+"""Tests for the Stage 5 pressure-fit helpers.
+
+These reuse the real functions from ``fit_vmec_pressure_from_transport_h5.py``, loaded
+by path because ``stages/`` has no package ``__init__``, so the tests pin the actual
+fit and file-rewrite behavior rather than a copy. The script imports h5py/numpy only,
+so it loads with no solver present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from tests.helpers.stage_import import load_stage_module
+from tests.helpers.synthetic import write_transport_solution
+
+fit_mod = load_stage_module("stages/stage5-post-processing/fit_vmec_pressure_from_transport_h5.py")
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def _profiles(n_species: int = 3, n_rho: int = 5) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    rho = np.linspace(0.0, 1.0, n_rho)
+    density = np.linspace(1.0, 2.0, n_species * n_rho).reshape(n_species, n_rho)
+    temperature = np.linspace(2.0, 3.0, n_species * n_rho).reshape(n_species, n_rho)
+    return rho, density, temperature
+
+
+def test_fit_power_series_recovers_known_polynomial() -> None:
+    rho = np.linspace(0.0, 1.0, 6)
+    s = rho**2
+    coeffs_true = np.array([3.0, -2.0, 0.5])  # low-order first: 3 - 2 s + 0.5 s^2
+    p = coeffs_true[0] + coeffs_true[1] * s + coeffs_true[2] * s**2
+    coeffs = fit_mod._fit_power_series(s, p, degree=2)
+    assert_allclose(coeffs, coeffs_true, atol=1e-9)
+
+
+def test_load_total_pressure_temperature_density_matches_pressure(tmp_path: Path) -> None:
+    rho, density, temperature = _profiles()
+    pressure = density * temperature
+    file_td = write_transport_solution(tmp_path / "td.h5", rho=rho, temperature=temperature, density=density)
+    file_p = write_transport_solution(tmp_path / "p.h5", rho=rho, pressure=pressure)
+
+    rho_td, total_td, idx_td = fit_mod._load_total_pressure(file_td, time_index=-1, final_time=False)
+    rho_p, total_p, idx_p = fit_mod._load_total_pressure(file_p, time_index=-1, final_time=False)
+
+    assert_allclose(total_td, total_p)
+    assert_allclose(total_p, np.sum(pressure, axis=0))
+    assert_allclose(rho_td, rho)
+    assert idx_td is None and idx_p is None  # static profile has no resolved time index
+
+
+def test_load_total_pressure_final_time_selects_last_slice(tmp_path: Path) -> None:
+    rho, density, temperature = _profiles()
+    slice0 = density * temperature
+    slice1 = 2.0 * slice0
+    pressure_3d = np.stack([slice0, slice1])  # (n_time=2, n_species, n_rho)
+    f3d = write_transport_solution(tmp_path / "p3d.h5", rho=rho, pressure=pressure_3d)
+
+    _, total_final, idx_final = fit_mod._load_total_pressure(f3d, time_index=-1, final_time=True)
+    _, total_initial, idx_initial = fit_mod._load_total_pressure(f3d, time_index=0, final_time=False)
+
+    assert idx_final == 1 and idx_initial == 0
+    assert_allclose(total_final, np.sum(slice1, axis=0))
+    assert_allclose(total_initial, np.sum(slice0, axis=0))
+
+
+def test_load_total_pressure_missing_rho_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "no_rho.h5"
+    with h5py.File(bad, "w") as f:
+        f.create_dataset("pressure", data=np.ones((3, 5)))
+    with pytest.raises(KeyError):
+        fit_mod._load_total_pressure(bad, time_index=-1, final_time=False)
+
+
+def test_write_vmec_input_rewrites_pressure_keys(tmp_path: Path) -> None:
+    coeffs = np.array([3.0, -2.0, 0.5])
+    out = tmp_path / "vmec_out.txt"
+    fixture = DATA_DIR / "vmec_indata_min.txt"
+
+    result = fit_mod._write_vmec_input_with_pressure_fit(fixture, coeffs, output_path=out)
+
+    assert result == out
+    text = out.read_text()
+    assert "PMASS_TYPE = 'power_series'" in text
+    assert "PRES_SCALE = 1.0000000000000000E+00" in text
+    assert fit_mod._format_am_line(coeffs) in text
+    assert "AM = 0.0" in fixture.read_text()  # committed fixture left unmodified

--- a/tests/stage5-transport/test_pressure_fit.py
+++ b/tests/stage5-transport/test_pressure_fit.py
@@ -30,6 +30,9 @@ def _profiles(n_species: int = 3, n_rho: int = 5) -> tuple[np.ndarray, np.ndarra
     return rho, density, temperature
 
 
+# A round-trip test for the polynomial fitter. It builds pressure data from known coefficients [3, -2, 0.5], fits a
+# degree-2 power series back to that data, and asserts the recovered coefficients match the originals. Recovering a
+# known analytical answer is a strong correctness check.
 def test_fit_power_series_recovers_known_polynomial() -> None:
     rho = np.linspace(0.0, 1.0, 6)
     s = rho**2
@@ -39,6 +42,10 @@ def test_fit_power_series_recovers_known_polynomial() -> None:
     assert_allclose(coeffs, coeffs_true, atol=1e-9)
 
 
+# Total pressure can be supplied directly, or reconstructed from temperature x density. This writes one file each way
+# (with matching inputs) and asserts `_load_total_pressure` returns the same total for both, that it equals the
+# species-summed pressure, and that a static profile reports no time index. Confirms the two supported input forms
+# agree.
 def test_load_total_pressure_temperature_density_matches_pressure(tmp_path: Path) -> None:
     rho, density, temperature = _profiles()
     pressure = density * temperature
@@ -54,6 +61,9 @@ def test_load_total_pressure_temperature_density_matches_pressure(tmp_path: Path
     assert idx_td is None and idx_p is None  # static profile has no resolved time index
 
 
+# For a time-resolved file, `_load_total_pressure` should be able to pick a specific time slice. This writes a
+# 2-time-step pressure, then asserts that `final_time=True` selects the last slice (time index 1) and `time_index=0`
+# selects the first, with the returned totals matching each slice's sum.
 def test_load_total_pressure_final_time_selects_last_slice(tmp_path: Path) -> None:
     rho, density, temperature = _profiles()
     slice0 = density * temperature
@@ -77,6 +87,12 @@ def test_load_total_pressure_missing_rho_raises(tmp_path: Path) -> None:
         fit_mod._load_total_pressure(bad, time_index=-1, final_time=False)
 
 
+# This is the feedback step that turns the fitted pressure back into a VMEC input file for the next loop iteration.
+# Starting from a committed template fixture, it writes a new file with the fitted coefficients and asserts the pressure
+# keys are set correctly (`PMASS_TYPE`, `PRES_SCALE`, and the `AM` coefficient line). The expected `AM` line is
+# hard-coded (not built by the writer's own formatter) so a bug in that formatter can't hide itself. It also asserts the
+# template's `AM` line was replaced in place (not duplicated) and that the committed fixture file itself is left
+# unmodified.
 def test_write_vmec_input_rewrites_pressure_keys(tmp_path: Path) -> None:
     coeffs = np.array([3.0, -2.0, 0.5])
     out = tmp_path / "vmec_out.txt"

--- a/tests/stage5-transport/test_pressure_fit.py
+++ b/tests/stage5-transport/test_pressure_fit.py
@@ -48,9 +48,9 @@ def test_load_total_pressure_temperature_density_matches_pressure(tmp_path: Path
     rho_td, total_td, idx_td = fit_mod._load_total_pressure(file_td, time_index=-1, final_time=False)
     rho_p, total_p, idx_p = fit_mod._load_total_pressure(file_p, time_index=-1, final_time=False)
 
-    assert_allclose(total_td, total_p)
-    assert_allclose(total_p, np.sum(pressure, axis=0))
-    assert_allclose(rho_td, rho)
+    assert_allclose(total_td, total_p, rtol=1e-12)
+    assert_allclose(total_p, np.sum(pressure, axis=0), rtol=1e-12)
+    assert_allclose(rho_td, rho, rtol=1e-12)
     assert idx_td is None and idx_p is None  # static profile has no resolved time index
 
 
@@ -65,8 +65,8 @@ def test_load_total_pressure_final_time_selects_last_slice(tmp_path: Path) -> No
     _, total_initial, idx_initial = fit_mod._load_total_pressure(f3d, time_index=0, final_time=False)
 
     assert idx_final == 1 and idx_initial == 0
-    assert_allclose(total_final, np.sum(slice1, axis=0))
-    assert_allclose(total_initial, np.sum(slice0, axis=0))
+    assert_allclose(total_final, np.sum(slice1, axis=0), rtol=1e-12)
+    assert_allclose(total_initial, np.sum(slice0, axis=0), rtol=1e-12)
 
 
 def test_load_total_pressure_missing_rho_raises(tmp_path: Path) -> None:
@@ -88,5 +88,9 @@ def test_write_vmec_input_rewrites_pressure_keys(tmp_path: Path) -> None:
     text = out.read_text()
     assert "PMASS_TYPE = 'power_series'" in text
     assert "PRES_SCALE = 1.0000000000000000E+00" in text
-    assert fit_mod._format_am_line(coeffs) in text
+    # Literal AM line for coeffs [3.0, -2.0, 0.5], independent of the writer's own formatter,
+    # so a bug in _format_am_line cannot mask itself.
+    expected_am_line = "AM = 3.0000000000000000E+00, -2.0000000000000000E+00, 5.0000000000000000E-01"
+    assert expected_am_line in text
+    assert "AM = 0.0" not in text  # the template AM line is replaced in place, not left behind or duplicated
     assert "AM = 0.0" in fixture.read_text()  # committed fixture left unmodified


### PR DESCRIPTION
Resolves #100
### Summary

This PR adds the fast, no-Docker test layer for driftless-star. It focuses on the repo-owned glue: path resolution, config rewriting, helper command construction, the closed-loop driver, Snakefile DAG wiring, stage math helpers, and file-based inter-stage I/O contracts.

The suite is designed to run locally in seconds with:

```bash
pixi run -e test test
```

It intentionally does not claim full pipeline execution. Docker end-to-end execution, numeric regression against reference values, and CI scheduling are deferred to PR 2. Per-stage upstream API and CLI checks are deferred to PR 3.

### What Changed

- Added a dedicated root `test` pixi environment and `pytest.ini` marker setup.
- Added orchestration tests for path resolution, config edits, stage helper commands, and the `ouroboros` loop driver.
- Added a no-Docker Snakefile dry-run test that verifies the forward-pass DAG wiring and selected parse-time guards.
- Added stage helper and post-processing unit tests for Boozer parsing, SFINCS radius selection and snapshots, SPECTRAX flux conversion and padding, and Stage 5 pressure fitting and convergence signals.
- Added reusable inter-stage contract validators in `src/io_contracts.py`.
- Added synthetic and opportunistic real-baseline contract tests for quick-run artifacts when `outputs/quick_run/loop/iter_*` artifacts are present locally.
- Added focused doctests for pure helper behavior in `src/utils/config_edit.py`, `src/utils/paths.py`, and `src/io_contracts.py`.
- Added `tests/__init__.py` and `tests/helpers/__init__.py` for helper-package imports.

### Scope Notes

- This PR tests the recipe repo's glue and file contracts, not upstream solver physics.
- The DAG test runs `snakemake -n` only. It plans the graph and catches wiring or parse-time regressions, but it does not run containers.
- The legacy `tests/stage4-turbulence/SPECTRAX-GK/` scripts remain ignored by pytest because they are argparse-style scripts that import `spectraxgk`, not fast pytest tests for this environment.
- No `stages/` runtime logic is changed in this PR.

Additional checks performed during the review pass:

- Each new or changed test was bite-checked by temporarily breaking the relevant source behavior and confirming the expected test failed, then restoring the source.
- Real quick-run baseline artifacts found under `outputs/quick_run/loop/iter_*` were validated opportunistically.
- The final diff was checked to confirm there are no committed `stages/` logic changes.

Additional Notes:
- Fable was used to cross-check and verify this the contents of this branch before a PR was opened.