### PR TITLE
Refactor: Parallelize Stages 3 and 4 into per-surface Snakemake jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Render the file-flow graph (files as nodes, rules as edges) **including the clos
 pixi run -e pipeline bash -c 'snakemake --filegraph outputs/quick_run/stage5_post_processing/converge_status.json --configfile inputs/quick_run/config.yaml | dot -Tpdf > docs/figs/stellaforge_filegraph.pdf'
 ```
 
-Omit the target to graph the plain forward pass (stops at Stage 5). Needs a one-time `pixi run -e pipeline dot -c`; see [docs/mvp-pipeline.md](docs/mvp-pipeline.md#visualizing-the-file-flow-graph) for PNG/SVG and `--rulegraph`/`--dag` variants.
+Omit the target to graph the plain forward pass (stops at Stage 5). Needs a one-time `pixi run -e pipeline dot -c`; see [docs/mvp-pipeline.md](docs/mvp-pipeline.md#visualizing-the-file-flow-graph) for PNG/SVG and `--rulegraph`/`--dag` variants, including [drawing the complete per-surface job DAG](docs/mvp-pipeline.md#drawing-the-complete-per-surface-job-dag) (the Stage 3/4 fan-out appears in `--dag` output only after the `prepare` manifests exist).
 
 <!--
 git clone https://github.com/driftless-star/driftless-star.git

--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,8 @@
 # driftless-star MVP Snakemake workflow
 
+import json
+import posixpath
+
 from src import stage3_helper, stage4_helper, stage5_helper
 from src.utils import resolve_pipeline_paths, RESOLVED_COMMON_CONFIG
 
@@ -47,8 +50,10 @@ S1_INPUT  = P["s1_input"]
 S1_OUTPUT = P["s1_output"]
 S2_OUTPUT = P["s2_output"]
 S3_CONFIG = P["s3_config"]
+S3_MANIFEST = P["stage3_manifest"]
 S3_OUTPUT = P["s3_output"]
 S4_CONFIG = P["s4_config"]
+S4_MANIFEST = P["stage4_manifest"]
 S4_OUTPUT = P["s4_output"]
 S5_CONFIG = P["s5_config"]
 S5_OUTPUT = P["s5_output"]
@@ -96,17 +101,22 @@ rule stage2_boozer:
         "python stages/stage2-boozer/run_boozer.py --wout {input} --output {output}"
         " 2>&1 | tee {log}"
 
-rule stage3_sfincs:
+
+# Per-surface run-directory basenames e.g. rho_012_r0p4898 follow the pattern:
+# zero-padded radial-grid index then the normalized flux-surface radius (e.g. rho=0.4898).
+SURF_PATTERN = r"rho_\d+_r[0-9p]+"
+
+checkpoint stage3_prepare:
     input:
         config_file = S3_CONFIG,
         wout        = S1_OUTPUT,
         common_config = S5_CONFIG,
     output:
-        S3_OUTPUT,
+        S3_MANIFEST,
     log:
-        f"{P['stage3_dir']}/{RUN_NAME}.log"
+        f"{P['stage3_dir']}/{RUN_NAME}.prepare.log"
     shell:
-        stage3_helper.radial_scan_cmd(
+        stage3_helper.prepare_cmd(
             docker_prefix=DOCKER_PREFIX,
             image=STAGE3_JAX_IMG,
             stage_cfg=STAGE3_CFG,
@@ -114,18 +124,112 @@ rule stage3_sfincs:
             device=DEVICE,
         ) + " 2>&1 | tee {log}"
 
-rule stage4_spectrax:
+rule stage3_run_one:
+    input:
+        manifest = S3_MANIFEST,
+    output:
+        f"{P['stage3_dir']}/runs/{{surf}}/result.json",
+    wildcard_constraints:
+        surf = SURF_PATTERN,
+    log:
+        f"{P['stage3_dir']}/runs/{{surf}}/run.log"
+    shell:
+        stage3_helper.run_one_cmd(
+            docker_prefix=DOCKER_PREFIX,
+            image=STAGE3_JAX_IMG,
+            stage_cfg=STAGE3_CFG,
+            output_dir=P["stage3_dir"],
+            device=DEVICE,
+        ) + " 2>&1 | tee {log}"
+
+def stage3_surface_results(wildcards):
+    """List every per-surface result.json named by the Stage 3 manifest."""
+    manifest_path = checkpoints.stage3_prepare.get().output[0]
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    return [
+        f"{P['stage3_dir']}/runs/{run['run_subdir']}/result.json"
+        for run in manifest["runs"]
+    ]
+
+rule stage3_collect:
+    input:
+        manifest = S3_MANIFEST,
+        results  = stage3_surface_results,
+    output:
+        S3_OUTPUT,
+    log:
+        f"{P['stage3_dir']}/{RUN_NAME}.collect.log"
+    shell:
+        stage3_helper.collect_cmd(
+            docker_prefix=DOCKER_PREFIX,
+            image=STAGE3_JAX_IMG,
+            stage_cfg=STAGE3_CFG,
+            output_dir=P["stage3_dir"],
+            device=DEVICE,
+        ) + " 2>&1 | tee {log}"
+
+checkpoint stage4_prepare:
     input:
         config_file = S4_CONFIG,
         wout        = S1_OUTPUT,
         boozer      = S2_OUTPUT,
         common_config = S5_CONFIG,
     output:
+        S4_MANIFEST,
+    log:
+        f"{P['stage4_dir']}/{RUN_NAME}.prepare.log"
+    shell:
+        stage4_helper.prepare_cmd(
+            docker_prefix=DOCKER_PREFIX,
+            image=STAGE4_IMG,
+            stage_cfg=STAGE4_CFG,
+            output_dir=P["stage4_dir"],
+            device=DEVICE,
+        ) + " 2>&1 | tee {log}"
+
+rule stage4_run_one:
+    input:
+        manifest = S4_MANIFEST,
+    output:
+        f"{P['stage4_dir']}/runs/{{surf}}/run.diagnostics.csv",
+    wildcard_constraints:
+        surf = SURF_PATTERN,
+    log:
+        f"{P['stage4_dir']}/runs/{{surf}}/run.log"
+    shell:
+        stage4_helper.run_one_cmd(
+            docker_prefix=DOCKER_PREFIX,
+            image=STAGE4_IMG,
+            stage_cfg=STAGE4_CFG,
+            output_dir=P["stage4_dir"],
+            device=DEVICE,
+        ) + " 2>&1 | tee {log}"
+
+def stage4_surface_diagnostics(wildcards):
+    """List every per-surface diagnostics CSV named by the Stage 4 manifest.
+
+    Stage 4 manifest entries carry no run_subdir key, only the container-absolute
+    run_dir, so the host-side path is rebuilt from its POSIX basename.
+    """
+    manifest_path = checkpoints.stage4_prepare.get().output[0]
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    return [
+        f"{P['stage4_dir']}/runs/{posixpath.basename(run['run_dir'])}/run.diagnostics.csv"
+        for run in manifest["runs"]
+    ]
+
+rule stage4_collect:
+    input:
+        manifest = S4_MANIFEST,
+        diagnostics = stage4_surface_diagnostics,
+    output:
         S4_OUTPUT,
     log:
-        f"{P['stage4_dir']}/{RUN_NAME}.log"
+        f"{P['stage4_dir']}/{RUN_NAME}.collect.log"
     shell:
-        stage4_helper.radial_scan_cmd(
+        stage4_helper.collect_cmd(
             docker_prefix=DOCKER_PREFIX,
             image=STAGE4_IMG,
             stage_cfg=STAGE4_CFG,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -240,8 +240,9 @@ When a stage completes Phase 2 (containerized, tested, and producing valid outpu
 > Define the process for adding a stage to the Snakemake DAG.
 
 **Design points to keep in mind:**
-- Stages 3 and 4 run in parallel after Stage 2; Stage 3's `NEO_JAX` also runs in parallel with `sfincs_jax`
-- `NEO_JAX`'s epsilon_eff is a screening metric only -- it should not be wired as a dependency for Stage 5
+- The forward-pass Stage 3 (`sfincs_jax`) reads only the Stage 1 wout, so it runs in parallel with Stage 2; Stage 4 (`SPECTRAX-GK`) also needs the Stage 2 boozmn, so it follows Stage 2.
+- `NEO_JAX` reads the Stage 2 boozmn and runs alongside `sfincs_jax` as a screening diagnostic, but it has **no Snakemake rule** and is not part of the forward pass. Its epsilon_eff is a screening metric only. It should not be wired as a dependency for Stage 5.
+- Stages 3 and 4 each fan out one Snakemake job per flux surface via a three-rule `prepare` (checkpoint) / `run_one` / `collect` layout; see [Per-surface fan-out](mvp-pipeline.md#per-surface-fan-out-stages-3-and-4).
 
 ### Config-Driven Selection
 

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -157,7 +157,7 @@ pixi run --manifest-path stages/pixi.toml stage-3-sfincs
 ```
 
 > [!NOTE]
-> The pixi `stage-3-sfincs` task and the Snakemake `stage3_sfincs` rule both pass the wout path to `sfincs_jax` via `--wout-path`, overriding the namelist `equilibriumFile` field. Populate `outputs/quick_run/stage1_equilibrium/` by running `pixi run --manifest-path stages/pixi.toml stage-1-vmec` first. The `sfincs_fortran` backend has no CLI override and still reads `equilibriumFile` from the namelist.
+> The pixi `stage-3-sfincs` task and the Snakemake `stage3_prepare` checkpoint both pass the wout path to `sfincs_jax` via `--wout-path`, overriding the namelist `equilibriumFile` field. Populate `outputs/quick_run/stage1_equilibrium/` by running `pixi run --manifest-path stages/pixi.toml stage-1-vmec` first. The `sfincs_fortran` backend has no CLI override and still reads `equilibriumFile` from the namelist.
 
 
 **Code:** SFINCS (Fortran)
@@ -218,8 +218,11 @@ pixi run --manifest-path stages/pixi.toml stage-4-spectrax
 which executes something morally equivalent to
 
 ```
-spectrax-gk run --config inputs/quick_run/HSX_vacuum_ns201_quickrun.toml --out outputs/quick_run/stage4_turbulence/hsx_run
+python -m spectraxgk.cli run --config inputs/quick_run/HSX_vacuum_ns201_quickrun.toml --out outputs/quick_run/stage4_turbulence/hsx_run
 ```
+
+> [!NOTE]
+> The pixi `stage-4-spectrax` task runs the all-in-one radial scan, which fans one `python -m spectraxgk.cli run` subprocess out per flux surface; the command above is the underlying per-surface invocation.
 
 ---
 
@@ -256,22 +259,58 @@ Stage 5 is orchestrated by Snakemake (`rule stage5_neopax`), which runs `neopax`
 
 Automates the MVP forward pass end-to-end: `Stage 1 -> {Stage 2, Stage 3, Stage 4} -> Stage 5`. Stages 2 and 3 fan out in parallel off the Stage 1 wout; Stage 4 also needs Stage 2's boozmn, so it follows Stage 2; and Stage 5 consumes all upstream outputs (wout, boozmn, neoclassical + turbulent fluxes). Each stage runs inside its pre-built GHCR container image (`ghcr.io/driftless-star/driftless-star:stage-N-<code>-{cpu,gpu}`) via `docker run`, so no local Pixi install is required beyond the `pipeline` env itself.
 
-| Direction | Format              | Location                                                                                            |
-| --------- | ------------------- | --------------------------------------------------------------------------------------------------- |
-| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `device`, `input_dir`, `output_dir`, `filenames`, `stage3`, `stage4`)                                   |
-| **In**    | Workflow definition | `Snakefile`                                                                                         |
-| **In**    | Per-stage inputs    | `inputs/quick_run/` (all stage inputs, flat)                                                          |
-| **Out**   | Stage 2 NetCDF      | `outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc`                                           |
-| **Out**   | Stage 3 HDF5        | `outputs/quick_run/stage3_neoclassical/sfincs_jax_flux_profiles.h5`                                                    |
-| **Out**   | Stage 4 HDF5        | `outputs/quick_run/stage4_turbulence/neopax_fluxes.h5` (+ `flux_summary.h5`, `manifest.json`, `runs.csv`) |
-| **Out**   | Stage 4 cache       | `outputs/quick_run/stage4_turbulence/runs/rho_*/wout_HSX_vacuum_ns201_quickrun.eik.nc` (per-radius geometry, regenerated every rerun) |
-| **Out**   | Stage 5 HDF5        | `outputs/quick_run/stage5_transport/transport_solution.h5` (transport solution; default `rule all` target) |
+| Direction | Format              | Location                                                                                                                                                           |
+| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `device`, `input_dir`, `output_dir`, `filenames`, `stage3`, `stage4`)                                            |
+| **In**    | Workflow definition | `Snakefile`                                                                                                                                                        |
+| **In**    | Per-stage inputs    | `inputs/quick_run/` (all stage inputs, flat)                                                                                                                       |
+| **Out**   | Stage 2 NetCDF      | `outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc`                                                                                              |
+| **Out**   | Stage 3 HDF5        | `outputs/quick_run/stage3_neoclassical/sfincs_jax_flux_profiles.h5`                                                                                                |
+| **Out**   | Stage 3 cache       | `outputs/quick_run/stage3_neoclassical/manifest.json` + `runs/rho_*/{input.namelist, payload.json, sfincsOutput.h5, result.json}` (per-surface inputs and results) |
+| **Out**   | Stage 4 HDF5        | `outputs/quick_run/stage4_turbulence/neopax_fluxes.h5` (+ `flux_summary.h5`, `manifest.json`, `runs.csv`)                                                          |
+| **Out**   | Stage 4 cache       | `outputs/quick_run/stage4_turbulence/runs/rho_*/wout_HSX_vacuum_ns201_quickrun.eik.nc` (per-radius geometry, regenerated every rerun)                              |
+| **Out**   | Stage 5 HDF5        | `outputs/quick_run/stage5_transport/transport_solution.h5` (transport solution; default `rule all` target)                                                         |
 
 > [!NOTE]
 > `rule all` targets the Stage 5 transport solution (`transport_solution.h5`); all upstream artifacts (wout, boozmn, neoclassical + turbulent fluxes) are produced transitively because downstream rules declare them as `input:`. The loop-closing post-processing step is *not* part of `rule all` -- a plain `snakemake` stays a pure forward pass; see [Closing the Loop](#closing-the-loop).
 
 > [!NOTE]
 > Docker must be running on the host. On macOS / Windows that is Docker Desktop; on Linux, the docker engine or a rootless equivalent (podman aliased to `docker`). Windows users should invoke from WSL2 or Git Bash so bash expansions like `$PWD` resolve correctly inside the Snakefile's shell directives. HPC clusters that disallow Docker are a planned follow-up (Apptainer via `--sdm apptainer`).
+
+### Per-surface fan-out (Stages 3 and 4)
+
+Stages 3 and 4 do not run as single jobs. Each expands into three rules that fan one Snakemake job out per flux surface:
+
+1. **`checkpoint stageN_prepare`** -- reads the stage config plus its upstream geometry (Stage 3 takes the Stage 1 wout; Stage 4 takes the Stage 1 wout and the Stage 2 boozmn), then writes `manifest.json` at the stage directory enumerating the surfaces, plus each surface's inputs under `runs/<surf>/` (`input.namelist` + `payload.json` for Stage 3; the runtime `input.toml` + geometry `*.eik.nc` for Stage 4). Surface directory basenames look like `rho_012_r0p4898`.
+2. **`rule stageN_run_one`** -- one job and one container per surface. Stage 3 solves the surface and writes `runs/<surf>/result.json` (and `sfincsOutput.h5`); Stage 4 evolves it and writes `runs/<surf>/run.diagnostics.csv`.
+3. **`rule stageN_collect`** -- reduces every per-surface output into the stage's declared HDF5 (`sfincs_jax_flux_profiles.h5` / `neopax_fluxes.h5`).
+
+Which surfaces are scanned is driven by the `stage3.sfincs_jax` / `stage4.spectrax_gk` blocks in the run config (`analytical_n_radii` and the commented `num_radii` / `rho_min` / `rho_max` / `rho_indices` alternatives); see each stage's `spec.md`.
+
+> [!NOTE]
+> `prepare` is a Snakemake `checkpoint` because the surface count can be data-dependent: with `profiles_source: transport_h5` the rho grid is read from a `transport_solution.h5` at run time. A dry run (`snakemake -n`) therefore plans only up to the checkpoints plus the deferred `collect` jobs; the per-surface `run_one` layer materializes only after `prepare` actually runs. Surface-level concurrency is `snakemake --cores`, one job per surface.
+
+> [!NOTE]
+> `collect` is fail-fast: it requires every per-surface output, so one failed surface fails the stage. The zero-filling fallback survives only in each scan script's manual all-in-one CLI (running the script without a subcommand), which the Snakemake path does not use.
+
+### How the fan-out executes
+
+The Snakefile is Python, so defining a rule and executing its job happen at different times:
+
+1. **Parse time -- command strings only.** Each fan-out rule's `shell:` directive calls a per-phase composer in `src/stage3_helper.py` / `src/stage4_helper.py` (`prepare_cmd` / `run_one_cmd` / `collect_cmd`), which translates the run config's stage block into a one-line `docker run ...` command string. Nothing executes at this point, on any invocation (including dry runs); Snakemake placeholders (`{input.*}`, `{log}`, `{wildcards.surf}`) stay literal in the stored string.
+2. **Job execution.** When the scheduler selects a job (its inputs are built, its output is missing or stale, and a core is free), Snakemake substitutes the concrete paths into the stored string and runs it through bash under `set -o pipefail`, streaming container output to the rule's log via `tee` while the job runs. `snakemake -np` prints every fully substituted command without executing.
+3. **The checkpoint defers the per-surface layer.** `stageN_collect` declares its per-surface inputs as a gather function rather than a static list. That function calls `checkpoints.stageN_prepare.get()`, which fails softly until the checkpoint has run -- the reason dry runs plan only `prepare -> collect` (see the note above). Once `prepare` writes `manifest.json`, Snakemake re-evaluates the DAG and calls the gather function again: it now reads the manifest with stdlib `json` (the `pipeline` env has no numpy/h5py) and returns the per-surface output paths, built from each run directory's basename only -- the manifest's stored paths are container-absolute and never valid on the host.
+4. **Wildcard matching mints the jobs.** The gather function returns file paths, not jobs. Snakemake finds each path's producer by matching it against `stageN_run_one`'s `output:` template, where `{surf}` is a regex capture group constrained to `rho_\d+_r[0-9p]+`. Each demanded path solves to one `surf` value (e.g. `rho_012_r0p4898`), instantiating one job, and that value threads into every `{surf}` / `{wildcards.surf}` in the rule (the log path; `--payload` / `--run-name` in the composed command), so each job addresses exactly its own surface. quick_run's 50 demanded Stage 3 paths yield 50 jobs from one template rule, with no explicit loop anywhere.
+
+End to end for Stage 3 (Stage 4 has the same shape, with the Stage 2 boozmn as an extra `prepare` input), Snakemake plans demand-first and then executes dependency-first:
+
+1. `rule all` needs the Stage 5 output, whose rule inputs the Stage 3 HDF5; the producer of that file is `stage3_collect`.
+2. `stage3_collect` declares two inputs: the manifest file and the gather function. Evaluating the function calls `checkpoints.stage3_prepare.get()`, which signals "checkpoint not run yet", so the per-surface input list is deferred.
+3. The manifest demand schedules `checkpoint stage3_prepare`, whose own inputs pull in `stage1_vmec` (the wout) upstream.
+4. Execution starts: `stage1_vmec` runs, then `stage3_prepare` runs and writes `manifest.json` plus each surface's inputs under `runs/<surf>/`.
+5. Checkpoint completion triggers the DAG re-evaluation: the gather function runs again, now reads the manifest, and returns the per-surface `runs/<surf>/result.json` paths (50 for quick_run).
+6. Each returned path is wildcard-matched to `stage3_run_one`'s output pattern, minting one job per surface; they execute up to `--cores` at a time.
+7. Once every `result.json` exists, `stage3_collect` finally has a complete input set, runs, and reduces them into the stage HDF5, unblocking Stage 5.
 
 ### How to Install
 
@@ -342,7 +381,23 @@ pixi run -e pipeline bash -c 'snakemake --filegraph --configfile inputs/quick_ru
 
 
 > [!NOTE]
-> For the inverse view (*rules* as nodes, showing how they depend on each other irrespective of which files they share), swap `--filegraph` for `--rulegraph`. For the per-job DAG (every rule instance, one node each, most useful when wildcards produce many parallel jobs), swap for `--dag`.
+> For the inverse view (*rules* as nodes, showing how they depend on each other irrespective of which files they share), swap `--filegraph` for `--rulegraph`. For the per-job DAG (every rule instance, one node each, most useful when wildcards produce many parallel jobs), swap for `--dag` -- but see [Drawing the complete per-surface job DAG](#drawing-the-complete-per-surface-job-dag) for how the Stage 3/4 checkpoints affect it.
+
+### Drawing the complete per-surface job DAG
+
+Because the [per-surface fan-out](#per-surface-fan-out-stages-3-and-4) is checkpoint-driven, `--dag` can only place the per-surface `run_one` layer in the graph once each stage's `manifest.json` exists and is up to date; until then the graph collapses to `prepare -> collect`, for the same reason a dry run plans only up to the checkpoints. To materialize both manifests without a full pipeline run, target them directly (only Stage 1, Stage 2, and the two `prepare` jobs execute), then render:
+
+```
+pixi run -e pipeline snakemake --configfile inputs/quick_run/config.yaml --cores 4 \
+  outputs/quick_run/stage3_neoclassical/manifest.json \
+  outputs/quick_run/stage4_turbulence/manifest.json
+pixi run -e pipeline bash -c 'snakemake --dag --configfile inputs/quick_run/config.yaml | dot -Tsvg > ./driftless-star_dag.svg'
+```
+
+Jobs that are already up to date are drawn with dashed borders. Prefer SVG: with `inputs/quick_run/`'s 50 Stage 3 surfaces the fanned-out graph is very wide (for PNG, reuse the `-Tpng -Gdpi=150` form above).
+
+> [!NOTE]
+> Do not combine `--dag` with `--forceall`/`-F`: forcing the checkpoints to rerun makes their manifests count as not-yet-available while the DAG is built, so the per-surface layer is deferred and the graph collapses back to `prepare -> collect`. The same collapse happens whenever Snakemake decides a `prepare` must rerun for any other reason (e.g. edited configs or code-change rerun triggers); appending `--rerun-triggers mtime` restores the fan-out as long as the manifests are newer than their inputs.
 
 ---
 

--- a/docs/stage3-neoclassical/spec.md
+++ b/docs/stage3-neoclassical/spec.md
@@ -142,6 +142,9 @@ The definitions below are for default values of 'nu_n', 'Delta' and 'alpha'
 - `Nx`: energy grid points.
 - Solver tolerance: `solverTolerance` (commonly around $10^{-6}$ to $10^{-10}$ depending on the case and solver path). In this `sfincs_jax` checkout, this is the main named tolerance parameter exposed in the input namelist for the linear solve.
 
+> [!NOTE]
+> **Radial-scan bridge namelist overrides.** The `sfincs_jax_radial_scan.py` bridge that the Snakemake forward pass runs does not use the template namelist verbatim; it patches a fresh copy per flux surface. It sets `RHSMode = 1`, `inputRadialCoordinate = 3` (`rN`), and `rN_wish` to the surface's rho, and it **drops** `inputRadialCoordinateForGradients` from the template so `sfincs_jax` infers the gradient coordinates on its own (species gradients supplied as `dNHatdrNs`/`dTHatdrNs` select mode 3, and the potential gradient supplied as `Er` selects mode 4). Unless overridden on the command line, it also forces the reduced quickrun smoke-test resolution `Ntheta = 5, Nzeta = 11, Nxi = 12, NL = 3, Nx = 4, solverTolerance = 1e-6`, which overrides the raw `sfincs_jax` namelist defaults listed in the field table below.
+
 **Optional input fields** :
 
 **Phi1 / Electrostatic Effects:**
@@ -300,9 +303,28 @@ The definitions below are for default values of 'nu_n', 'Delta' and 'alpha'
 ### Output Specification
 
 
-**Forward-chain handoff:** `sfincs_jax_flux_profiles.h5` (HDF5) -- aggregated flux profiles (Gamma, Q, Upar vs radius) consumed by `NEOPAX` (Stage 5).
+The Snakemake forward pass runs the `sfincs_jax` radial scan as a per-surface fan-out (`stage3_prepare` checkpoint, one `stage3_run_one` job per flux surface, then `stage3_collect`; see [Per-surface fan-out](../mvp-pipeline.md#per-surface-fan-out-stages-3-and-4)). It produces one aggregated handoff file plus a per-surface run tree.
 
-**Native SFINCS output (per surface):** `sfincsOutput.h5` (HDF5) -- the native solver file. The `sfincs_jax` radial scan writes one per flux surface and aggregates them into the handoff above; the standalone `SFINCS` (Fortran) binary writes it directly. Its fields:
+**Forward-chain handoff:** `sfincs_jax_flux_profiles.h5` (HDF5) -- flux profiles versus radius, consumed by `NEOPAX` (Stage 5). The `collect` step assembles it from every per-surface `result.json`. Its schema is the exact subset checked by the in-repo contract validator `src/io_contracts.py` (`validate_sfincs_flux`):
+
+| Dataset | Shape | Meaning |
+|---------|-------|---------|
+| `rho` | `(n_radii,)` | Normalized radial coordinate of each aggregated surface |
+| `r` | `(n_radii,)` | Radial coordinate written from `sfincs_jax`'s `rHat` (alias of `rHat`) |
+| `rHat` | `(n_radii,)` | `sfincs_jax` `rHat` radial coordinate |
+| `Gamma` | `(n_species, n_radii)` | Neoclassical particle flux in NEOPAX units |
+| `Q` | `(n_species, n_radii)` | Neoclassical heat flux in NEOPAX units |
+| `Upar` | `(n_species, n_radii)` | Parallel-flow observable |
+| `species_names` | `(n_species,)` | UTF-8 species labels (root dataset) |
+
+Root attributes:
+- `axis_zero_padded` (bool, **required** by the contract): the scan drops the magnetic-axis (`rho = 0`) surface, so when no aggregated surface sits at `rho = 0` the `collect` step prepends a zero-flux `rho = 0` column and sets this flag `true`.
+- Provenance echoes read back from the scan `manifest.json` rather than measured live: `backend`, `max_parallel`, `worker_sharding`, `profiles_source`, `source_transport_solution`, `source_sfincs_template`, `time_index`, `time_value`, `include_phi1`.
+- Unit / convention notes: `Upar_note`, `normalization_note`, `radius_note` (how `Gamma`/`Q`/`Upar` are converted to NEOPAX units and which coordinate `r`/`rHat` carries).
+
+**Per-surface run tree** (under `outputs/<run>/stage3_neoclassical/`): `manifest.json` at the stage directory records the surfaces and provenance the `collect` step reduces over; `runs/rho_*/` holds one directory per surface (basenames like `rho_012_r0p4898`), each with `input.namelist` (patched per surface), `payload.json` (worker inputs), `sfincsOutput.h5` (native per-surface solver output), and `result.json` (the extracted fluxes `collect` reads).
+
+**Native SFINCS output (per surface):** `sfincsOutput.h5` (HDF5) -- the native solver file. The `sfincs_jax` radial scan writes one per flux surface (under `runs/rho_*/`) and aggregates them into the handoff above; the standalone `SFINCS` (Fortran) binary writes it directly. Its fields:
 
 | Field | Availability | Meaning | Primary Use | Normalization | Units |
 |-------|--------------|---------|-------------|---------------|----|
@@ -447,7 +469,7 @@ pixi run stage-3-sfincs
 ```
 
 > [!NOTE]
-> The pixi task and the Snakemake `stage3_sfincs` rule both pass the wout path to `sfincs_jax` via `--wout-path`. Populate `outputs/quick_run/stage1_equilibrium/` by running `pixi run stage-1-vmec` first. The namelist's `equilibriumFile` field is retained as a fallback for the `sfincs_fortran` backend and for direct `sfincs_jax` invocations that omit `--wout-path`.
+> The pixi task and the Snakemake `stage3_prepare` checkpoint both pass the wout path to `sfincs_jax` via `--wout-path`. Populate `outputs/quick_run/stage1_equilibrium/` by running `pixi run stage-1-vmec` first. The namelist's `equilibriumFile` field is retained as a fallback for the `sfincs_fortran` backend and for direct `sfincs_jax` invocations that omit `--wout-path`.
 
 **Input:** `outputs/quick_run/stage1_equilibrium/wout_HSX_vacuum_ns201_quickrun.nc` + `inputs/quick_run/sfincs_input.HSX_vacuum_ns201_quickrun`
 **Output:** `outputs/quick_run/stage3_neoclassical/sfincs_jax_flux_profiles.h5`

--- a/docs/stage4-turbulence/spec.md
+++ b/docs/stage4-turbulence/spec.md
@@ -86,6 +86,9 @@ Optional input fields:
 - `experts`: Advanced special-purpose controls.
      - Defaults: `fixed_mode=False, iky_fixed=None, ikx_fixed=None, dealias_kz=False`
 
+> [!NOTE]
+> **Radial-scan bridge defaults and reproducibility.** The defaults listed above are the raw SPECTRAX-GK config defaults. The `spectrax_gk_radial_scan.py` bridge that the Snakemake forward pass runs generates a runtime TOML per flux surface rather than using the template verbatim, and its `prepare` shaping defaults differ: `nx = 12`, `ny = 12`, `ntheta = 30` (theta points for the generated VMEC geometry), `t_max = 10.0`, `sample_stride = 50`, `diagnostics_stride = 1` (these are also the values set in the `stage4.spectrax_gk` block of the quick-run config). The bridge does **not** emit `random_seed` into the generated TOMLs, so the SPECTRAX-GK default seed is left implicit and runs are not explicitly re-seeded through this path (a known reproducibility gap).
+
 ### `GX` Inputs (Alternative)
 
 | Field | Type | Description | Source |
@@ -126,7 +129,28 @@ Reference: `stellarator_io_reference.tex`, Sections 3.9-3.10.
 | `heat_flux_s0` | 1D array (time) | Species-resolved particle flux time trace | Diagnostic | Normalization specified in toml file |
 | `particle_flux_s0` | 1D array (time) | Species-resolved particle flux time trace |  Diagnostic | Normalization specified in toml file |
 
-Output in CSV files, along with a json file that records the info for only last time step.
+Output in CSV files, along with a json file that records the info for only last time step. These are the per-surface diagnostics; in the Snakemake forward pass they are written under each surface's run directory and reduced into the aggregated files below.
+
+#### Aggregated forward-pass outputs (radial scan)
+
+The Snakemake forward pass runs the SPECTRAX-GK radial scan as a per-surface fan-out (`stage4_prepare` checkpoint, one `stage4_run_one` job per flux surface, then `stage4_collect`; see [Per-surface fan-out](../mvp-pipeline.md#per-surface-fan-out-stages-3-and-4)). The `collect` step reduces the per-surface diagnostics into two HDF5 files.
+
+**Forward-chain handoff:** `neopax_fluxes.h5` (HDF5), consumed by `NEOPAX` (Stage 5). Its schema is the exact subset checked by the in-repo contract validator `src/io_contracts.py` (`validate_neopax_fluxes`):
+
+| Dataset | Shape | Meaning |
+|---------|-------|---------|
+| `rho` | `(n_radii,)` | Normalized radial coordinate (sorted ascending) |
+| `r` | `(n_radii,)` | Physical minor-radius coordinate `r = a * rho` |
+| `Gamma` | `(n_species, n_radii)` | Turbulent particle flux in NEOPAX units |
+| `Q` | `(n_species, n_radii)` | Turbulent heat flux in NEOPAX units |
+| `Upar` | `(n_species, n_radii)` | Parallel flow; **always written as zeros** (this path supplies no parallel-flow channel) |
+| `meta/species_names` | `(n_species,)` | UTF-8 species labels (dataset inside the `meta` group) |
+
+Required `meta` group attributes (checked by the contract): `particle_flux_units = "m^-2 s^-1"`, `heat_flux_units = "eV m^-2 s^-1"`, and `minor_radius_m`. The `meta` group also carries `rho_star_source`, `radial_flux_coordinate`, `conversion`, `reference_species_name`, and `manifest` provenance attributes. The scan drops the magnetic-axis (`rho = 0`) surface, so when the manifest records a dropped axis the `collect` step re-inserts a zero-flux `rho = 0` column before writing, restoring a full profile for Stage 5.
+
+**Companion aggregate:** `flux_summary.h5` (HDF5) -- the richer scan summary the plots and audits build on, holding `rho`, `r`, `rho_index`, `torflux`, `Er`, `heat_flux_total`, `particle_flux_total`, the averaging-window bounds, a `species` group (`names`, `heat_flux`, `particle_flux`), and a `meta` group. It is not read by Stage 5.
+
+**Per-surface run tree** (under `outputs/<run>/stage4_turbulence/`): `manifest.json` at the stage directory records the surfaces, geometry, and profile provenance the `collect` step reduces over; `runs.csv` and `normalization_audit.csv` summarize the planned runs; `runs/rho_*/` holds one directory per surface (basenames like `rho_012_r0p4898`), each with the generated runtime `input.toml`, the local geometry cache `*.eik.nc`, `run.diagnostics.csv` (the per-surface time traces `collect` reads), and `run.summary.json`.
 
 The natural downstream contract is the same as `GX`: turbulent heat and particle flux (steady-state values).
 
@@ -213,8 +237,11 @@ pixi run stage-4-spectrax
 which executes something morally equivalent to:
 
 ```
-spectrax-gk run --config inputs/quick_run/HSX_vacuum_ns201_quickrun.toml --out outputs/quick_run/stage4_turbulence/hsx_run
+python -m spectraxgk.cli run --config inputs/quick_run/HSX_vacuum_ns201_quickrun.toml --out outputs/quick_run/stage4_turbulence/hsx_run
 ```
+
+> [!NOTE]
+> The pixi `stage-4-spectrax` task runs the all-in-one radial scan, which fans one `python -m spectraxgk.cli run` subprocess out per flux surface; the command above is the underlying per-surface invocation.
 
 **Input:** `outputs/quick_run/stage1_equilibrium/wout_HSX_vacuum_ns201_quickrun.nc` + `inputs/quick_run/HSX_vacuum_ns201_quickrun.toml`
 **Output:** `outputs/quick_run/stage4_turbulence/neopax_fluxes.h5` (+ `flux_summary.h5`, `manifest.json`, `runs.csv`)

--- a/inputs/quick_run/config.yaml
+++ b/inputs/quick_run/config.yaml
@@ -32,11 +32,21 @@ convergence:
   pressure_rel_tol: 1.0e-2
 
 # Stage 3 SFINCS (sfincs_jax) radial scan.
+# Surface-level concurrency is controlled by `snakemake --cores`.
 stage3:
   sfincs_jax:
     # --- Profile source ---
     profiles_source: analytical
     neopax_result: null
+
+    # --- Surface selection ---
+    # Number of rho grid points for profiles_source: analytical (the axis point is
+    # dropped, so for e.g. 51 points scan 50 surfaces).
+    analytical_n_radii: 51
+    # num_radii: 4            # subsample this many radii inside the rho window
+    # rho_min: 0.1            # lower edge of the rho window
+    # rho_max: 0.9            # upper edge of the rho window
+    # rho_indices: "1,5,10"   # comma-separated explicit indices instead of the full grid
 
     # --- Resolution ---
     ntheta: 5
@@ -45,8 +55,6 @@ stage3:
     nx: 4
     solver_tolerance: 1.0e-6
 
-    # --- Parallelism ---
-    max_parallel: 1
     # Used only when `device: gpu`.
     gpu_ids: "0"
 
@@ -55,11 +63,21 @@ stage3:
     verbose_workers: true
 
 # Stage 4 SPECTRAX-GK radial scan.
+# Surface-level concurrency is controlled by `snakemake --cores`.
 stage4:
   spectrax_gk:
     # --- Profile source ---
     profiles_source: analytical
     neopax_result: null
+
+    # --- Surface selection ---
+    # Number of rho grid points for profiles_source: analytical; null falls back to
+    # [geometry].n_radial in common_input.toml (5 points, scanning 4 nonzero surfaces).
+    analytical_n_radii: null
+    # num_radii: 4            # subsample this many radii inside the rho window
+    # rho_min: 0.0            # lower edge of the rho window
+    # rho_max: 1.0            # upper edge of the rho window
+    # rho_indices: "1,2,3"    # comma-separated explicit indices instead of the window
 
     # --- Resolution / time window ---
     nx: 12
@@ -70,8 +88,6 @@ stage4:
     sample_stride: 50
     diagnostics_stride: 1
 
-    # --- Parallelism ---
-    max_parallel: 1
     # Used only when `device: gpu`.
     gpu_ids: "0"
 
@@ -79,4 +95,3 @@ stage4:
     plot: true
     plot_run_heat_traces: true
     verbose_workers: true
-    collect_even_if_failures: true

--- a/src/stage3_helper.py
+++ b/src/stage3_helper.py
@@ -1,32 +1,61 @@
 """Stage 3 (neoclassical) shell-command composition for the Snakemake workflow.
 
 The Stage 3 ``sfincs_jax`` radial-scan script accepts many optional flags; this
-module turns the user-facing ``config.yaml`` ``stage3.sfincs_jax`` block into a
-single shell command string that the Snakefile's ``rule stage3_sfincs`` runs.
+module turns the user-facing ``config.yaml`` ``stage3.sfincs_jax`` block into the
+per-phase shell commands run by the Snakefile's ``stage3_prepare`` checkpoint and
+its ``stage3_run_one``/``stage3_collect`` rules.
 """
 
 from __future__ import annotations
 
-# (config_key, cli_flag) — emitted as `<flag> <value>` when the config value is not None.
-_OPTIONAL_FLAGS: list[tuple[str, str]] = [
-    ("profiles_source",   "--profiles-source"),
-    ("neopax_result",     "--neopax-result"),
-    ("ntheta",            "--ntheta"),
-    ("nzeta",             "--nzeta"),
-    ("nxi",               "--nxi"),
-    ("nx",                "--nx"),
-    ("solver_tolerance",  "--solver-tolerance"),
-    ("max_parallel",      "--max-parallel"),
+_SCRIPT = "stages/stage3-neoclassical/sfincs_jax_radial_scan.py"
+
+# (config_key, cli_flag) accepted by the `prepare` subcommand; emitted as `<flag> <value>` when set.
+_PREPARE_OPTIONAL_FLAGS: list[tuple[str, str]] = [
+    ("profiles_source",    "--profiles-source"),
+    ("neopax_result",      "--neopax-result"),
+    ("ntheta",             "--ntheta"),
+    ("nzeta",              "--nzeta"),
+    ("nxi",                "--nxi"),
+    ("nx",                 "--nx"),
+    ("solver_tolerance",   "--solver-tolerance"),
+    ("analytical_n_radii", "--analytical-n-radii"),
+    ("rho_indices",        "--rho-indices"),
+    ("rho_min",            "--rho-min"),
+    ("rho_max",            "--rho-max"),
+    ("num_radii",          "--num-radii"),
 ]
 
-# (config_key, on_flag, off_flag) — tri-state: None = script default, True/False = explicit.
-_BOOL_FLAGS: list[tuple[str, str, str]] = [
-    ("plot",            "--plot",            "--no-plot"),
+# verbose_workers is baked into each per-surface payload at prepare time.
+_PREPARE_BOOL_FLAGS: list[tuple[str, str, str]] = [
     ("verbose_workers", "--verbose-workers", "--no-verbose-workers"),
 ]
 
+# Plotting happens in the collect step.
+_COLLECT_BOOL_FLAGS: list[tuple[str, str, str]] = [
+    ("plot", "--plot", "--no-plot"),
+]
 
-def radial_scan_cmd(
+
+def _append_optional_flags(parts: list[str], stage_cfg: dict, table: list[tuple[str, str]]) -> None:
+    """Append ``<flag> <value>`` to ``parts`` for each table entry whose config value is not None."""
+    for key, flag in table:
+        value = stage_cfg.get(key)
+        if value is not None:
+            parts.append(f"{flag} {value}")
+
+
+def _append_bool_flags(parts: list[str], stage_cfg: dict, table: list[tuple[str, str, str]]) -> None:
+    """Append the on-flag for True and the off-flag for False; a missing/None key appends nothing."""
+    for key, on, off in table:
+        value = stage_cfg.get(key)
+        if value is True:
+            parts.append(on)
+        elif value is False:
+            parts.append(off)
+
+
+def prepare_cmd(
     *,
     docker_prefix: str,
     image: str,
@@ -34,7 +63,12 @@ def radial_scan_cmd(
     output_dir: str,
     device: str,
 ) -> str:
-    """Compose the Stage 3 ``sfincs_jax`` radial-scan shell command.
+    """Compose the Stage 3 ``sfincs_jax`` ``prepare`` shell command.
+
+    Concretely: build the CLI arguments for the scan script's ``prepare``
+    subcommand from ``stage_cfg`` and wrap them in a ``docker run`` invocation
+    of the stage image. Nothing executes here; the returned string is the
+    command Snakemake runs when the checkpoint's job fires.
 
     Parameters
     ----------
@@ -47,34 +81,104 @@ def radial_scan_cmd(
     output_dir : str
         Stage 3 output directory (already ``{run_name}``-substituted).
     device : str
-        ``"cpu"`` or ``"gpu"``; controls JAX backend and GPU pinning.
+        ``"cpu"`` or ``"gpu"``; recorded into the manifest as the run backend.
 
     Returns
     -------
     str
-        A single-line shell command suitable for a Snakemake ``shell:`` block.
-        Snakemake placeholders ``{input.*}`` remain literal so they are
-        substituted at rule-execution time.
+        A single-line ``prepare`` subcommand that writes the per-surface
+        payloads and scan manifest. ``{input.*}`` placeholders remain literal
+        so Snakemake substitutes them at rule-execution time.
     """
     parts = [
         f"{docker_prefix} {image}",
-        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py",
+        f"python {_SCRIPT} prepare",
         "--common-config {input.common_config}",
         "--sfincs-template {input.config_file}",
         "--wout-path {input.wout}",
         f"--output-dir {output_dir}",
         f"--backend {device}",
     ]
-    for key, flag in _OPTIONAL_FLAGS:
-        v = stage_cfg.get(key)
-        if v is not None:
-            parts.append(f"{flag} {v}")
+    _append_optional_flags(parts, stage_cfg, _PREPARE_OPTIONAL_FLAGS)
+    _append_bool_flags(parts, stage_cfg, _PREPARE_BOOL_FLAGS)
+    return " ".join(parts)
+
+
+def run_one_cmd(
+    *,
+    docker_prefix: str,
+    image: str,
+    stage_cfg: dict,
+    output_dir: str,
+    device: str,
+) -> str:
+    """Compose the Stage 3 ``sfincs_jax`` ``run-one`` shell command.
+
+    Parameters
+    ----------
+    docker_prefix : str
+        ``docker run ...`` prefix prepared by the Snakefile.
+    image : str
+        Container image for Stage 3 (e.g. ``ghcr.io/.../stage-3-sfincs-cpu``).
+    stage_cfg : dict
+        The ``config.yaml`` ``stage3.sfincs_jax`` block.
+    output_dir : str
+        Stage 3 output directory (already ``{run_name}``-substituted).
+    device : str
+        ``"cpu"`` or ``"gpu"``; controls the JAX backend and GPU pinning.
+
+    Returns
+    -------
+    str
+        A single-line ``run-one`` subcommand that solves one surface. The
+        ``{wildcards.surf}`` placeholder names the per-surface run directory and
+        stays literal so Snakemake substitutes it at rule-execution time.
+    """
+    parts = [
+        f"{docker_prefix} {image}",
+        f"python {_SCRIPT} run-one",
+        f"--payload {output_dir}/runs/{{wildcards.surf}}/payload.json",
+        f"--backend {device}",
+    ]
     if device == "gpu" and stage_cfg.get("gpu_ids") is not None:
         parts.append(f"--gpu-ids {stage_cfg['gpu_ids']}")
-    for key, on, off in _BOOL_FLAGS:
-        v = stage_cfg.get(key)
-        if v is True:
-            parts.append(on)
-        elif v is False:
-            parts.append(off)
+    return " ".join(parts)
+
+
+def collect_cmd(
+    *,
+    docker_prefix: str,
+    image: str,
+    stage_cfg: dict,
+    output_dir: str,
+    device: str,
+) -> str:
+    """Compose the Stage 3 ``sfincs_jax`` ``collect`` shell command.
+
+    Parameters
+    ----------
+    docker_prefix : str
+        ``docker run ...`` prefix prepared by the Snakefile.
+    image : str
+        Container image for Stage 3 (e.g. ``ghcr.io/.../stage-3-sfincs-cpu``).
+    stage_cfg : dict
+        The ``config.yaml`` ``stage3.sfincs_jax`` block.
+    output_dir : str
+        Stage 3 output directory (already ``{run_name}``-substituted).
+    device : str
+        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature and
+        not used by the reduction step.
+
+    Returns
+    -------
+    str
+        A single-line ``collect`` subcommand that reduces the per-surface
+        results into the flux-profile HDF5.
+    """
+    parts = [
+        f"{docker_prefix} {image}",
+        f"python {_SCRIPT} collect",
+        f"--output-dir {output_dir}",
+    ]
+    _append_bool_flags(parts, stage_cfg, _COLLECT_BOOL_FLAGS)
     return " ".join(parts)

--- a/src/stage4_helper.py
+++ b/src/stage4_helper.py
@@ -146,10 +146,10 @@ def run_one_cmd(
         "--run-name {wildcards.surf}",
         f"--backend {device}",
     ]
-    # The run-one worker pins a single device via --gpu-id. The raw config string is passed through
-    # unchanged; splitting a multi-GPU list round-robin across surfaces is a deferred follow-up.
+    # The raw comma-separated config value is passed through and the worker pins the first id,
+    # matching Stage 3; distributing a multi-GPU list across surfaces is a deferred follow-up.
     if device == "gpu" and stage_cfg.get("gpu_ids") is not None:
-        parts.append(f"--gpu-id {stage_cfg['gpu_ids']}")
+        parts.append(f"--gpu-ids {stage_cfg['gpu_ids']}")
     # --verbose-worker is a plain store_true with no negative form, so only an explicit config True
     # emits it; False and a missing key both leave the worker at its quiet default.
     if stage_cfg.get("verbose_workers") is True:

--- a/src/stage4_helper.py
+++ b/src/stage4_helper.py
@@ -2,36 +2,64 @@
 
 The Stage 4 SPECTRAX-GK radial-scan script accepts many optional flags; this
 module turns the user-facing ``config.yaml`` ``stage4.spectrax_gk`` block into
-a single shell command string that the Snakefile's ``rule stage4_spectrax``
-runs.
+the per-phase shell commands run by the Snakefile's ``stage4_prepare``
+checkpoint and its ``stage4_run_one``/``stage4_collect`` rules.
 """
 
 from __future__ import annotations
 
-# (config_key, cli_flag) — emitted as `<flag> <value>` when the config value is not None.
-_OPTIONAL_FLAGS: list[tuple[str, str]] = [
+_SCRIPT = "stages/stage4-turbulence/spectrax_gk_radial_scan.py"
+
+# (config_key, cli_flag) accepted by the `prepare` subcommand; emitted as `<flag> <value>` when set.
+# The config key t_max is spelled --t-final, an accepted alias whose argparse dest is t_max.
+_PREPARE_OPTIONAL_FLAGS: list[tuple[str, str]] = [
     ("profiles_source",    "--profiles-source"),
     ("neopax_result",      "--neopax-result"),
     ("nx",                 "--nx"),
     ("ny",                 "--ny"),
     ("ntheta",             "--ntheta"),
     ("t_max",              "--t-final"),
-    ("average_window",     "--average-window"),
     ("sample_stride",      "--sample-stride"),
     ("diagnostics_stride", "--diagnostics-stride"),
-    ("max_parallel",       "--max-parallel"),
+    ("analytical_n_radii", "--analytical-n-radii"),
+    ("rho_indices",        "--rho-indices"),
+    ("rho_min",            "--rho-min"),
+    ("rho_max",            "--rho-max"),
+    ("num_radii",          "--num-radii"),
 ]
 
-# (config_key, on_flag, off_flag) — tri-state: None = script default, True/False = explicit.
-_BOOL_FLAGS: list[tuple[str, str, str]] = [
-    ("plot",                     "--plot",                     "--no-plot"),
-    ("plot_run_heat_traces",     "--plot-run-heat-traces",     "--no-plot-run-heat-traces"),
-    ("verbose_workers",          "--verbose-workers",          "--no-verbose-workers"),
-    ("collect_even_if_failures", "--collect-even-if-failures", "--no-collect-even-if-failures"),
+# Flux averaging and plotting happen in the collect step. Config t_max is deliberately not re-emitted
+# at collect: it reaches the manifest via prepare, and collect's --t-final falls back to the manifest
+# value, keeping a single source of truth for the time window.
+_COLLECT_OPTIONAL_FLAGS: list[tuple[str, str]] = [
+    ("average_window", "--average-window"),
+]
+
+_COLLECT_BOOL_FLAGS: list[tuple[str, str, str]] = [
+    ("plot",                 "--plot",                 "--no-plot"),
+    ("plot_run_heat_traces", "--plot-run-heat-traces", "--no-plot-run-heat-traces"),
 ]
 
 
-def radial_scan_cmd(
+def _append_optional_flags(parts: list[str], stage_cfg: dict, table: list[tuple[str, str]]) -> None:
+    """Append ``<flag> <value>`` to ``parts`` for each table entry whose config value is not None."""
+    for key, flag in table:
+        value = stage_cfg.get(key)
+        if value is not None:
+            parts.append(f"{flag} {value}")
+
+
+def _append_bool_flags(parts: list[str], stage_cfg: dict, table: list[tuple[str, str, str]]) -> None:
+    """Append the on-flag for True and the off-flag for False; a missing/None key appends nothing."""
+    for key, on, off in table:
+        value = stage_cfg.get(key)
+        if value is True:
+            parts.append(on)
+        elif value is False:
+            parts.append(off)
+
+
+def prepare_cmd(
     *,
     docker_prefix: str,
     image: str,
@@ -39,7 +67,12 @@ def radial_scan_cmd(
     output_dir: str,
     device: str,
 ) -> str:
-    """Compose the Stage 4 SPECTRAX-GK radial-scan shell command.
+    """Compose the Stage 4 SPECTRAX-GK ``prepare`` shell command.
+
+    Concretely: build the CLI arguments for the scan script's ``prepare``
+    subcommand from ``stage_cfg`` and wrap them in a ``docker run`` invocation
+    of the stage image. Nothing executes here; the returned string is the
+    command Snakemake runs when the checkpoint's job fires.
 
     Parameters
     ----------
@@ -52,35 +85,115 @@ def radial_scan_cmd(
     output_dir : str
         Stage 4 output directory (already ``{run_name}``-substituted).
     device : str
-        ``"cpu"`` or ``"gpu"``; controls JAX backend and GPU pinning.
+        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature. The
+        prepare step only writes the manifest and runtime TOMLs, and its parser
+        takes no backend flag, so no device flag is emitted.
 
     Returns
     -------
     str
-        A single-line shell command suitable for a Snakemake ``shell:`` block.
-        Snakemake placeholders ``{input.*}`` remain literal so they are
-        substituted at rule-execution time.
+        A single-line ``prepare`` subcommand that writes the per-radius manifest
+        and SPECTRAX runtime TOMLs. ``{input.*}`` placeholders remain literal so
+        Snakemake substitutes them at rule-execution time.
     """
     parts = [
         f"{docker_prefix} {image}",
-        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py",
+        f"python {_SCRIPT} prepare",
         "--common-config {input.common_config}",
         "--spectrax-template {input.config_file}",
         "--vmec-file-override {input.wout}",
         "--boozer-file-override {input.boozer}",
         f"--output-dir {output_dir}",
+    ]
+    _append_optional_flags(parts, stage_cfg, _PREPARE_OPTIONAL_FLAGS)
+    return " ".join(parts)
+
+
+def run_one_cmd(
+    *,
+    docker_prefix: str,
+    image: str,
+    stage_cfg: dict,
+    output_dir: str,
+    device: str,
+) -> str:
+    """Compose the Stage 4 SPECTRAX-GK ``run-one`` shell command.
+
+    Parameters
+    ----------
+    docker_prefix : str
+        ``docker run ...`` prefix prepared by the Snakefile.
+    image : str
+        Container image for Stage 4 (e.g. ``ghcr.io/.../stage-4-spectrax-cpu``).
+    stage_cfg : dict
+        The ``config.yaml`` ``stage4.spectrax_gk`` block.
+    output_dir : str
+        Stage 4 output directory (already ``{run_name}``-substituted).
+    device : str
+        ``"cpu"`` or ``"gpu"``; controls the JAX backend and GPU pinning.
+
+    Returns
+    -------
+    str
+        A single-line ``run-one`` subcommand that evolves one surface. The
+        ``{wildcards.surf}`` placeholder names the manifest run to execute and
+        stays literal so Snakemake substitutes it at rule-execution time.
+    """
+    parts = [
+        f"{docker_prefix} {image}",
+        f"python {_SCRIPT} run-one",
+        f"--manifest {output_dir}/manifest.json",
+        "--run-name {wildcards.surf}",
         f"--backend {device}",
     ]
-    for key, flag in _OPTIONAL_FLAGS:
-        v = stage_cfg.get(key)
-        if v is not None:
-            parts.append(f"{flag} {v}")
+    # The run-one worker pins a single device via --gpu-id. The raw config string is passed through
+    # unchanged; splitting a multi-GPU list round-robin across surfaces is a deferred follow-up.
     if device == "gpu" and stage_cfg.get("gpu_ids") is not None:
-        parts.append(f"--gpu-ids {stage_cfg['gpu_ids']}")
-    for key, on, off in _BOOL_FLAGS:
-        v = stage_cfg.get(key)
-        if v is True:
-            parts.append(on)
-        elif v is False:
-            parts.append(off)
+        parts.append(f"--gpu-id {stage_cfg['gpu_ids']}")
+    # --verbose-worker is a plain store_true with no negative form, so only an explicit config True
+    # emits it; False and a missing key both leave the worker at its quiet default.
+    if stage_cfg.get("verbose_workers") is True:
+        parts.append("--verbose-worker")
+    return " ".join(parts)
+
+
+def collect_cmd(
+    *,
+    docker_prefix: str,
+    image: str,
+    stage_cfg: dict,
+    output_dir: str,
+    device: str,
+) -> str:
+    """Compose the Stage 4 SPECTRAX-GK ``collect`` shell command.
+
+    Parameters
+    ----------
+    docker_prefix : str
+        ``docker run ...`` prefix prepared by the Snakefile.
+    image : str
+        Container image for Stage 4 (e.g. ``ghcr.io/.../stage-4-spectrax-cpu``).
+    stage_cfg : dict
+        The ``config.yaml`` ``stage4.spectrax_gk`` block.
+    output_dir : str
+        Stage 4 output directory (already ``{run_name}``-substituted).
+    device : str
+        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature and
+        not used by the reduction step.
+
+    Returns
+    -------
+    str
+        A single-line ``collect`` subcommand that reduces per-radius
+        diagnostics into ``flux_summary.h5`` and ``neopax_fluxes.h5``.
+    """
+    parts = [
+        f"{docker_prefix} {image}",
+        f"python {_SCRIPT} collect",
+        f"--manifest {output_dir}/manifest.json",
+        f"--out {output_dir}/flux_summary.h5",
+        f"--neopax-flux-out {output_dir}/neopax_fluxes.h5",
+    ]
+    _append_optional_flags(parts, stage_cfg, _COLLECT_OPTIONAL_FLAGS)
+    _append_bool_flags(parts, stage_cfg, _COLLECT_BOOL_FLAGS)
     return " ".join(parts)

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -20,6 +20,9 @@ _STAGE_SUBDIRS: dict[str, str] = {
 # Basename of the resolved NEOPAX config written under the Stage 5 output dir.
 RESOLVED_COMMON_CONFIG = "common_input_updated.toml"
 
+# Basename of the per-surface scan manifest each prepare checkpoint writes under its stage dir.
+MANIFEST_BASENAME = "manifest.json"
+
 
 def resolve_pipeline_paths(
     config: dict,
@@ -48,9 +51,11 @@ def resolve_pipeline_paths(
           (``s5_config`` is the shared ``common_input`` template);
         - output artifacts ``s1_output``..``s5_output``, ``s5_signal``;
         - per-stage output dirs ``stage1_dir``..``stage5_post_dir``;
-        - paths generated under ``outputs/``: ``s5_resolved_config`` (the
-          path-resolved NEOPAX copy NEOPAX actually runs) and ``s1_feedback``
-          (the evolved Stage 1 boundary the loop feeds to the next iteration).
+        - paths generated under ``outputs/``: ``stage3_manifest`` and
+          ``stage4_manifest`` (the per-surface scan manifests the prepare
+          checkpoints write), ``s5_resolved_config`` (the path-resolved NEOPAX
+          copy NEOPAX actually runs), and ``s1_feedback`` (the evolved Stage 1
+          boundary the loop feeds to the next iteration).
 
     Examples
     --------
@@ -113,6 +118,8 @@ def resolve_pipeline_paths(
         "stage5_dir": stage_dir("s5_output"),
         "stage5_post_dir": stage_dir("s5_signal"),
         # Generated under outputs/.
+        "stage3_manifest": f"{stage_dir('s3_output')}/{MANIFEST_BASENAME}",
+        "stage4_manifest": f"{stage_dir('s4_output')}/{MANIFEST_BASENAME}",
         "s5_resolved_config": f"{stage_dir('s5_output')}/{RESOLVED_COMMON_CONFIG}",
         "s1_feedback": f"{stage_dir('s5_signal')}/{fn('s1_input')}",
     }

--- a/stages/stage3-neoclassical/sfincs_jax_radial_scan.py
+++ b/stages/stage3-neoclassical/sfincs_jax_radial_scan.py
@@ -926,7 +926,28 @@ def _run_tasks_in_parallel(
         raise
 
 
-def cmd_main(args: argparse.Namespace) -> int:
+def _prepare(args: argparse.Namespace) -> tuple[dict[str, Any], list[Path]]:
+    """Build per-surface sfincs_jax inputs and the scan manifest.
+
+    Loads profiles, selects flux surfaces, and writes an ``input.namelist`` plus ``payload.json`` under
+    each ``output_dir/runs/<run_subdir>`` directory, then records ``output_dir/manifest.json`` describing
+    the scan. Reuse detection is preserved: a surface whose namelist is byte-identical to the existing
+    one and whose ``result.json`` is usable is treated as already complete and is not returned as
+    pending.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments for the prepare phase.
+
+    Returns
+    -------
+    tuple[dict[str, Any], list[Path]]
+        The manifest dict (also written to ``manifest.json``) and the ``payload.json`` paths of surfaces
+        that still need to run. Pending-ness is in-memory only and is never stored in the manifest. Each
+        ``runs`` entry records only paths relative to ``output_dir`` so a host scheduler can rebuild real
+        paths under its own view of the output directory.
+    """
     config_path = Path(args.common_config).resolve()
     cfg = _load_toml(config_path)
     species = _parse_species_from_config(cfg)
@@ -974,10 +995,9 @@ def cmd_main(args: argparse.Namespace) -> int:
         "Nx": args.nx,
     }
 
-    task_payloads: list[Path] = []
     pending_task_payloads: list[Path] = []
-    reused_runs = 0
-    for radius_index in radius_indices:
+    manifest_runs: list[dict[str, Any]] = []
+    for position, radius_index in enumerate(radius_indices):
         rho_value = float(snapshot.rho[radius_index])
         run_name = f"rho_{radius_index:03d}_r{rho_value:.4f}".replace(".", "p")
         surface_dir = run_dir / run_name
@@ -1024,47 +1044,71 @@ def cmd_main(args: argparse.Namespace) -> int:
         payload_path = surface_dir / "payload.json"
         with payload_path.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2)
-        task_payloads.append(payload_path)
-        if can_reuse:
-            reused_runs += 1
-        else:
+        if not can_reuse:
             pending_task_payloads.append(payload_path)
-
-    backend = str(args.backend).lower()
-    gpu_ids = [token.strip() for token in str(args.gpu_ids).split(",") if token.strip()]
-    if backend == "gpu" and not gpu_ids:
-        gpu_ids = ["0"]
-
-    rho_min_val = float(np.min(snapshot.rho[radius_indices]))
-    rho_max_val = float(np.max(snapshot.rho[radius_indices]))
-    backend_note = f"backend={backend}"
-    parallel_note = f"max_parallel={int(args.max_parallel)}"
-    if backend == "gpu":
-        placement_note = f"gpu_ids={','.join(gpu_ids)}"
-    else:
-        placement_note = (
-            f"cores_per_run={int(args.cores_per_run)} "
-            f"worker_sharding={str(args.worker_sharding).lower()}"
-        )
-    print(
-        "[sfincs-scan] "
-        f"selected {len(radius_indices)} radii over rho in [{rho_min_val:.4f}, {rho_max_val:.4f}] "
-        f"({backend_note}, {parallel_note}, {placement_note})"
-    , flush=True)
-    if reused_runs:
-        print(
-            "[sfincs-scan] "
-            f"reusing {reused_runs}/{len(radius_indices)} existing completed runs; "
-            f"launching {len(pending_task_payloads)} new workers.",
-            flush=True,
+        manifest_runs.append(
+            {
+                "index": position,
+                "radius_index": int(radius_index),
+                "rho": rho_value,
+                "run_subdir": run_name,
+                "payload": "payload.json",
+                "result_json": "result.json",
+            }
         )
 
-    if pending_task_payloads:
-        _run_tasks_in_parallel(
-            task_payloads=pending_task_payloads,
-            args=args,
-            gpu_ids=gpu_ids,
-        )
+    manifest = {
+        "schema_version": 1,
+        "profiles_source": str(args.profiles_source),
+        "source_transport_solution": None if transport_solution is None else str(transport_solution),
+        "source_sfincs_template": str(template_path),
+        "time_index": int(args.time_index),
+        "time_value": None if snapshot.time_value is None else float(snapshot.time_value),
+        "include_phi1": args.include_phi1,
+        "backend": str(args.backend).lower(),
+        "max_parallel": int(args.max_parallel),
+        "worker_sharding": str(args.worker_sharding).lower(),
+        "benchmark_repeats": int(args.benchmark_repeats),
+        "benchmark_warmup": int(args.benchmark_warmup),
+        "species_meta": [
+            {"name": sp.name, "charge": sp.charge, "mass_mp": sp.mass_mp} for sp in species
+        ],
+        "wout_path": None if wout_path is None else str(wout_path),
+        "runs": manifest_runs,
+    }
+    manifest_path = output_dir / "manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+
+    return manifest, pending_task_payloads
+
+
+def _collect(args: argparse.Namespace, manifest: dict[str, Any]) -> int:
+    """Reduce per-surface worker results into the Stage 3 flux-profile HDF5.
+
+    Reads each surface's ``result.json`` (located relative to ``output_dir`` from the manifest run
+    entries), stacks the flux arrays, applies the magnetic-axis zero-padding, and writes
+    ``sfincs_jax_flux_profiles.h5``. Provenance attributes are taken from the manifest rather than live
+    arguments so this phase can run independently of the process that prepared the scan.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments; only ``output_dir`` and ``plot`` are consumed.
+    manifest : dict[str, Any]
+        The scan manifest produced by :func:`_prepare`.
+
+    Returns
+    -------
+    int
+        Process exit code (0 on success).
+    """
+    output_dir = Path(args.output_dir).resolve()
+    run_dir = output_dir / "runs"
+    species = [
+        SpeciesMeta(name=meta["name"], charge=meta["charge"], mass_mp=meta["mass_mp"])
+        for meta in manifest["species_meta"]
+    ]
 
     rho_out = []
     rhat_out = []
@@ -1073,9 +1117,13 @@ def cmd_main(args: argparse.Namespace) -> int:
     upar_out = []
     raw_meta = {"Gamma_key": None, "Q_key": None, "Upar_key": None}
     benchmark_rows: list[dict[str, Any]] = []
-    for payload_path in sorted(task_payloads, key=lambda p: json.loads(p.read_text(encoding="utf-8"))["rho"]):
-        payload = json.loads(payload_path.read_text(encoding="utf-8"))
-        result_json = Path(payload["result_json"])
+    for run in sorted(manifest["runs"], key=lambda r: r["rho"]):
+        result_json = run_dir / run["run_subdir"] / run["result_json"]
+        if not result_json.exists():
+            raise FileNotFoundError(
+                f"Missing sfincs_jax worker result for run {run['run_subdir']} at {result_json}. "
+                "Run the surface before collecting."
+            )
         summary = json.loads(result_json.read_text(encoding="utf-8"))
         rho_out.append(float(summary["rho"]))
         rhat_value = summary.get("rHat")
@@ -1110,6 +1158,8 @@ def cmd_main(args: argparse.Namespace) -> int:
         upar_arr = np.concatenate([zero_flux, upar_arr], axis=1)
         axis_padded = True
 
+    time_value = manifest["time_value"]
+    include_phi1 = manifest["include_phi1"]
     out_h5 = output_dir / "sfincs_jax_flux_profiles.h5"
     with h5py.File(out_h5, "w") as f:
         f.create_dataset("r", data=rhat_arr)
@@ -1119,15 +1169,17 @@ def cmd_main(args: argparse.Namespace) -> int:
         f.create_dataset("Q", data=q_arr)
         f.create_dataset("Upar", data=upar_arr)
         f.create_dataset("species_names", data=np.asarray([sp.name.encode("utf-8") for sp in species]))
-        f.attrs["profiles_source"] = str(args.profiles_source)
-        f.attrs["source_transport_solution"] = "" if transport_solution is None else str(transport_solution)
-        f.attrs["source_sfincs_template"] = str(template_path)
-        f.attrs["time_index"] = int(args.time_index)
-        f.attrs["time_value"] = np.nan if snapshot.time_value is None else float(snapshot.time_value)
-        f.attrs["backend"] = backend
-        f.attrs["max_parallel"] = int(args.max_parallel)
-        f.attrs["worker_sharding"] = str(args.worker_sharding).lower()
-        f.attrs["include_phi1"] = bool(args.include_phi1) if args.include_phi1 is not None else -1
+        f.attrs["profiles_source"] = str(manifest["profiles_source"])
+        f.attrs["source_transport_solution"] = (
+            "" if manifest["source_transport_solution"] is None else str(manifest["source_transport_solution"])
+        )
+        f.attrs["source_sfincs_template"] = str(manifest["source_sfincs_template"])
+        f.attrs["time_index"] = int(manifest["time_index"])
+        f.attrs["time_value"] = np.nan if time_value is None else float(time_value)
+        f.attrs["backend"] = str(manifest["backend"])
+        f.attrs["max_parallel"] = int(manifest["max_parallel"])
+        f.attrs["worker_sharding"] = str(manifest["worker_sharding"])
+        f.attrs["include_phi1"] = bool(include_phi1) if include_phi1 is not None else -1
         f.attrs["axis_zero_padded"] = bool(axis_padded)
         for key, value in raw_meta.items():
             if value is not None:
@@ -1191,16 +1243,87 @@ def cmd_main(args: argparse.Namespace) -> int:
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
-        description=(
-            __doc__
-            + "\n\n"
-            + "Unless overridden on the command line, this script forces the following "
-            + "sfincs_jax resolution settings (quickrun smoke test): "
-            + "Ntheta=5, Nzeta=11, Nxi=12, NL=3, Nx=4, solverTolerance=1e-6."
+def cmd_main(args: argparse.Namespace) -> int:
+    manifest, pending_task_payloads = _prepare(args)
+
+    backend = str(args.backend).lower()
+    gpu_ids = [token.strip() for token in str(args.gpu_ids).split(",") if token.strip()]
+    if backend == "gpu" and not gpu_ids:
+        gpu_ids = ["0"]
+
+    runs = manifest["runs"]
+    total_runs = len(runs)
+    reused_runs = total_runs - len(pending_task_payloads)
+    rho_values = [run["rho"] for run in runs]
+    rho_min_val = float(min(rho_values))
+    rho_max_val = float(max(rho_values))
+    backend_note = f"backend={backend}"
+    parallel_note = f"max_parallel={int(args.max_parallel)}"
+    if backend == "gpu":
+        placement_note = f"gpu_ids={','.join(gpu_ids)}"
+    else:
+        placement_note = (
+            f"cores_per_run={int(args.cores_per_run)} "
+            f"worker_sharding={str(args.worker_sharding).lower()}"
         )
+    print(
+        "[sfincs-scan] "
+        f"selected {total_runs} radii over rho in [{rho_min_val:.4f}, {rho_max_val:.4f}] "
+        f"({backend_note}, {parallel_note}, {placement_note})"
+    , flush=True)
+    if reused_runs:
+        print(
+            "[sfincs-scan] "
+            f"reusing {reused_runs}/{total_runs} existing completed runs; "
+            f"launching {len(pending_task_payloads)} new workers.",
+            flush=True,
+        )
+
+    if pending_task_payloads:
+        _run_tasks_in_parallel(
+            task_payloads=pending_task_payloads,
+            args=args,
+            gpu_ids=gpu_ids,
+        )
+
+    return _collect(args, manifest)
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    _prepare(args)
+    return 0
+
+
+def cmd_run_one(args: argparse.Namespace) -> int:
+    payload_path = Path(args.payload).resolve()
+    gpu_id = None
+    if str(args.backend).lower() == "gpu":
+        gpu_tokens = [token.strip() for token in str(args.gpu_ids).split(",") if token.strip()]
+        gpu_id = gpu_tokens[0] if gpu_tokens else "0"
+    env = _build_worker_env(args, gpu_id=gpu_id)
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "--worker-payload", str(payload_path)],
+        env=env,
     )
+    return proc.returncode
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.output_dir).resolve() / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"No manifest.json found at {manifest_path}. Run the prepare phase before collecting."
+        )
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    return _collect(args, manifest)
+
+
+def _add_output_dir(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Output directory for runs and collected fluxes.")
+
+
+def _add_io_and_shaping(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--common-config",
         default=str(DEFAULT_COMMON_CONFIG),
@@ -1228,7 +1351,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=str(DEFAULT_SFINCS_TEMPLATE),
         help="Template sfincs_jax input.namelist.",
     )
-    p.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Output directory for runs and collected fluxes.")
+    _add_output_dir(p)
     p.add_argument("--time-index", type=int, default=-1, help="Time index in transport_solution.h5. Default: final.")
     p.add_argument("--rho-indices", default=None, help="Comma-separated explicit rho indices.")
     p.add_argument("--rho-min", type=float, default=None, help="Minimum rho to include.")
@@ -1244,16 +1367,34 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--nl", type=int, default=3, help="Override NL. Default: 3.")
     p.add_argument("--nx", type=int, default=4, help="Override Nx. Default: 4.")
     p.add_argument("--solver-tolerance", type=float, default=1.0e-6, help="Override solverTolerance. Default: 1e-6.")
+
+
+def _add_dense_fp_max(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--dense-fp-max",
         type=int,
         default=None,
         help="Set SFINCS_JAX_RHSMODE1_DENSE_FP_MAX for worker processes.",
     )
+
+
+def _add_backend(p: argparse.ArgumentParser) -> None:
     p.add_argument("--backend", choices=("cpu", "gpu"), default="cpu", help="Parallel execution backend.")
+
+
+def _add_gpu_ids(p: argparse.ArgumentParser) -> None:
     p.add_argument("--gpu-ids", default="0", help="Comma-separated GPU ids for backend=gpu.")
+
+
+def _add_max_parallel(p: argparse.ArgumentParser) -> None:
     p.add_argument("--max-parallel", type=int, default=8, help="Maximum concurrent sfincs_jax runs.")
+
+
+def _add_cores_per_run(p: argparse.ArgumentParser) -> None:
     p.add_argument("--cores-per-run", type=int, default=1, help="CPU cores per run for backend=cpu.")
+
+
+def _add_worker_sharding(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--worker-sharding",
         choices=("off", "auto", "theta", "zeta", "x", "flat"),
@@ -1263,6 +1404,9 @@ def build_parser() -> argparse.ArgumentParser:
             "Default: off."
         ),
     )
+
+
+def _add_benchmark(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--benchmark-repeats",
         type=int,
@@ -1275,9 +1419,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Number of same-worker warmup solves to discard before benchmark repeats.",
     )
+
+
+def _add_plot(p: argparse.ArgumentParser) -> None:
     p.add_argument("--plot", dest="plot", action="store_true", help="Write PNG plots of Gamma, Q, and Upar versus rho.")
     p.add_argument("--no-plot", dest="plot", action="store_false", help="Skip PNG plots.")
     p.set_defaults(plot=True)
+
+
+def _add_verbose_workers(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--verbose-workers",
         dest="verbose_workers",
@@ -1291,7 +1441,60 @@ def build_parser() -> argparse.ArgumentParser:
         help="Silence sfincs_jax worker logging.",
     )
     p.set_defaults(verbose_workers=True)
+
+
+def _add_worker_payload(p: argparse.ArgumentParser) -> None:
     p.add_argument("--worker-payload", default=None, help=argparse.SUPPRESS)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            __doc__
+            + "\n\n"
+            + "Unless overridden on the command line, this script forces the following "
+            + "sfincs_jax resolution settings (quickrun smoke test): "
+            + "Ntheta=5, Nzeta=11, Nxi=12, NL=3, Nx=4, solverTolerance=1e-6."
+        )
+    )
+    _add_io_and_shaping(p)
+    _add_dense_fp_max(p)
+    _add_backend(p)
+    _add_gpu_ids(p)
+    _add_max_parallel(p)
+    _add_cores_per_run(p)
+    _add_worker_sharding(p)
+    _add_benchmark(p)
+    _add_plot(p)
+    _add_verbose_workers(p)
+    _add_worker_payload(p)
+    p.set_defaults(func=cmd_main)
+
+    sub = p.add_subparsers(dest="command", required=False)
+
+    prepare = sub.add_parser("prepare", help="Write per-surface sfincs_jax inputs and the scan manifest.")
+    _add_io_and_shaping(prepare)
+    _add_backend(prepare)
+    _add_max_parallel(prepare)
+    _add_worker_sharding(prepare)
+    _add_benchmark(prepare)
+    _add_verbose_workers(prepare)
+    prepare.set_defaults(func=cmd_prepare)
+
+    run_one = sub.add_parser("run-one", help=argparse.SUPPRESS)
+    run_one.add_argument("--payload", required=True, help="Path to a per-surface payload.json to execute.")
+    _add_dense_fp_max(run_one)
+    _add_backend(run_one)
+    _add_gpu_ids(run_one)
+    _add_cores_per_run(run_one)
+    _add_worker_sharding(run_one)
+    run_one.set_defaults(func=cmd_run_one)
+
+    collect = sub.add_parser("collect", help="Reduce per-surface results into the flux-profile HDF5.")
+    _add_output_dir(collect)
+    _add_plot(collect)
+    collect.set_defaults(func=cmd_collect)
+
     return p
 
 
@@ -1299,7 +1502,7 @@ def main() -> int:
     args = build_parser().parse_args()
     if args.worker_payload:
         return _run_single_worker_from_payload(Path(args.worker_payload).resolve())
-    return cmd_main(args)
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/stages/stage4-turbulence/spectrax_gk_radial_scan.py
+++ b/stages/stage4-turbulence/spectrax_gk_radial_scan.py
@@ -1119,10 +1119,16 @@ def cmd_run_one(args: argparse.Namespace) -> int:
     )
     # When the parallel launcher starts this worker it exports the backend selectors into the
     # environment already, so --backend is omitted and the inherited variables are left untouched.
-    # A direct invocation with --backend configures those selectors here instead.
+    # A direct invocation with --backend configures those selectors here instead. --gpu-ids may
+    # carry a comma-separated list; a single surface consumes a single device, so only the first
+    # id is pinned and the rest are ignored.
     backend = getattr(args, "backend", None)
     if backend is not None:
-        _apply_backend_env(env, backend, getattr(args, "gpu_id", None), getattr(args, "threads_per_run", None))
+        gpu_id = None
+        if str(backend).lower() == "gpu":
+            gpu_tokens = [token.strip() for token in str(getattr(args, "gpu_ids", None) or "").split(",") if token.strip()]
+            gpu_id = gpu_tokens[0] if gpu_tokens else None
+        _apply_backend_env(env, backend, gpu_id, getattr(args, "threads_per_run", None))
     cmd = [
         sys.executable,
         "-m",
@@ -2069,7 +2075,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_one.add_argument("--run-name", default=None, help="Per-surface run_dir basename to execute instead of --index")
     run_one.add_argument("--verbose-worker", action="store_true")
     run_one.add_argument("--backend", choices=("cpu", "gpu"), default=None)
-    run_one.add_argument("--gpu-id", default=None)
+    run_one.add_argument("--gpu-ids", default=None, help="Comma-separated GPU ids; the worker pins the first one.")
     run_one.add_argument("--threads-per-run", type=int, default=None)
     run_one.set_defaults(func=cmd_run_one)
     return p

--- a/stages/stage4-turbulence/spectrax_gk_radial_scan.py
+++ b/stages/stage4-turbulence/spectrax_gk_radial_scan.py
@@ -964,6 +964,11 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     common_config = Path(args.common_config).resolve()
     spectrax_root = Path(args.spectrax_root).resolve()
     output_dir = Path(args.output_dir).resolve()
+    # Anchor a relative --spectrax-template at the invocation CWD like every other CLI path
+    # argument; the template resolver downstream would otherwise anchor it at the
+    # common-config directory and mangle CWD-relative values.
+    if args.spectrax_template:
+        args.spectrax_template = str(Path(args.spectrax_template).resolve())
 
     cfg = _load_toml(common_config)
     species = _parse_species_from_common_config(cfg)
@@ -1042,9 +1047,47 @@ def _has_completed_output(run_spec: dict[str, Any]) -> bool:
     return bool(times.size > 0)
 
 
+def _apply_backend_env(
+    env: dict[str, str],
+    backend: str,
+    gpu_id: int | str | None,
+    threads_per_run: int | None,
+) -> dict[str, str]:
+    # SPECTRAX workers pick their JAX device and thread count from these variables. The parallel
+    # launcher and the single-run worker both route through here so a CPU/GPU slot is configured the
+    # same way no matter which path started the run. A missing GPU id maps to device 0 and a missing
+    # CPU thread count maps to a single thread, matching the launcher's per-slot defaults.
+    mode = str(backend).lower()
+    if mode == "gpu":
+        env["CUDA_VISIBLE_DEVICES"] = str(0 if gpu_id is None else gpu_id)
+        env["JAX_PLATFORM_NAME"] = "gpu"
+        env["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+    else:
+        env["JAX_PLATFORM_NAME"] = "cpu"
+        env["OMP_NUM_THREADS"] = str(1 if threads_per_run is None else int(threads_per_run))
+    return env
+
+
+def _resolve_run_spec(manifest: dict[str, Any], *, index: int | None, run_name: str | None) -> dict[str, Any]:
+    # A per-surface run can be selected either by its manifest ordinal or by its directory name, where
+    # the name is the basename of run_dir (the rho_{idx}_r{value} surface folder). Exactly one selector
+    # must be supplied so the worker targets a single, unambiguous surface.
+    if (index is None) == (run_name is None):
+        raise ValueError("run-one requires exactly one of --index or --run-name")
+    runs = manifest["runs"]
+    if index is not None:
+        return runs[int(index)]
+    matches = [run for run in runs if os.path.basename(str(run["run_dir"])) == run_name]
+    if len(matches) != 1:
+        raise ValueError(
+            f"--run-name {run_name!r} matched {len(matches)} runs in the manifest; expected exactly one"
+        )
+    return matches[0]
+
+
 def cmd_run_one(args: argparse.Namespace) -> int:
     manifest = _load_manifest(Path(args.manifest).resolve())
-    run_spec = manifest["runs"][int(args.index)]
+    run_spec = _resolve_run_spec(manifest, index=args.index, run_name=getattr(args, "run_name", None))
     if _has_completed_output(run_spec):
         diag_csv = _diagnostics_csv_path(run_spec)
         row = _read_last_row_csv(diag_csv)
@@ -1074,6 +1117,12 @@ def cmd_run_one(args: argparse.Namespace) -> int:
     env["PYTHONPATH"] = (
         str(src_path) if not existing_pythonpath else os.pathsep.join([str(src_path), existing_pythonpath])
     )
+    # When the parallel launcher starts this worker it exports the backend selectors into the
+    # environment already, so --backend is omitted and the inherited variables are left untouched.
+    # A direct invocation with --backend configures those selectors here instead.
+    backend = getattr(args, "backend", None)
+    if backend is not None:
+        _apply_backend_env(env, backend, getattr(args, "gpu_id", None), getattr(args, "threads_per_run", None))
     cmd = [
         sys.executable,
         "-m",
@@ -1200,13 +1249,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         env = {
             "PYTHONPATH": str((Path(manifest["spectrax_root"]) / "src").resolve()),
         }
-        if mode == "gpu":
-            env["CUDA_VISIBLE_DEVICES"] = str(gpu_ids[slot % len(gpu_ids)])
-            env["JAX_PLATFORM_NAME"] = "gpu"
-            env["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
-        else:
-            env["JAX_PLATFORM_NAME"] = "cpu"
-            env["OMP_NUM_THREADS"] = str(int(args.threads_per_run))
+        gpu_id = gpu_ids[slot % len(gpu_ids)] if mode == "gpu" else None
+        _apply_backend_env(env, mode, gpu_id, args.threads_per_run)
         return env
 
     while pending or active:
@@ -1855,121 +1899,150 @@ def cmd_all(args: argparse.Namespace) -> int:
     return collect_rc
 
 
-def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument(
+def _add_common_io_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
         "--common-config",
         default=str(DEFAULT_COMMON_CONFIG),
         help="Path to the shared common_input TOML.",
     )
-    p.add_argument("--neopax-result", default=None, help="Optional explicit path to transport_solution.h5")
-    p.add_argument(
+    parser.add_argument("--neopax-result", default=None, help="Optional explicit path to transport_solution.h5")
+    parser.add_argument(
         "--output-dir",
         default=str(DEFAULT_OUTPUT_DIR),
         help="Directory for manifest, SPECTRAX outputs, and collected fluxes",
     )
-    p.add_argument("--spectrax-root", default=str(DEFAULT_SPECTRAX_ROOT))
-    p.add_argument(
+    parser.add_argument("--spectrax-root", default=str(DEFAULT_SPECTRAX_ROOT))
+    parser.add_argument(
         "--spectrax-template",
         default=str(DEFAULT_SPECTRAX_TEMPLATE),
         help="Base SPECTRAX runtime TOML used as the model template",
     )
-    p.add_argument("--profiles-source", choices=("transport_h5", "analytical"), default="analytical")
-    p.add_argument("--time-index", type=int, default=-1)
-    p.add_argument("--analytical-n-radii", type=int, default=None, help="Number of analytical rho points; defaults to [geometry].n_radial from the NEOPAX config")
-    p.add_argument("--electron-model", choices=("adiabatic", "kinetic"), default=None)
-    p.add_argument("--reference-ion", default=None)
-    p.add_argument("--rho-indices", default=None)
-    p.add_argument("--rho-min", type=float, default=0.0)
-    p.add_argument("--rho-max", type=float, default=1.0)
-    p.add_argument("--num-radii", type=int, default=-1, help="Number of radii to sample; use <=0 for all available nonzero radii")
-    p.add_argument("--vmec-file-override", default=None)
-    p.add_argument("--boozer-file-override", default=None)
-    p.add_argument("--density-floor", type=float, default=1.0e-8)
-    p.add_argument("--temperature-floor", type=float, default=1.0e-8)
-    p.add_argument("--gradient-coordinate", choices=("rho", "torflux", "rho_with_scale"), default="rho")
-    p.add_argument("--gradient-scale", type=float, default=1.0)
-    p.add_argument("--tprim-scale", type=float, default=1.0)
-    p.add_argument("--fprim-scale", type=float, default=1.0)
-    p.add_argument("--tau-e-override", type=float, default=None)
-    p.add_argument("--nu-ion", type=float, default=0.01)
-    p.add_argument("--nu-electron", type=float, default=0.0)
-    p.add_argument("--nx", type=int, default=12, help="Nonlinear spectral resolution in kx / x")
-    p.add_argument("--ny", type=int, default=12, help="Nonlinear spectral resolution in ky / y")
-    p.add_argument("--nz", type=int, default=None, help="Parallel/grid resolution in z")
-    p.add_argument("--lx", type=float, default=None)
-    p.add_argument("--ly", type=float, default=None)
-    p.add_argument("--boundary", default=None)
-    p.add_argument("--y0", type=float, default=None)
-    p.add_argument("--ntheta", type=int, default=30, help="Number of theta points for generated VMEC geometry")
-    p.add_argument("--nperiod", type=int, default=None)
-    p.add_argument("--t-max", type=float, default=10.0)
-    p.add_argument("--t-final", dest="t_max", type=float, help="Alias for --t-max")
-    p.add_argument("--dt", type=float, default=None)
-    p.add_argument("--method", default=None)
-    p.add_argument("--use-diffrax", action=argparse.BooleanOptionalAction, default=None)
-    p.add_argument("--fixed-dt", action=argparse.BooleanOptionalAction, default=None)
-    p.add_argument("--sample-stride", type=int, default=50)
-    p.add_argument("--diagnostics-stride", type=int, default=1)
-    p.add_argument("--chunk-steps", type=int, default=None, help="Adaptive nonlinear chunk size in steps for each SPECTRAX run")
-    p.add_argument("--cfl", type=float, default=None)
-    p.add_argument("--state-sharding", default=None)
-    p.add_argument("--ky", type=float, default=None, help="Default nonlinear reference ky retained unless overridden")
-    p.add_argument("--nl", type=int, default=None)
-    p.add_argument("--nm", type=int, default=None)
-    p.add_argument("--init-field", default=None)
-    p.add_argument("--init-amp", type=float, default=None)
-    p.add_argument("--alpha", type=float, default=None, help="Field-line label alpha for the local geometry")
-    p.add_argument("--npol", type=float, default=None)
-    p.add_argument("--beta", type=float, default=None)
-    p.add_argument("--nu-hermite", type=float, default=None)
-    p.add_argument("--nu-laguerre", type=float, default=None)
-    p.add_argument("--nu-hyper", type=float, default=None)
-    p.add_argument("--p-hyper", type=float, default=None)
-    p.add_argument("--hypercollisions-const", type=float, default=None)
-    p.add_argument("--hypercollisions-kz", type=float, default=None)
-    p.add_argument("--d-hyper", type=float, default=None)
-    p.add_argument("--damp-ends-amp", type=float, default=None)
-    p.add_argument("--damp-ends-widthfrac", type=float, default=None)
-    p.add_argument("--hyperdiffusion", type=float, default=None)
-    p.add_argument("--normalization-contract", default=None)
-    p.add_argument("--diagnostic-norm", default=None)
-    p.add_argument("--rho-star-physical", type=float, default=None, help="Optional manual rho_star override; otherwise derive it per radius from VMEC geometry and the reference-ion profile")
-    p.add_argument("--average-window", type=float, default=1.0, help="Average turbulent fluxes over the final time window")
-    p.add_argument("--plot", dest="plot", action="store_true", help="Write PNG plots of Gamma and Q versus rho.")
-    p.add_argument("--no-plot", dest="plot", action="store_false", help="Skip PNG plots.")
-    p.set_defaults(plot=True)
-    p.add_argument(
+
+
+def _add_prepare_shaping_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--profiles-source", choices=("transport_h5", "analytical"), default="analytical")
+    parser.add_argument("--time-index", type=int, default=-1)
+    parser.add_argument("--analytical-n-radii", type=int, default=None, help="Number of analytical rho points; defaults to [geometry].n_radial from the NEOPAX config")
+    parser.add_argument("--electron-model", choices=("adiabatic", "kinetic"), default=None)
+    parser.add_argument("--reference-ion", default=None)
+    parser.add_argument("--rho-indices", default=None)
+    parser.add_argument("--rho-min", type=float, default=0.0)
+    parser.add_argument("--rho-max", type=float, default=1.0)
+    parser.add_argument("--num-radii", type=int, default=-1, help="Number of radii to sample; use <=0 for all available nonzero radii")
+    parser.add_argument("--vmec-file-override", default=None)
+    parser.add_argument("--boozer-file-override", default=None)
+    parser.add_argument("--density-floor", type=float, default=1.0e-8)
+    parser.add_argument("--temperature-floor", type=float, default=1.0e-8)
+    parser.add_argument("--gradient-coordinate", choices=("rho", "torflux", "rho_with_scale"), default="rho")
+    parser.add_argument("--gradient-scale", type=float, default=1.0)
+    parser.add_argument("--tprim-scale", type=float, default=1.0)
+    parser.add_argument("--fprim-scale", type=float, default=1.0)
+    parser.add_argument("--tau-e-override", type=float, default=None)
+    parser.add_argument("--nu-ion", type=float, default=0.01)
+    parser.add_argument("--nu-electron", type=float, default=0.0)
+    parser.add_argument("--nx", type=int, default=12, help="Nonlinear spectral resolution in kx / x")
+    parser.add_argument("--ny", type=int, default=12, help="Nonlinear spectral resolution in ky / y")
+    parser.add_argument("--nz", type=int, default=None, help="Parallel/grid resolution in z")
+    parser.add_argument("--lx", type=float, default=None)
+    parser.add_argument("--ly", type=float, default=None)
+    parser.add_argument("--boundary", default=None)
+    parser.add_argument("--y0", type=float, default=None)
+    parser.add_argument("--ntheta", type=int, default=30, help="Number of theta points for generated VMEC geometry")
+    parser.add_argument("--nperiod", type=int, default=None)
+    parser.add_argument("--t-max", type=float, default=10.0)
+    parser.add_argument("--t-final", dest="t_max", type=float, help="Alias for --t-max")
+    parser.add_argument("--dt", type=float, default=None)
+    parser.add_argument("--method", default=None)
+    parser.add_argument("--use-diffrax", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--fixed-dt", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--sample-stride", type=int, default=50)
+    parser.add_argument("--diagnostics-stride", type=int, default=1)
+    parser.add_argument("--chunk-steps", type=int, default=None, help="Adaptive nonlinear chunk size in steps for each SPECTRAX run")
+    parser.add_argument("--cfl", type=float, default=None)
+    parser.add_argument("--state-sharding", default=None)
+    parser.add_argument("--ky", type=float, default=None, help="Default nonlinear reference ky retained unless overridden")
+    parser.add_argument("--nl", type=int, default=None)
+    parser.add_argument("--nm", type=int, default=None)
+    parser.add_argument("--init-field", default=None)
+    parser.add_argument("--init-amp", type=float, default=None)
+    parser.add_argument("--alpha", type=float, default=None, help="Field-line label alpha for the local geometry")
+    parser.add_argument("--npol", type=float, default=None)
+    parser.add_argument("--beta", type=float, default=None)
+    parser.add_argument("--nu-hermite", type=float, default=None)
+    parser.add_argument("--nu-laguerre", type=float, default=None)
+    parser.add_argument("--nu-hyper", type=float, default=None)
+    parser.add_argument("--p-hyper", type=float, default=None)
+    parser.add_argument("--hypercollisions-const", type=float, default=None)
+    parser.add_argument("--hypercollisions-kz", type=float, default=None)
+    parser.add_argument("--d-hyper", type=float, default=None)
+    parser.add_argument("--damp-ends-amp", type=float, default=None)
+    parser.add_argument("--damp-ends-widthfrac", type=float, default=None)
+    parser.add_argument("--hyperdiffusion", type=float, default=None)
+    parser.add_argument("--normalization-contract", default=None)
+    parser.add_argument("--diagnostic-norm", default=None)
+    parser.add_argument("--rho-star-physical", type=float, default=None, help="Optional manual rho_star override; otherwise derive it per radius from VMEC geometry and the reference-ion profile")
+
+
+def _add_collect_tuning_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--average-window", type=float, default=1.0, help="Average turbulent fluxes over the final time window")
+    parser.add_argument("--plot", dest="plot", action="store_true", help="Write PNG plots of Gamma and Q versus rho.")
+    parser.add_argument("--no-plot", dest="plot", action="store_false", help="Skip PNG plots.")
+    parser.set_defaults(plot=True)
+    parser.add_argument(
         "--plot-run-heat-traces",
         dest="plot_run_heat_traces",
         action="store_true",
         help="Write per-run heat-flux time-trace PNGs from existing diagnostics CSV files.",
     )
-    p.add_argument(
+    parser.add_argument(
         "--no-plot-run-heat-traces",
         dest="plot_run_heat_traces",
         action="store_false",
         help="Skip per-run heat-flux time-trace PNGs.",
     )
-    p.set_defaults(plot_run_heat_traces=True)
-    p.add_argument("--backend", choices=("cpu", "gpu"), default="cpu")
-    p.add_argument("--gpu-ids", default="0")
-    p.add_argument("--max-parallel", type=int, default=1)
-    p.add_argument("--threads-per-run", type=int, default=1)
-    p.add_argument("--poll-interval", type=float, default=2.0)
-    p.add_argument(
+    parser.set_defaults(plot_run_heat_traces=True)
+
+
+def _add_collect_io_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--manifest", required=True, help="Path to the prepare-stage manifest.json")
+    parser.add_argument("--out", required=True, help="Destination flux_summary.h5 path")
+    parser.add_argument("--neopax-flux-out", required=True, help="Destination neopax_fluxes.h5 path")
+    parser.add_argument(
+        "--t-final",
+        dest="t_final",
+        type=float,
+        default=None,
+        help="Final time to average up to; falls back to the manifest t_max",
+    )
+
+
+def _add_run_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--backend", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--gpu-ids", default="0")
+    parser.add_argument("--max-parallel", type=int, default=1)
+    parser.add_argument("--threads-per-run", type=int, default=1)
+    parser.add_argument("--poll-interval", type=float, default=2.0)
+    parser.add_argument(
         "--verbose-workers",
         dest="verbose_workers",
         action="store_true",
         help="Show the stdout/stderr from each SPECTRAX worker run",
     )
-    p.add_argument(
+    parser.add_argument(
         "--no-verbose-workers",
         dest="verbose_workers",
         action="store_false",
         help="Silence SPECTRAX worker stdout/stderr.",
     )
-    p.set_defaults(verbose_workers=True)
+    parser.set_defaults(verbose_workers=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    _add_common_io_args(p)
+    _add_prepare_shaping_args(p)
+    _add_collect_tuning_args(p)
+    _add_run_args(p)
     p.add_argument(
         "--collect-even-if-failures",
         action=argparse.BooleanOptionalAction,
@@ -1979,10 +2052,25 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_all)
 
     sub = p.add_subparsers(dest="cmd", required=False)
+
+    prepare = sub.add_parser("prepare", help="Build the per-radius manifest and SPECTRAX runtime TOMLs.")
+    _add_common_io_args(prepare)
+    _add_prepare_shaping_args(prepare)
+    prepare.set_defaults(func=cmd_prepare)
+
+    collect = sub.add_parser("collect", help="Reduce per-radius diagnostics into NEOPAX-unit flux HDF5 files.")
+    _add_collect_io_args(collect)
+    _add_collect_tuning_args(collect)
+    collect.set_defaults(func=cmd_collect)
+
     run_one = sub.add_parser("run-one", help=argparse.SUPPRESS)
     run_one.add_argument("--manifest", required=True)
-    run_one.add_argument("--index", required=True, type=int)
+    run_one.add_argument("--index", type=int, default=None)
+    run_one.add_argument("--run-name", default=None, help="Per-surface run_dir basename to execute instead of --index")
     run_one.add_argument("--verbose-worker", action="store_true")
+    run_one.add_argument("--backend", choices=("cpu", "gpu"), default=None)
+    run_one.add_argument("--gpu-id", default=None)
+    run_one.add_argument("--threads-per-run", type=int, default=None)
     run_one.set_defaults(func=cmd_run_one)
     return p
 

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -3,6 +3,11 @@
 ``snakemake -n`` parses the Snakefile and plans the job graph without running any
 container, so it catches wiring and parse-time errors with no Docker.
 
+Stages 3 and 4 fan out one job per flux surface behind ``prepare`` checkpoints, so
+a dry-run plans only up to each checkpoint plus the deferred ``collect`` gathers;
+the per-surface ``run_one`` layer enters the DAG only after a real ``prepare``
+writes its manifest.
+
 Overriding ``output_dir`` to a tmp dir keeps the Snakefile's parse-time
 ``prepare_neopax_config`` write, and every planned artifact path, out of the repo,
 and ``--runtime-source-cache-path`` keeps Snakemake's own runtime source cache under
@@ -22,7 +27,18 @@ import yaml
 from src.utils import resolve_pipeline_paths
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-FORWARD_RULES = ("stage1_vmec", "stage2_boozer", "stage3_sfincs", "stage4_spectrax", "stage5_neopax")
+FORWARD_RULES = (
+    "stage1_vmec",
+    "stage2_boozer",
+    "stage3_prepare",
+    "stage3_collect",
+    "stage4_prepare",
+    "stage4_collect",
+    "stage5_neopax",
+)
+# The per-surface run_one rules are gated behind the prepare checkpoints, so a plan built
+# before any manifest exists must not schedule them.
+DEFERRED_RULES = ("stage3_run_one", "stage4_run_one")
 
 
 def _dry_run(tmp_path: Path, targets: list[str], config_overrides: list[str]) -> subprocess.CompletedProcess:
@@ -39,9 +55,10 @@ def _dry_run(tmp_path: Path, targets: list[str], config_overrides: list[str]) ->
     )
 
 
-# This runs the default forward pass and asserts it plans successfully (exit code 0), that all five stage rules are
-# scheduled, and that the post-processing rule is NOT scheduled, because the default target is a pure forward pass with
-# no loop-closing step. This catches Snakefile wiring/parse errors without Docker.
+# This runs the default forward pass and asserts it plans successfully (exit code 0), that every stage rule visible
+# before the checkpoints run is scheduled (including both deferred collect gathers), and that the post-processing rule
+# is NOT scheduled, because the default target is a pure forward pass with no loop-closing step. This catches Snakefile
+# wiring/parse errors without Docker.
 def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
     result = _dry_run(tmp_path, targets=[], config_overrides=[])
     output = result.stdout + result.stderr
@@ -49,6 +66,11 @@ def test_forward_pass_dag_dry_run(tmp_path: Path) -> None:
     for rule in FORWARD_RULES:
         assert rule in output, f"rule {rule} not scheduled:\n{output}"
     assert "stage5_post_processing" not in output  # rule all is a pure forward pass
+    # Dry-run visibility ends at the unexecuted prepare checkpoints: the per-surface jobs
+    # must be absent and Snakemake must announce that the DAG grows after the checkpoints.
+    for rule in DEFERRED_RULES:
+        assert rule not in output, f"per-surface rule {rule} planned before its checkpoint ran:\n{output}"
+    assert "checkpoint jobs" in output, output
 
 
 # When you explicitly ask Snakemake to build the convergence-signal file (the loop-closing target), the post-processing

--- a/tests/orchestration/test_paths.py
+++ b/tests/orchestration/test_paths.py
@@ -30,6 +30,8 @@ EXPECTED_KEYS = {
     "stage4_dir",
     "stage5_dir",
     "stage5_post_dir",
+    "stage3_manifest",
+    "stage4_manifest",
     "s5_resolved_config",
     "s1_feedback",
 }
@@ -53,10 +55,12 @@ def test_quick_run_paths_match_contract(paths: dict) -> None:
     assert paths["s5_signal"] == "outputs/quick_run/stage5_post_processing/converge_status.json"
 
 
-# Pins the two paths that are derived for generated artifacts rather than user inputs: the path-resolved NEOPAX config
-# copy, and the evolved Stage 1 boundary the closed loop feeds back. Both must land under the output tree, not the input
-# tree.
+# Pins the paths that are derived for generated artifacts rather than user inputs: the Stage 3/4 per-surface scan
+# manifests, the path-resolved NEOPAX config copy, and the evolved Stage 1 boundary the closed loop feeds back. All must
+# land under the output tree, not the input tree.
 def test_quick_run_generated_paths(paths: dict) -> None:
+    assert paths["stage3_manifest"] == "outputs/quick_run/stage3_neoclassical/manifest.json"
+    assert paths["stage4_manifest"] == "outputs/quick_run/stage4_turbulence/manifest.json"
     assert paths["s5_resolved_config"] == "outputs/quick_run/stage5_transport/common_input_updated.toml"
     # The evolved Stage 1 boundary the loop feeds back lives under the post-processing dir.
     assert paths["s1_feedback"] == "outputs/quick_run/stage5_post_processing/vmec_input.HSX_vacuum_ns201_quickrun"

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -1,20 +1,24 @@
-"""Tests for ``src.stage3_helper.radial_scan_cmd``.
+"""Tests for the ``src.stage3_helper`` per-phase command composers.
 
-``radial_scan_cmd`` turns the ``stage3.sfincs_jax`` config block into the single
-shell command that the Snakefile's ``rule stage3_sfincs`` runs. The exact string
-it builds is the contract with that rule, so this pins it: the static base flags
-(including the literal ``{input.*}`` placeholders Snakemake substitutes at run
-time), the not-None-only optional flags, the tri-state booleans, and the
-gpu-only ``--gpu-ids`` flag.
+``prepare_cmd``, ``run_one_cmd``, and ``collect_cmd`` turn the ``stage3.sfincs_jax``
+config block into the three shell commands that the Snakefile's per-phase Stage 3
+rules run. The exact strings are the contract with those rules, so this pins them:
+the static base flags (including the literal ``{input.*}`` and ``{wildcards.surf}``
+placeholders Snakemake substitutes at run time), the not-None-only optional flags
+on ``prepare``, the tri-state booleans, the gpu-only ``--gpu-ids`` flag on
+``run-one``, and the absence of scan-level parallelism flags now that surface
+concurrency belongs to ``snakemake --cores``.
 """
 
 from __future__ import annotations
 
+import argparse
 import re
+from collections.abc import Callable
 
 import pytest
 
-from src.stage3_helper import radial_scan_cmd
+from src.stage3_helper import collect_cmd, prepare_cmd, run_one_cmd
 from tests.helpers.stage_import import load_stage_module
 
 _STAGE3_SCRIPT = "stages/stage3-neoclassical/sfincs_jax_radial_scan.py"
@@ -23,8 +27,34 @@ _STAGE3_SCRIPT = "stages/stage3-neoclassical/sfincs_jax_radial_scan.py"
 _PLACEHOLDER = re.compile(r"\{(?:input|output)\.[A-Za-z0-9_]+\}")
 _scan = load_stage_module(_STAGE3_SCRIPT)
 
+# Every prepare-phase optional key with a quick-run-like value, used both to exercise
+# each flag individually and to prove that a fully-populated config never leaks
+# scan-level parallelism flags. max_parallel is a retired key that older configs may
+# still carry; it must be ignored by every composer.
+_PREPARE_OPTIONALS: list[tuple[str, str, object]] = [
+    ("profiles_source",    "--profiles-source",    "analytical"),
+    ("neopax_result",      "--neopax-result",      "outputs/quick_run/stage5_transport/transport_solution.h5"),
+    ("ntheta",             "--ntheta",             5),
+    ("nzeta",              "--nzeta",              11),
+    ("nxi",                "--nxi",                12),
+    ("nx",                 "--nx",                 4),
+    ("solver_tolerance",   "--solver-tolerance",   1e-06),
+    ("analytical_n_radii", "--analytical-n-radii", 51),
+    ("rho_indices",        "--rho-indices",        "1,5,10"),
+    ("rho_min",            "--rho-min",            0.1),
+    ("rho_max",            "--rho-max",            0.9),
+    ("num_radii",          "--num-radii",          4),
+]
 
-def cmd(**overrides) -> str:
+_FULL_CFG: dict = {key: value for key, _, value in _PREPARE_OPTIONALS} | {
+    "gpu_ids": "0,1",
+    "plot": False,
+    "verbose_workers": True,
+    "max_parallel": 8,
+}
+
+
+def compose(composer: Callable[..., str], **overrides) -> str:
     """Build a command with quick-run-like defaults, overriding only what a test varies."""
     base = dict(
         docker_prefix="docker run --rm",
@@ -34,19 +64,30 @@ def cmd(**overrides) -> str:
         device="cpu",
     )
     base.update(overrides)
-    return radial_scan_cmd(**base)
+    return composer(**base)
 
 
-# `radial_scan_cmd` builds the shell command the Snakefile runs for Stage 3. With an empty config and cpu device, it
-# should emit just the fixed base command. This pins that exact string, including the literal `{input.*}` placeholders
-# that Snakemake fills in with real file paths at run time.
-def test_base_command_with_empty_config() -> None:
-    # Empty config + cpu emits exactly the static base parts; this equality also
-    # pins the literal {input.*} placeholders, which must survive verbatim so
-    # Snakemake can substitute them at rule-execution time.
-    assert cmd() == (
+def parse_with_stage_script(command: str) -> argparse.Namespace:
+    """Feed a composed command's argv into the real stage script parser and return the namespace.
+
+    Fails the test if argparse rejects any flag (argparse exits via ``sys.exit(2)``).
+    """
+    concrete = _PLACEHOLDER.sub("placeholder_path", command).replace("{wildcards.surf}", "rho_001_r0p1000")
+    tokens = concrete.split()
+    argv = tokens[tokens.index(_STAGE3_SCRIPT) + 1:]
+    try:
+        return _scan.build_parser().parse_args(argv)
+    except SystemExit as exc:
+        pytest.fail(f"stage script parser rejected a composer-emitted flag: argv={argv} (exit {exc.code})")
+
+
+# `prepare_cmd` builds the shell command that writes per-surface payloads and the scan manifest. With an empty config
+# and cpu device it should emit just the fixed base command. This pins that exact string, including the `prepare`
+# subcommand token and the literal `{input.*}` placeholders that Snakemake fills in with real file paths at run time.
+def test_prepare_base_command_with_empty_config() -> None:
+    assert compose(prepare_cmd) == (
         "docker run --rm ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu "
-        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py "
+        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py prepare "
         "--common-config {input.common_config} "
         "--sfincs-template {input.config_file} "
         "--wout-path {input.wout} "
@@ -55,62 +96,101 @@ def test_base_command_with_empty_config() -> None:
     )
 
 
-def test_only_non_none_optionals_appear() -> None:
-    out = cmd(stage_cfg={"ntheta": 31, "nx": 64, "nzeta": None})
-    assert "--ntheta 31" in out
-    assert "--nx 64" in out
-    assert "--nzeta" not in out             # explicit None -> omitted
-    assert "--profiles-source" not in out   # absent key -> omitted
+# `run_one_cmd` builds the per-surface worker command. This pins the exact string: the payload path is derived from the
+# output dir plus the literal `{wildcards.surf}` placeholder (Snakemake substitutes the surface's run-directory name at
+# rule-execution time), and nothing beyond the payload and backend is emitted with an empty config.
+def test_run_one_base_command_with_empty_config() -> None:
+    assert compose(run_one_cmd) == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu "
+        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py run-one "
+        "--payload outputs/quick_run/stage3_neoclassical/runs/{wildcards.surf}/payload.json "
+        "--backend cpu"
+    )
 
 
-# Boolean toggles are tri-state: True emits `--flag`, False emits `--no-flag`, and an absent key emits neither.
-# Parametrized over two such toggles, this checks all three cases. It splits the command into tokens and checks
-# membership so, e.g., `--plot` isn't falsely "found" inside `--no-plot`.
-@pytest.mark.parametrize(
-    "key, on, off",
-    [
-        ("plot", "--plot", "--no-plot"),
-        ("verbose_workers", "--verbose-workers", "--no-verbose-workers"),
-    ],
-)
-def test_tristate_bools(key: str, on: str, off: str) -> None:
-    # Token membership (not substring) so --plot does not match inside --no-plot.
-    assert on in cmd(stage_cfg={key: True}).split()
-    assert off in cmd(stage_cfg={key: False}).split()
-    absent = cmd(stage_cfg={}).split()
-    assert on not in absent and off not in absent
+# `collect_cmd` builds the reduction command that folds per-surface results into the flux-profile HDF5. With an empty
+# config it should emit only the `collect` subcommand and the output dir; no backend flag exists on the reduction step.
+def test_collect_base_command_with_empty_config() -> None:
+    assert compose(collect_cmd) == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu "
+        "python stages/stage3-neoclassical/sfincs_jax_radial_scan.py collect "
+        "--output-dir outputs/quick_run/stage3_neoclassical"
+    )
 
 
-def test_gpu_ids_only_on_gpu() -> None:
+# Each prepare-phase optional key set on its own must emit its flag-value pair exactly once; an absent key must emit
+# nothing. Parametrizing over the full optional table also locks the config-key to CLI-flag spelling (for example
+# analytical_n_radii becomes --analytical-n-radii).
+@pytest.mark.parametrize("key, flag, value", _PREPARE_OPTIONALS)
+def test_prepare_optional_flag_emitted_exactly_once(key: str, flag: str, value: object) -> None:
+    out = compose(prepare_cmd, stage_cfg={key: value})
+    assert f"{flag} {value}" in out
+    assert out.split().count(flag) == 1
+    assert flag not in compose(prepare_cmd, stage_cfg={})
+
+
+# verbose_workers is consumed at prepare time (baked into each payload.json), so its toggle lives on `prepare` and is
+# tri-state: True emits the on-flag, False the off-flag, and an absent key emits neither so the script default applies.
+# Token membership is used so --verbose-workers is not falsely found inside --no-verbose-workers.
+def test_prepare_verbose_workers_tristate() -> None:
+    assert "--verbose-workers" in compose(prepare_cmd, stage_cfg={"verbose_workers": True}).split()
+    assert "--no-verbose-workers" in compose(prepare_cmd, stage_cfg={"verbose_workers": False}).split()
+    absent = compose(prepare_cmd, stage_cfg={}).split()
+    assert "--verbose-workers" not in absent and "--no-verbose-workers" not in absent
+
+
+# Plotting happens in the reduction step, so the plot toggle lives on `collect` and is tri-state: True emits --plot,
+# False emits --no-plot, absent emits neither. Token membership so --plot is not falsely found inside --no-plot.
+def test_collect_plot_tristate() -> None:
+    assert "--plot" in compose(collect_cmd, stage_cfg={"plot": True}).split()
+    assert "--no-plot" in compose(collect_cmd, stage_cfg={"plot": False}).split()
+    absent = compose(collect_cmd, stage_cfg={}).split()
+    assert "--plot" not in absent and "--no-plot" not in absent
+
+
+# GPU pinning applies only to the worker phase: --gpu-ids appears only when the device is gpu AND the config sets
+# gpu_ids. A cpu device suppresses it even when gpu_ids is configured, and a gpu device without gpu_ids emits nothing.
+def test_run_one_gpu_ids_only_on_gpu() -> None:
     cfg = {"gpu_ids": "0,1"}
-    on_gpu = cmd(stage_cfg=cfg, device="gpu")
-    assert "--gpu-ids 0,1" in on_gpu
-    assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
-    assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
+    assert "--gpu-ids 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu")
 
 
-# A drift guard. The exact-string tests only check the helper against itself; this checks it against the real stage
-# script. It configures every optional and toggle, strips out the Snakemake placeholders, and feeds the resulting flags
-# into the stage script's own argparse parser (`build_parser`). If the script ever renames or drops a flag, argparse
-# exits (`sys.exit(2)`) and this test fails, catching the mismatch.
-def test_emitted_flags_parse_with_stage_script() -> None:
-    stage_cfg = {
-        "profiles_source": "analytical",
-        "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",
-        "ntheta": 31,
-        "nzeta": 15,
-        "nxi": 12,
-        "nx": 64,
-        "solver_tolerance": 1.0e-6,
-        "max_parallel": 8,
-        "gpu_ids": "0,1",
-        "plot": False,            # emits --no-plot
-        "verbose_workers": True,  # emits --verbose-workers
-    }
-    concrete = _PLACEHOLDER.sub("placeholder_path", cmd(stage_cfg=stage_cfg, device="gpu"))
-    tokens = concrete.split()
-    argv = tokens[tokens.index(_STAGE3_SCRIPT) + 1:]
-    try:
-        _scan.build_parser().parse_args(argv)
-    except SystemExit as exc:
-        pytest.fail(f"stage script parser rejected a helper-emitted flag: argv={argv} (exit {exc.code})")
+# A drift guard. The exact-string tests only check the composer against itself; this checks it against the real stage
+# script. It configures every optional and toggle, substitutes the Snakemake placeholders, and feeds the argv into the
+# stage script's own `build_parser`. Parsing must succeed and dispatch to cmd_prepare, so a renamed or dropped flag on
+# the prepare subparser fails here.
+def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
+    args = parse_with_stage_script(compose(prepare_cmd, stage_cfg=_FULL_CFG))
+    assert args.func.__name__ == "cmd_prepare"
+
+
+# A drift guard for the worker phase: the composed run-one command (gpu variant, so --gpu-ids is included) must parse
+# with the real stage script and dispatch to cmd_run_one, and the payload path must land on the run-one --payload
+# argument rather than on any flat-parser attribute.
+def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
+    args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
+    assert args.func.__name__ == "cmd_run_one"
+    assert args.payload == "outputs/quick_run/stage3_neoclassical/runs/rho_001_r0p1000/payload.json"
+
+
+# A drift guard for the reduction phase. The flat (no-subcommand) parser defines its own --output-dir and --plot
+# defaults; this asserts the collect subparser's parsed values win, so the composed --output-dir and --no-plot reach
+# cmd_collect instead of being shadowed by flat-parser defaults.
+def test_collect_flags_parse_and_dispatch_to_cmd_collect() -> None:
+    args = parse_with_stage_script(compose(collect_cmd, stage_cfg=_FULL_CFG))
+    assert args.func.__name__ == "cmd_collect"
+    assert args.output_dir == "outputs/quick_run/stage3_neoclassical"
+    assert args.plot is False
+    assert args.command == "collect"
+
+
+# Surface-level concurrency now belongs to `snakemake --cores`, so even a fully-populated config (including the retired
+# max_parallel key) must never make any composer emit a scan-level parallelism flag.
+def test_no_composer_emits_scan_level_parallelism_flags() -> None:
+    for composer in (prepare_cmd, run_one_cmd, collect_cmd):
+        for device in ("cpu", "gpu"):
+            out = compose(composer, stage_cfg=_FULL_CFG, device=device)
+            assert "--max-parallel" not in out
+            assert "--collect-even-if-failures" not in out

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -1,21 +1,26 @@
-"""Tests for ``src.stage4_helper.radial_scan_cmd``.
+"""Tests for the ``src.stage4_helper`` per-phase command composers.
 
-``radial_scan_cmd`` turns the ``stage4.spectrax_gk`` config block into the single
-shell command that the Snakefile's ``rule stage4_spectrax`` runs. The exact string
-it builds is the contract with that rule, so this pins it: the static base flags
-(the ``--vmec-file-override`` and ``--boozer-file-override`` geometry inputs plus
-the literal ``{input.*}`` placeholders Snakemake substitutes at run time), the
-not-None-only optional flags (where ``t_max`` is emitted as ``--t-final``), the
-four tri-state bool toggles, and the gpu-only ``--gpu-ids`` flag.
+``prepare_cmd``, ``run_one_cmd``, and ``collect_cmd`` turn the ``stage4.spectrax_gk``
+config block into the three shell commands that the Snakefile's per-phase Stage 4
+rules run. The exact strings are the contract with those rules, so this pins them:
+the static base flags (the ``--vmec-file-override`` and ``--boozer-file-override``
+geometry inputs plus the literal ``{input.*}`` and ``{wildcards.surf}`` placeholders
+Snakemake substitutes at run time), the not-None-only optional flags on ``prepare``
+(where ``t_max`` is emitted as ``--t-final``) and ``collect``, the tri-state and
+on-only booleans, the gpu-only singular ``--gpu-id`` flag on ``run-one``, and the
+absence of scan-level parallelism flags now that surface concurrency belongs to
+``snakemake --cores``.
 """
 
 from __future__ import annotations
 
+import argparse
 import re
+from collections.abc import Callable
 
 import pytest
 
-from src.stage4_helper import radial_scan_cmd
+from src.stage4_helper import collect_cmd, prepare_cmd, run_one_cmd
 from tests.helpers.stage_import import load_stage_module
 
 _STAGE4_SCRIPT = "stages/stage4-turbulence/spectrax_gk_radial_scan.py"
@@ -24,8 +29,40 @@ _STAGE4_SCRIPT = "stages/stage4-turbulence/spectrax_gk_radial_scan.py"
 _PLACEHOLDER = re.compile(r"\{(?:input|output)\.[A-Za-z0-9_]+\}")
 _scan = load_stage_module(_STAGE4_SCRIPT)
 
+# Every prepare-phase optional key with a quick-run-like value, used both to exercise
+# each flag individually and to prove that a fully-populated config never leaks
+# scan-level flags. The t_max key is deliberately spelled --t-final, the prepare
+# parser's alias whose argparse dest is t_max.
+_PREPARE_OPTIONALS: list[tuple[str, str, object]] = [
+    ("profiles_source",    "--profiles-source",    "analytical"),
+    ("neopax_result",      "--neopax-result",      "outputs/quick_run/stage5_transport/transport_solution.h5"),
+    ("nx",                 "--nx",                 12),
+    ("ny",                 "--ny",                 12),
+    ("ntheta",             "--ntheta",             30),
+    ("t_max",              "--t-final",            10.0),
+    ("sample_stride",      "--sample-stride",      50),
+    ("diagnostics_stride", "--diagnostics-stride", 1),
+    ("analytical_n_radii", "--analytical-n-radii", 5),
+    ("rho_indices",        "--rho-indices",        "1,5,10"),
+    ("rho_min",            "--rho-min",            0.1),
+    ("rho_max",            "--rho-max",            0.9),
+    ("num_radii",          "--num-radii",          4),
+]
 
-def cmd(**overrides) -> str:
+# max_parallel and collect_even_if_failures are retired keys that older configs may
+# still carry; every composer must ignore them.
+_FULL_CFG: dict = {key: value for key, _, value in _PREPARE_OPTIONALS} | {
+    "average_window": 1.0,
+    "gpu_ids": "0,1",
+    "plot": False,
+    "plot_run_heat_traces": True,
+    "verbose_workers": True,
+    "max_parallel": 1,
+    "collect_even_if_failures": True,
+}
+
+
+def compose(composer: Callable[..., str], **overrides) -> str:
     """Build a command with quick-run-like defaults, overriding only what a test varies."""
     base = dict(
         docker_prefix="docker run --rm",
@@ -35,94 +72,163 @@ def cmd(**overrides) -> str:
         device="cpu",
     )
     base.update(overrides)
-    return radial_scan_cmd(**base)
+    return composer(**base)
 
 
-# `radial_scan_cmd` builds the shell command the Snakefile runs for Stage 4. With an empty config and cpu device, this
-# pins the exact base command string, including the two geometry-input overrides and the literal `{input.*}`
-# placeholders Snakemake fills in with real paths at run time.
-def test_base_command_with_empty_config() -> None:
-    # Empty config + cpu emits exactly the static base parts; this equality also
-    # pins the literal {input.*} placeholders (including the two geometry
-    # overrides) that Snakemake substitutes at rule-execution time.
-    assert cmd() == (
+def parse_with_stage_script(command: str) -> argparse.Namespace:
+    """Feed a composed command's argv into the real stage script parser and return the namespace.
+
+    Fails the test if argparse rejects any flag (argparse exits via ``sys.exit(2)``).
+    """
+    concrete = _PLACEHOLDER.sub("placeholder_path", command).replace("{wildcards.surf}", "rho_001_r0p1000")
+    tokens = concrete.split()
+    argv = tokens[tokens.index(_STAGE4_SCRIPT) + 1:]
+    try:
+        return _scan.build_parser().parse_args(argv)
+    except SystemExit as exc:
+        pytest.fail(f"stage script parser rejected a composer-emitted flag: argv={argv} (exit {exc.code})")
+
+
+# `prepare_cmd` builds the shell command that writes the per-radius manifest and SPECTRAX runtime TOMLs. With an empty
+# config it should emit just the fixed base command: the two geometry-input overrides plus the literal `{input.*}`
+# placeholders Snakemake fills in at run time. The prepare parser takes no backend flag, so none may appear.
+def test_prepare_base_command_with_empty_config() -> None:
+    assert compose(prepare_cmd) == (
         "docker run --rm ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu "
-        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py "
+        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py prepare "
         "--common-config {input.common_config} "
         "--spectrax-template {input.config_file} "
         "--vmec-file-override {input.wout} "
         "--boozer-file-override {input.boozer} "
-        "--output-dir outputs/quick_run/stage4_turbulence "
+        "--output-dir outputs/quick_run/stage4_turbulence"
+    )
+
+
+# `run_one_cmd` builds the per-surface worker command. This pins the exact string: the manifest path is derived from the
+# output dir, the surface is selected by run-directory basename through the literal `{wildcards.surf}` placeholder that
+# Snakemake substitutes at rule-execution time, and only the backend is added with an empty config on cpu.
+def test_run_one_base_command_with_empty_config() -> None:
+    assert compose(run_one_cmd) == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu "
+        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py run-one "
+        "--manifest outputs/quick_run/stage4_turbulence/manifest.json "
+        "--run-name {wildcards.surf} "
         "--backend cpu"
     )
 
 
-# Optional flags appear only when set. This also checks a rename: the config key `t_max` is emitted as the `--t-final`
-# flag. It asserts the two set values appear (with the rename applied), the None-valued key is omitted, and a key absent
-# from the config is omitted.
-def test_only_non_none_optionals_appear() -> None:
-    out = cmd(stage_cfg={"t_max": 250.0, "ntheta": 16, "ny": None})
-    assert "--t-final 250.0" in out          # t_max is renamed to --t-final
-    assert "--ntheta 16" in out
-    assert "--ny" not in out                 # explicit None -> omitted
-    assert "--profiles-source" not in out    # absent key -> omitted
+# `collect_cmd` builds the reduction command that folds per-radius diagnostics into the two flux HDF5 files. This pins
+# the exact string, including the flux_summary.h5 and neopax_fluxes.h5 destination filenames the pipeline consumes.
+def test_collect_base_command_with_empty_config() -> None:
+    assert compose(collect_cmd) == (
+        "docker run --rm ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu "
+        "python stages/stage4-turbulence/spectrax_gk_radial_scan.py collect "
+        "--manifest outputs/quick_run/stage4_turbulence/manifest.json "
+        "--out outputs/quick_run/stage4_turbulence/flux_summary.h5 "
+        "--neopax-flux-out outputs/quick_run/stage4_turbulence/neopax_fluxes.h5"
+    )
 
 
-# Boolean toggles are tri-state: True emits `--flag`, False emits `--no-flag`, absent emits neither. Parametrized over
-# Stage 4's four toggles, this verifies all three cases. It compares whole tokens so a short flag like `--plot` isn't
-# falsely matched inside `--no-plot` or `--plot-run-heat-traces`.
+# Each prepare-phase optional key set on its own must emit its flag-value pair exactly once; an absent key must emit
+# nothing. Parametrizing over the full optional table also locks the config-key to CLI-flag spelling, in particular the
+# t_max to --t-final rename and analytical_n_radii to --analytical-n-radii.
+@pytest.mark.parametrize("key, flag, value", _PREPARE_OPTIONALS)
+def test_prepare_optional_flag_emitted_exactly_once(key: str, flag: str, value: object) -> None:
+    out = compose(prepare_cmd, stage_cfg={key: value})
+    assert f"{flag} {value}" in out
+    assert out.split().count(flag) == 1
+    assert flag not in compose(prepare_cmd, stage_cfg={})
+
+
+# Flux averaging happens in the reduction step, so average_window is a collect-phase optional: present exactly once
+# when set, absent otherwise.
+def test_collect_average_window_emitted_exactly_once() -> None:
+    out = compose(collect_cmd, stage_cfg={"average_window": 1.0})
+    assert "--average-window 1.0" in out
+    assert out.split().count("--average-window") == 1
+    assert "--average-window" not in compose(collect_cmd, stage_cfg={})
+
+
+# Plot toggles live on `collect` and are tri-state: True emits the on-flag, False the off-flag, absent emits neither.
+# Token membership so a short flag like --plot is not falsely found inside --no-plot or --plot-run-heat-traces.
 @pytest.mark.parametrize(
     "key, on, off",
     [
         ("plot", "--plot", "--no-plot"),
         ("plot_run_heat_traces", "--plot-run-heat-traces", "--no-plot-run-heat-traces"),
-        ("verbose_workers", "--verbose-workers", "--no-verbose-workers"),
-        ("collect_even_if_failures", "--collect-even-if-failures", "--no-collect-even-if-failures"),
     ],
 )
-def test_tristate_bools(key: str, on: str, off: str) -> None:
-    # Token membership (not substring) so --plot does not match inside --no-plot
-    # or --plot-run-heat-traces.
-    assert on in cmd(stage_cfg={key: True}).split()
-    assert off in cmd(stage_cfg={key: False}).split()
-    absent = cmd(stage_cfg={}).split()
+def test_collect_plot_tristates(key: str, on: str, off: str) -> None:
+    assert on in compose(collect_cmd, stage_cfg={key: True}).split()
+    assert off in compose(collect_cmd, stage_cfg={key: False}).split()
+    absent = compose(collect_cmd, stage_cfg={}).split()
     assert on not in absent and off not in absent
 
 
-def test_gpu_ids_only_on_gpu() -> None:
+# The run-one worker's --verbose-worker is a plain store_true with no negative form, unlike the tri-state toggles: only
+# an explicit config True emits it, while False and an absent key both emit nothing and leave the worker at its quiet
+# default. This asymmetry is asserted explicitly.
+def test_run_one_verbose_worker_on_only() -> None:
+    assert "--verbose-worker" in compose(run_one_cmd, stage_cfg={"verbose_workers": True}).split()
+    assert "--verbose-worker" not in compose(run_one_cmd, stage_cfg={"verbose_workers": False}).split()
+    assert "--verbose-worker" not in compose(run_one_cmd, stage_cfg={}).split()
+    assert "--no-verbose-worker" not in compose(run_one_cmd, stage_cfg={"verbose_workers": False})
+
+
+# GPU pinning applies only to the worker phase and uses the singular --gpu-id flag (the raw gpu_ids config string is
+# passed through; splitting a multi-GPU list across surfaces is deferred). It appears only when the device is gpu AND
+# the config sets gpu_ids: cpu suppresses it even when gpu_ids is configured, and gpu without gpu_ids emits nothing.
+# Token membership so --gpu-id is matched exactly.
+def test_run_one_gpu_id_only_on_gpu() -> None:
     cfg = {"gpu_ids": "0,1"}
-    on_gpu = cmd(stage_cfg=cfg, device="gpu")
-    assert "--gpu-ids 0,1" in on_gpu
-    assert "--gpu-ids" not in cmd(stage_cfg=cfg, device="cpu")  # cpu suppresses it
-    assert "--gpu-ids" not in cmd(stage_cfg={}, device="gpu")   # gpu but no ids
+    assert "--gpu-id 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
+    assert "--gpu-id" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu").split()
+    assert "--gpu-id" not in compose(run_one_cmd, stage_cfg={}, device="gpu").split()
 
 
-# A drift guard. The exact-string tests only check the helper against itself; this checks it against the real stage
-# script. It configures every optional and toggle (including the `t_max` -> `--t-final` rename), strips out the
-# Snakemake placeholders, and feeds the resulting flags into the stage script's own argparse parser (`build_parser`). If
-# the script ever renames or drops a flag, argparse exits (`sys.exit(2)`) and this test fails, catching the mismatch.
-def test_emitted_flags_parse_with_stage_script() -> None:
-    stage_cfg = {
-        "profiles_source": "analytical",
-        "neopax_result": "outputs/quick_run/stage5_transport/transport_solution.h5",
-        "nx": 12,
-        "ny": 12,
-        "ntheta": 16,
-        "t_max": 250.0,
-        "average_window": 1.0,
-        "sample_stride": 50,
-        "diagnostics_stride": 1,
-        "max_parallel": 1,
-        "gpu_ids": "0,1",
-        "plot": False,                     # emits --no-plot
-        "plot_run_heat_traces": True,      # emits --plot-run-heat-traces
-        "verbose_workers": False,          # emits --no-verbose-workers
-        "collect_even_if_failures": True,  # emits --collect-even-if-failures
-    }
-    concrete = _PLACEHOLDER.sub("placeholder_path", cmd(stage_cfg=stage_cfg, device="gpu"))
-    tokens = concrete.split()
-    argv = tokens[tokens.index(_STAGE4_SCRIPT) + 1:]
-    try:
-        _scan.build_parser().parse_args(argv)
-    except SystemExit as exc:
-        pytest.fail(f"stage script parser rejected a helper-emitted flag: argv={argv} (exit {exc.code})")
+# A drift guard. The exact-string tests only check the composer against itself; this checks it against the real stage
+# script. It configures every optional (including the t_max to --t-final rename), substitutes the Snakemake
+# placeholders, and feeds the argv into the stage script's own `build_parser`. Parsing must succeed and dispatch to
+# cmd_prepare, so a renamed or dropped flag on the prepare subparser fails here.
+def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
+    args = parse_with_stage_script(compose(prepare_cmd, stage_cfg=_FULL_CFG))
+    assert args.func.__name__ == "cmd_prepare"
+    assert args.t_max == 10.0
+
+
+# A drift guard for the worker phase: the composed run-one command (gpu variant with verbose_workers on, so --gpu-id
+# and --verbose-worker are included) must parse with the real stage script and dispatch to cmd_run_one, with the
+# substituted surface name landing on the run-one --run-name argument.
+def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
+    args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
+    assert args.func.__name__ == "cmd_run_one"
+    assert args.run_name == "rho_001_r0p1000"
+    assert args.gpu_id == "0,1"
+
+
+# A drift guard for the reduction phase: the composed collect command must parse with the real stage script, dispatch
+# to cmd_collect, and route the two destination paths onto --out and --neopax-flux-out. t_final must stay None so it
+# falls back to the manifest's t_max, which prepare recorded from the same config key.
+def test_collect_flags_parse_and_dispatch_to_cmd_collect() -> None:
+    args = parse_with_stage_script(compose(collect_cmd, stage_cfg=_FULL_CFG))
+    assert args.func.__name__ == "cmd_collect"
+    assert args.out == "outputs/quick_run/stage4_turbulence/flux_summary.h5"
+    assert args.neopax_flux_out == "outputs/quick_run/stage4_turbulence/neopax_fluxes.h5"
+    assert args.t_final is None
+    assert args.plot is False
+
+
+# The time window has a single source of truth: config t_max reaches the manifest via prepare, and collect's --t-final
+# falls back to that manifest value. Even with t_max configured, collect must therefore never emit --t-final.
+def test_collect_never_emits_t_final() -> None:
+    assert "--t-final" not in compose(collect_cmd, stage_cfg=_FULL_CFG)
+
+
+# Surface-level concurrency now belongs to `snakemake --cores`, so even a fully-populated config (including the retired
+# max_parallel and collect_even_if_failures keys) must never make any composer emit a scan-level flag.
+def test_no_composer_emits_scan_level_flags() -> None:
+    for composer in (prepare_cmd, run_one_cmd, collect_cmd):
+        for device in ("cpu", "gpu"):
+            out = compose(composer, stage_cfg=_FULL_CFG, device=device)
+            assert "--max-parallel" not in out
+            assert "--collect-even-if-failures" not in out

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -7,7 +7,7 @@ the static base flags (the ``--vmec-file-override`` and ``--boozer-file-override
 geometry inputs plus the literal ``{input.*}`` and ``{wildcards.surf}`` placeholders
 Snakemake substitutes at run time), the not-None-only optional flags on ``prepare``
 (where ``t_max`` is emitted as ``--t-final``) and ``collect``, the tri-state and
-on-only booleans, the gpu-only singular ``--gpu-id`` flag on ``run-one``, and the
+on-only booleans, the gpu-only ``--gpu-ids`` flag on ``run-one``, and the
 absence of scan-level parallelism flags now that surface concurrency belongs to
 ``snakemake --cores``.
 """
@@ -175,15 +175,15 @@ def test_run_one_verbose_worker_on_only() -> None:
     assert "--no-verbose-worker" not in compose(run_one_cmd, stage_cfg={"verbose_workers": False})
 
 
-# GPU pinning applies only to the worker phase and uses the singular --gpu-id flag (the raw gpu_ids config string is
-# passed through; splitting a multi-GPU list across surfaces is deferred). It appears only when the device is gpu AND
-# the config sets gpu_ids: cpu suppresses it even when gpu_ids is configured, and gpu without gpu_ids emits nothing.
-# Token membership so --gpu-id is matched exactly.
-def test_run_one_gpu_id_only_on_gpu() -> None:
+# GPU pinning applies only to the worker phase: --gpu-ids passes the raw gpu_ids config string through and the worker
+# pins the first id (distributing a multi-GPU list across surfaces is deferred). It appears only when the device is
+# gpu AND the config sets gpu_ids: cpu suppresses it even when gpu_ids is configured, and gpu without gpu_ids emits
+# nothing. Token membership so --gpu-ids is matched exactly.
+def test_run_one_gpu_ids_only_on_gpu() -> None:
     cfg = {"gpu_ids": "0,1"}
-    assert "--gpu-id 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
-    assert "--gpu-id" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu").split()
-    assert "--gpu-id" not in compose(run_one_cmd, stage_cfg={}, device="gpu").split()
+    assert "--gpu-ids 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu").split()
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu").split()
 
 
 # A drift guard. The exact-string tests only check the composer against itself; this checks it against the real stage
@@ -196,14 +196,14 @@ def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
     assert args.t_max == 10.0
 
 
-# A drift guard for the worker phase: the composed run-one command (gpu variant with verbose_workers on, so --gpu-id
+# A drift guard for the worker phase: the composed run-one command (gpu variant with verbose_workers on, so --gpu-ids
 # and --verbose-worker are included) must parse with the real stage script and dispatch to cmd_run_one, with the
 # substituted surface name landing on the run-one --run-name argument.
 def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
     args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
     assert args.func.__name__ == "cmd_run_one"
     assert args.run_name == "rho_001_r0p1000"
-    assert args.gpu_id == "0,1"
+    assert args.gpu_ids == "0,1"
 
 
 # A drift guard for the reduction phase: the composed collect command must parse with the real stage script, dispatch


### PR DESCRIPTION
Resolves #99

## Motivation

Stages 3 (`sfincs_jax`) and 4 (`SPECTRAX-GK`) each ran as a single Snakemake rule launching one container, inside which the radial-scan script looped over every flux surface itself, forking worker subprocesses throttled by a `max_parallel` config key. Hiding the per-surface parallelism inside one process blocked cluster execution. Under the [HTCondor executor plugin](https://github.com/htcondor/snakemake-executor-plugin-htcondor), each Snakemake job maps to one cluster submission, so a 50-surface scan packed into one job cannot spread across 50 slots.

Making every unit of parallel work a real Snakemake job is the prerequisite for HTCondor simplicity.

## Design Decisions
### How the fan-out executes

A Snakefile is Python, so the per-phase composers run while Snakemake reads the file and only build one-line `docker run ...` command strings (placeholders like `{input.*}`, `{log}`, `{wildcards.surf}` stay literal); nothing executes until the scheduler later substitutes concrete paths into a job's stored string and runs it through bash under `set -o pipefail`, streaming to the rule's log via `tee`. The per-surface layer is dynamic: `prepare` is a `checkpoint`, and `collect` declares its per-surface inputs as a gather *function* that can only be evaluated after `prepare` has written `manifest.json`, at which point a DAG re-evaluation materializes one `run_one` job per surface via wildcard matching. Fail-fast falls out for free, because `collect` requires the complete manifest enumeration, so a single failed surface stops the stage before any partially-filled HDF5 can reach Stage 5.

Resolution order, concretely (Stage 3 shown; Stage 4 has the same shape, with the Stage 2 boozmn as an additional `prepare` input). Snakemake plans demand-first, then executes dependency-first:

  1. `rule all` needs `S5_OUTPUT`, whose rule inputs `S3_OUTPUT`; the producer of `S3_OUTPUT` is `stage3_collect`. Planning only matches demanded paths to producing rules; every `shell:` string was already composed at parse time and nothing has run.
  2. `stage3_collect` declares two inputs: the manifest file and the gather function `stage3_surface_results`. Evaluating the function calls `checkpoints.stage3_prepare.get()`, which fails softly before the checkpoint has run, so the per-surface input list is deferred. This deferral is why dry runs and `--dag` plan only `prepare -> collect`.
  3. The manifest demand schedules `checkpoint stage3_prepare`, whose own inputs pull in `stage1_vmec` (the wout) upstream. Declaring it a `checkpoint` rather than a plain rule is what arms the DAG re-evaluation in step 5.
  4. Execution starts: `stage1_vmec` runs, then `stage3_prepare` runs and writes `manifest.json` plus each surface's inputs under `runs/<surf>/`. For each job, Snakemake substitutes the concrete paths into the parse-time command string and executes it.
  5. Checkpoint completion triggers the DAG re-evaluation: `stage3_surface_results` runs again, now reads the manifest (stdlib `json`; host paths rebuilt from run-directory basenames only), and returns (for the quick_run version) the 50 `runs/<surf>/result.json` paths.
  6. Each returned path is wildcard-matched to `stage3_run_one`'s output template: `{surf}` is a regex capture group (constrained to `rho_\d+_r[0-9p]+`), and each captured value is threaded into the rule's other `{surf}` occurrences, the log path and the composed `--payload .../runs/<surf>/payload.json`, so each job reads exactly its own surface's inputs. 50 demanded paths mint 50 instances of one generic rule, no explicit loop anywhere, executing up to `--cores` at a time.
  7. Once all 50 `result.json` files exist, `stage3_collect` finally has a complete input set, runs, and reduces them into `sfincs_jax_flux_profiles.h5` (`S3_OUTPUT`), unblocking Stage 5. If any surface job fails, `collect` is never scheduled and no aggregate is written.

### How the scan scripts were decomposed

Each of the six Snakemake rules launches its own container, so each phase had to become a standalone CLI invocation instead of one step of an internal loop. Stage 3's flat `cmd_main` was split at its natural seams (the no-subcommand path recomposes the same halves, so the all-in-one behavior is unchanged by construction), while Stage 4 already had separate `cmd_*` phase functions that only needed surfacing as subparsers; in both scripts the per-surface jobs reuse the internal launchers' env helpers, so a Snakemake job and an internal worker get identical environments. Profile handling, physics calculations, and output reduction are untouched: the scripts are **scientifically equivalent**, though the new interfaces and the Stage 4 template-path fix mean not every invocation is behaviorally identical.

### What the spec rewrites pin down

Each spec is the authoritative I/O contract for its stage, and the one-sentence Output Specifications on `main` no longer described the artifact (now the product of a per-surface fan-out plus its run tree). Both specs were rewritten to the same pattern: frame the handoff as the `prepare -> run_one -> collect` output (linking to `docs/mvp-pipeline.md` for the mechanics), give the datasets and shapes as a table scoped to exactly what `src/io_contracts.py` validates (so any spec-validator divergence is a documentation bug by definition), tier the attributes into contract-required vs manifest-sourced provenance vs convention notes, and document the per-surface `runs/rho_*/` tree that `collect` reduces over. Notable per-stage additions: Stage 4 clarifies that only `neopax_fluxes.h5` is the validated Stage 5 handoff (`flux_summary.h5` is a companion Stage 5 never reads) and flags the `random_seed` reproducibility gap; Stage 3 gained a bridge NOTE on the forced namelist overrides.

### Why `collect_even_if_failures` was removed

`collect_even_if_failures` was Stage 4's zero-fill switch: when a surface's turbulence run crashed, the old collector proceeded anyway and wrote zeros for that surface's fluxes into `neopax_fluxes.h5`. That is potentially dangerous because the fluxes are direct numerical inputs to Stage 5's transport solve, so a zero does not read as "missing data" downstream, it reads as "this surface transports nothing" and silently corrupts the profile evolution. The refactor makes the knob both unnecessary and impossible on the Snakemake path: `stage4_collect`'s input list is the complete manifest enumeration, so one failed surface means `collect` is never scheduled and no code path can zero-fill regardless of any flag. The replacement is a fail-fast, surface-granular resume where a failed scan reruns exactly the failed surface plus `collect`. The recovery path the fail-fast smoke confirmed rebuilds a bitwise-identical Stage 5 H5 file.

## Summary

* Replace the single `stage3_sfincs` / `stage4_spectrax` rules in the `Snakefile` with three rules per stage: `checkpoint stageN_prepare` (writes `manifest.json` plus each surface's inputs under `runs/<surf>/`), `rule stageN_run_one` (one job and one container per flux surface), and `rule stageN_collect` (gathers everything into the unchanged stage HDF5). `S3_OUTPUT`/`S4_OUTPUT` are unchanged, so Stage 5 and `rule all` are untouched; the manifest paths come from new `stage3_manifest` / `stage4_manifest` keys in `resolve_pipeline_paths` (`src/utils/paths.py`).
* Surface concurrency is now governed by `snakemake --cores`, the prerequisite for the [[[HTCondor executor plugin](https://github.com/htcondor/snakemake-executor-plugin-htcondor)](https://github.com/htcondor/snakemake-executor-plugin-htcondor)](https://github.com/htcondor/snakemake-executor-plugin-htcondor) where each job maps to one submission. `prepare` is a checkpoint because the surface count can be data-dependent (`profiles_source: transport_h5` reads the rho grid at run time), so the `run_one` layer materializes only after `prepare` runs.
* Add `prepare` / `run-one` / `collect` subcommands to both scan scripts (`stages/stage{3-neoclassical,4-turbulence}/*_radial_scan.py`); the no-subcommand all-in-one paths and internal launchers are unchanged (Stage 3's byte-for-byte, and the `stages/pixi.toml` task is unaffected). Also fixes Stage 4's `cmd_prepare` to CWD-anchor a relative `--spectrax-template` (it previously doubled `inputs/quick_run/`). Details in "How the scan scripts were decomposed" below.
* Replace each `radial_scan_cmd` in `src/stage3_helper.py` / `src/stage4_helper.py` with per-phase composers `prepare_cmd` / `run_one_cmd` / `collect_cmd`; `--max-parallel` and `--collect-even-if-failures` are no longer emitted (superseded by `snakemake --cores` and the fail-fast policy).
* `inputs/quick_run/config.yaml`: add surface-selection keys (`analytical_n_radii` plus commented `num_radii` / `rho_min` / `rho_max` / `rho_indices` alternatives) whose defaults preserve quick_run's surface counts (50 for Stage 3, 4 for Stage 4); remove `max_parallel` (its fully-serial default only existed because concurrent workers sharing one container's memory OOM-died) and `collect_even_if_failures`.
* Unify on fail-fast gathering: `collect` requires every per-surface output, so one failed surface fails the stage instead of silently zero-filling fluxes that Stage 5 would consume. See "Why `collect_even_if_failures` was removed" below.
* Update the existing tests in lockstep: `tests/orchestration/test_stage{3,4}_helper_cmd.py` rewritten around the per-phase composers (with drift guards against the real subparsers), `tests/orchestration/test_paths.py` extended for the two manifest keys, and `tests/e2e/test_dry_run_dag.py` redesigned for checkpoint semantics.
* Update the docs to the six-rule layout: `docs/guide.md`, `docs/mvp-pipeline.md` (per-surface fan-out section, fail-fast policy, fan-out execution mechanics, `--dag` drawing instructions pointed to from `README.md`), and both stage specs (see "What the spec rewrites pin down" below).

### Notes / follow-ups

* Stacked on #104: base branch is `test/orchestration-and-io-contracts`. will rebase or retarget once #104 merges.
* New tests for the new behavior land in a separate follow-up PR.
* Dry-run DAG visibility ends at the checkpoints; this is intrinsic to checkpoint-based fan-out.
* `docs/mvp-pipeline.md` is currently more detailed than it needs to be; a docs refactor to consolidate and trim will land in a future PR.

---

**Tested:**

* [x] Fast suite green before and after: `pixi run -e test pytest tests -q -m "not docker and not stage_env and not e2e"` reports 161 passed / 0 failed; the full `pixi run -e test test` task additionally runs the 4 doctests (`config_edit.py`, `paths.py`, `io_contracts.py`), all passing.
* [x] Every commit in the series is individually green: `git rebase --exec "pixi run -e test test"` over the branch passed (161 + 4 doctests) at each of the four commits, so the history bisects cleanly.
* [x] Manifest-path resolution: the `stage3_manifest`/`stage4_manifest` keys were factored into `resolve_pipeline_paths` after the smoke runs; the resolved strings were checked identical to the inline derivations the smoke exercised, and a dry run re-verified exit 0 afterward.
* [x] Dry runs exit 0: the forward pass plans 8 jobs (`stage1_vmec`, `stage2_boozer`, `stage{3,4}_prepare`, `stage{3,4}_collect`, `stage5_neopax`, `all`), the `s5_signal` target pulls `stage5_post_processing`, and `--config device=bogus` fails at parse with guidance.
* [x] Reduced-surface end-to-end docker smoke (`analytical_n_radii: 5`, 4 surfaces per stage) through the checkpoint DAG: exactly 1 prepare + 4 `run_one` + 1 collect per stage, exit 0; both stage HDF5s pass the `src.io_contracts` validators (with a negative control confirming the validators raise on corrupted files).
* [x] Physics-equivalence vs the pre-refactor scripts: the old all-in-one CLIs (extracted from the base branch) were rerun in the same containers on the same inputs and compared dataset-by-dataset with h5py. `sfincs_jax_flux_profiles.h5` (7/7 datasets), `neopax_fluxes.h5` (6/6), and `flux_summary.h5` (13/13) are all bitwise identical; the only attribute deltas are run-provenance echoes (`max_parallel`, manifest path), as designed.
* [x] Fail-fast: corrupting one surface's `input.namelist` fails `stage3_run_one` and the stage, and no aggregated HDF5 is produced; after restoring the input, the rerun recomputes exactly that surface plus `collect` (sibling surface outputs untouched by mtime) and the rebuilt HDF5 is bitwise identical to the pre-corruption file.
* [x] Closed loop: 1-iteration `python -m src.ouroboros` resolves `s5_signal` through the checkpoint DAG in a fresh `loop/iter_1` tree (both prepares re-run fresh, 4+4 surface jobs, both collects, Stage 5, post-processing) and stops on `{"converged": true}`.