### PR TITLE
feat: Allow jobs across multiple GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ cp -r inputs/quick_run inputs/my_run
 pixi run -e pipeline snakemake --configfile inputs/my_run/config.yaml --cores 4
 ```
 
+### Run the closed loop
+
+The commands above are a single forward pass. To iterate toward transport-consistent profiles, the `ouroboros` driver sequences independent forward passes, feeding each pass's Stage 5 transport solution into the next one as a boundary refit from the evolved pressure and as kinetic profiles prescribed to Stages 3, 4, and 5:
+
+```
+pixi run -e pipeline ouroboros --config inputs/quick_run/config.yaml --max-iters 3 --cores 4
+```
+
+Each iteration is a full pipeline run under its own `outputs/<run>/loop/iter_N/` tree, and the driver stops early once the pressure profile settles within the config's `convergence.pressure_rel_tol`. Stages listed under `loop.rerun` as `false` are frozen, so iterations after the first reuse their iteration 1 artifacts. See [docs/mvp-pipeline.md](docs/mvp-pipeline.md#closing-the-loop).
+
+### Run on GPUs
+
+Two top-level run-config keys pick the `-gpu` image variant for every stage and the device pool its containers may use:
+
+```yaml
+gpu_ids: "4,5,6,7"   # null runs CPU images; "all" uses every GPU the execution host reports
+jobs_per_gpu: 2      # concurrent jobs allowed per GPU
+```
+
+Every concurrent job is pinned to one free slot of that pool, so the pool offers pool size times `jobs_per_gpu` slots and saturating it takes at least that many cores. Either key can be overridden per invocation, on a forward pass or on the loop:
+
+```
+pixi run -e pipeline snakemake --configfile inputs/quick_run/config.yaml --cores 8 --config gpu_ids=4,5,6,7 jobs_per_gpu=2
+pixi run -e pipeline ouroboros --config inputs/quick_run/config.yaml --cores 8 --gpu-ids 4,5,6,7 --jobs-per-gpu 2
+```
+
+GPU mode needs an NVIDIA host with `nvidia-container-toolkit` configured on the docker daemon. See [docs/mvp-pipeline.md](docs/mvp-pipeline.md#multi-gpu-scheduling) for how the pinning works, how to share a host with other users, and the current limitations.
+
 ### Visualize the pipeline graph
 
 Render the file-flow graph (files as nodes, rules as edges) **including the closed-loop post-processing step** by targeting the convergence signal file:

--- a/Snakefile
+++ b/Snakefile
@@ -4,7 +4,7 @@ import json
 import posixpath
 
 from src import stage3_helper, stage4_helper, stage5_helper
-from src.utils import resolve_pipeline_paths, resolve_rerun_flags, RESOLVED_COMMON_CONFIG
+from src.utils import resolve_gpu_settings, resolve_pipeline_paths, resolve_rerun_flags, RESOLVED_COMMON_CONFIG
 
 # Require an explicit run config
 if not config:
@@ -18,11 +18,8 @@ if _missing:
 
 RUN_NAME = config["run_name"]
 
-DEVICE = config.get("device", "cpu")
-if DEVICE not in ("cpu", "gpu"):
-    raise ValueError(
-        f"config['device'] must be 'cpu' or 'gpu', got {DEVICE!r}."
-    )
+GPU = resolve_gpu_settings(config)
+DEVICE = GPU.device
 
 # Per-stage rerun flags for the closed loop, validated at parse time so a bad combination fails before any job runs.
 # Freezing a stage means reading its artifacts from an earlier pass, which takes an address from loop.reuse_output_dir.
@@ -39,7 +36,16 @@ elif not RERUN["stage5"]:
         "target. The loop driver runs a single iteration for an all-frozen config instead of naming a reuse tree."
     )
 
-GPU_FLAG       = "--gpus all " if DEVICE == "gpu" else ""
+# The slot allocator holds one flock slot for the container's lifetime and substitutes the acquired id into @GPU_ID@.
+GPU_FLAG = ""
+SLOT_PREFIX = ""
+if DEVICE == "gpu":
+    GPU_FLAG = "--gpus device=@GPU_ID@ "
+    SLOT_PREFIX = (
+        f"python -m src.gpu_slots --gpu-ids {','.join(GPU.pool) if GPU.pool else 'all'} "
+        f"--jobs-per-gpu {GPU.jobs_per_gpu} --lock-dir .snakemake/gpu_slots -- "
+    )
+
 STAGE1_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-1-vmec-{DEVICE}"
 STAGE2_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-2-booz-jax-{DEVICE}"
 STAGE3_JAX_IMG = f"ghcr.io/driftless-star/driftless-star:stage-3-sfincs-{DEVICE}"
@@ -49,7 +55,7 @@ STAGE5_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-5-neopax-{DEVICE}
 # --user: make bind-mounted writes host-owned (Linux docker otherwise writes as root).
 # -e HOME=/tmp: pixi activation needs a writable HOME after dropping root.
 DOCKER_PREFIX = (
-    f'docker run --rm --pull=missing {GPU_FLAG}'
+    f'{SLOT_PREFIX}docker run --rm --pull=missing {GPU_FLAG}'
     '--user "$(id -u):$(id -g)" '
     '-e HOME=/tmp '
     '-v "$PWD:/work" -w /work'

--- a/Snakefile
+++ b/Snakefile
@@ -176,7 +176,6 @@ if RERUN["stage3"]:
             stage3_helper.run_one_cmd(
                 docker_prefix=DOCKER_PREFIX,
                 image=STAGE3_JAX_IMG,
-                stage_cfg=STAGE3_CFG,
                 output_dir=P["stage3_dir"],
                 device=DEVICE,
             ) + " 2>&1 | tee {log}"
@@ -205,7 +204,6 @@ if RERUN["stage3"]:
                 image=STAGE3_JAX_IMG,
                 stage_cfg=STAGE3_CFG,
                 output_dir=P["stage3_dir"],
-                device=DEVICE,
             ) + " 2>&1 | tee {log}"
 
 if RERUN["stage4"]:
@@ -225,7 +223,6 @@ if RERUN["stage4"]:
                 image=STAGE4_IMG,
                 stage_cfg=STAGE4_CFG,
                 output_dir=P["stage4_dir"],
-                device=DEVICE,
             ) + " 2>&1 | tee {log}"
 
     rule stage4_run_one:
@@ -274,7 +271,6 @@ if RERUN["stage4"]:
                 image=STAGE4_IMG,
                 stage_cfg=STAGE4_CFG,
                 output_dir=P["stage4_dir"],
-                device=DEVICE,
             ) + " 2>&1 | tee {log}"
 
 rule stage5_neopax:

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -76,6 +76,12 @@ DRIVER version      : 590.48.01
 CUDA Version        : 13.1
 ```
 
+* Run the same container pinned to a single GPU, the form the pipeline's slot allocator emits for each job
+
+```console
+$ docker run --rm -ti --gpus device=4 ghcr.io/driftless-star/driftless-star:stage-1-vmec-gpu bash
+```
+
 ## Apptainer
 
 On Linux machines Apptainer can be installed from conda-forge with

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -248,6 +248,7 @@ When a stage completes Phase 2 (containerized, tested, and producing valid outpu
 - The forward-pass Stage 3 (`sfincs_jax`) reads only the Stage 1 wout, so it runs in parallel with Stage 2; Stage 4 (`SPECTRAX-GK`) also needs the Stage 2 boozmn, so it follows Stage 2.
 - `NEO_JAX` reads the Stage 2 boozmn and runs alongside `sfincs_jax` as a screening diagnostic, but it has **no Snakemake rule** and is not part of the forward pass. Its epsilon_eff is a screening metric only. It should not be wired as a dependency for Stage 5.
 - Stages 3 and 4 each fan out one Snakemake job per flux surface via a three-rule `prepare` (checkpoint) / `run_one` / `collect` layout; see [Per-surface fan-out](mvp-pipeline.md#per-surface-fan-out-stages-3-and-4).
+- On GPU hosts every job is pinned to one device from a user-supplied pool (or every host GPU via `gpu_ids: "all"`), so no pipeline container reaches a device outside it; see [Multi-GPU scheduling](mvp-pipeline.md#multi-gpu-scheduling).
 
 ### Config-Driven Selection
 

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -261,7 +261,7 @@ Automates the MVP forward pass end-to-end: `Stage 1 -> {Stage 2, Stage 3, Stage 
 
 | Direction | Format              | Location                                                                                                                                                           |
 | --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `device`, `input_dir`, `output_dir`, `filenames`, `convergence`, `loop`, `stage3`, `stage4`)                                            |
+| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `gpu_ids`, `jobs_per_gpu`, `input_dir`, `output_dir`, `filenames`, `convergence`, `loop`, `stage3`, `stage4`)    |
 | **In**    | Workflow definition | `Snakefile`                                                                                                                                                        |
 | **In**    | Per-stage inputs    | `inputs/quick_run/` (all stage inputs, flat)                                                                                                                       |
 | **Out**   | Stage 2 NetCDF      | `outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc`                                                                                              |
@@ -275,7 +275,7 @@ Automates the MVP forward pass end-to-end: `Stage 1 -> {Stage 2, Stage 3, Stage 
 > `rule all` targets the Stage 5 transport solution (`transport_solution.h5`); all upstream artifacts (wout, boozmn, neoclassical + turbulent fluxes) are produced transitively because downstream rules declare them as `input:`. The loop-closing post-processing step is *not* part of `rule all` -- a plain `snakemake` stays a pure forward pass; see [Closing the Loop](#closing-the-loop).
 
 > [!NOTE]
-> Docker must be running on the host. On macOS / Windows that is Docker Desktop; on Linux, the docker engine or a rootless equivalent (podman aliased to `docker`). Windows users should invoke from WSL2 or Git Bash so bash expansions like `$PWD` resolve correctly inside the Snakefile's shell directives. HPC clusters that disallow Docker are a planned follow-up (Apptainer via `--sdm apptainer`).
+> Docker must be running on the host. On macOS / Windows that is Docker Desktop; on Linux, the docker engine or a rootless equivalent (podman aliased to `docker`). Windows users should invoke from WSL2 or Git Bash so bash expansions like `$PWD` resolve correctly inside the Snakefile's shell directives; GPU mode needs WSL2 specifically, since the slot allocator requires a POSIX host (see [Multi-GPU scheduling](#multi-gpu-scheduling)). HPC clusters that disallow Docker are a planned follow-up (Apptainer via `--sdm apptainer`).
 
 ### Per-surface fan-out (Stages 3 and 4)
 
@@ -340,7 +340,8 @@ rm -rf outputs/quick_run/                                                       
 Per-invocation overrides via `--config` (layered on top of the config file):
 
 ```
-pixi run -e pipeline snakemake --configfile inputs/quick_run/config.yaml --cores 4 --config device=gpu   # use -gpu images + --gpus all
+pixi run -e pipeline snakemake --configfile inputs/quick_run/config.yaml --cores 4 --config gpu_ids=all                    # use -gpu images, one job pinned per host GPU
+pixi run -e pipeline snakemake --configfile inputs/quick_run/config.yaml --cores 8 --config gpu_ids=4,5,6,7 jobs_per_gpu=2 # use -gpu images, pinning each job to one of 8 slots across GPUs 4-7
 ```
 
 Defining another run via its own config file:
@@ -352,10 +353,36 @@ pixi run -e pipeline snakemake --configfile inputs/my_run/config.yaml --cores 4
 Each run is self-contained: its `config.yaml` sets `input_dir`/`output_dir` and the input basenames, so there is no shared base file to inherit from. To change a few keys for one invocation without editing the file, append `--config key=value` (it overrides the file), or pass additional `--configfile` files (later files override earlier ones).
 
 > [!NOTE]
-> A run config is required: there is no hardcoded `configfile:` directive, so a bare `snakemake` errors with guidance to pass `--configfile`. Precedence (highest wins): `--config key=value` on the CLI → `--configfile` files (later override earlier) → in-code defaults via `config.get(...)`. `--config` is how `device` switches hardware per invocation without committing host-specific defaults.
+> A run config is required: there is no hardcoded `configfile:` directive, so a bare `snakemake` errors with guidance to pass `--configfile`. Precedence (highest wins): `--config key=value` on the CLI → `--configfile` files (later override earlier) → in-code defaults via `config.get(...)`. `--config` is how `gpu_ids` switches hardware per invocation without committing host-specific defaults.
 
 > [!NOTE]
-> `device=gpu` requires an NVIDIA host with `nvidia-container-toolkit` configured on the docker daemon.
+> Any non-null `gpu_ids` requires an NVIDIA host with `nvidia-container-toolkit` configured on the docker daemon. `gpu_ids: "all"` additionally needs `nvidia-smi` on the execution host, which the NVIDIA driver already provides.
+
+### Multi-GPU scheduling
+
+Two top-level run-config keys decide which image variant every stage runs and which devices its containers may use:
+
+```yaml
+# Container runtime GPU pool. One of:
+# null: run every stage on CPU images with no GPU access.
+# "all": run GPU images, pinning each concurrent job to one free GPU of the execution host
+# ids e.g. "4,5,6,7": run GPU images with each concurrent job pinned to one free id from the pool.
+gpu_ids: null
+# Concurrent jobs allowed per GPU.
+jobs_per_gpu: 1
+```
+
+**How pinning works.** In GPU mode every job's `docker run` is wrapped by the slot allocator (`python -m src.gpu_slots ... -- docker run --gpus device=@GPU_ID@ ...`). An explicit id list is passed through as written; `gpu_ids: "all"` is resolved by the wrapper on the execution host when the job starts, taking the ids `CUDA_VISIBLE_DEVICES` lists when that variable is set (exporting it is the supported way to restrict `"all"` on a shared host) and every GPU `nvidia-smi` reports otherwise. The wrapper takes an exclusive `flock` on one lock file per slot under `.snakemake/gpu_slots/` (relative to the invocation directory, i.e. the repo root), substitutes the acquired id into the command's `@GPU_ID@` token, and holds the lock for the container's whole lifetime. The kernel drops a `flock` when the holding process exits for any reason, so a crashed or cancelled job frees its slot with no stale-lock cleanup. Each job logs `[gpu_slots] acquired GPU <id>`, and a job that finds every slot taken logs one `[gpu_slots] waiting for a free GPU slot` line before it blocks, because a rule's `2>&1 | tee {log}` pipe covers the wrapper as well as the container.
+
+**Enforcement boundary.** Every pipeline job is wrapped, the single-job Stages 1, 2, and 5 and the Stage 3/4 `prepare` and `collect` phases included, so no pipeline container can reach a device outside the pool, and every container sees exactly one GPU regardless of mode.
+
+**Concurrency.** Job concurrency is still `snakemake --cores`, one job per surface (see [Per-surface fan-out](#per-surface-fan-out-stages-3-and-4)). The pool offers pool size times `jobs_per_gpu` slots, so saturating it takes at least that many cores. Asking for more cores than slots is safe, since the surplus jobs block on the flock and log the waiting line until a slot frees up.
+
+**Sharing a device.** Raising `jobs_per_gpu` is deliberate oversubscription and requires `gpu_ids` to name GPUs (`"all"` or an id list), so several JAX containers then share one device. The per-surface workers disable JAX VRAM preallocation, but co-located jobs can still exhaust a device's memory, which makes the count something to size against how much VRAM one surface needs. Both keys are validated by `resolve_gpu_settings` (`src/utils/gpu.py`) at Snakefile parse time and again at driver startup, so an unusable pool fails before any job runs; a config still carrying the removed `device` key fails the same way, with a migration hint.
+
+**On the command line.** `--config gpu_ids=4,5,6,7 jobs_per_gpu=2` overrides the file for one invocation, and CPU mode is either `gpu_ids=null` or an empty `gpu_ids=`. Snakemake parses the CLI value itself, and the validator accepts both the `"null"` string and `None` that this produces. The [closed-loop driver](#closing-the-loop) takes the same two settings as `--gpu-ids` / `--jobs-per-gpu`.
+
+**Limitations.** Concurrent pipeline invocations share slot accounting only when they are launched from the same working copy, since the lock files live under that copy's `.snakemake/gpu_slots/`, and only when they agree on `jobs_per_gpu`. Two users running from their own copies therefore allocate independently, and under `gpu_ids: "all"` both pools resolve to every GPU of the host, so each device runs twice the jobs asked for while both runs' `[gpu_slots] acquired` lines still report one job per device. Give each user a disjoint `CUDA_VISIBLE_DEVICES` share so their pools cannot overlap. The slot allocator also needs a POSIX host, since `fcntl.flock` has no Windows implementation, so GPU mode requires WSL2 rather than Git Bash; CPU mode wraps no job and is unaffected. Runtime Apptainer support is a planned follow-up; its per-device mechanism would be the `CUDA_VISIBLE_DEVICES` environment variable, since `apptainer --nv` has no per-device flag.
 
 ### Visualizing the file-flow graph
 
@@ -418,6 +445,8 @@ pixi run -e pipeline ouroboros --max-iters 3 --cores 4
 | `--config`    | `inputs/quick_run/config.yaml` | Pipeline run config file.               |
 | `--max-iters` | `3`           | Number of iterations (independent forward passes).   |
 | `--cores`     | `4`           | Cores passed to `snakemake --cores`.                 |
+| `--gpu-ids`   | the config's `gpu_ids` | Forwarded to every iteration's `snakemake --config` (see [Multi-GPU scheduling](#multi-gpu-scheduling)). |
+| `--jobs-per-gpu` | the config's `jobs_per_gpu` | Forwarded to every iteration's `snakemake --config`. |
 
 > [!NOTE]
 > Each iteration is a full forward pass, so Docker must be running and all stage images must be available (the loop exercises `stage-1-vmec` through `stage-5-neopax`; the post-processing step reuses the Stage 5 image). The driver runs on the orchestration `pipeline` env, like Snakemake itself.

--- a/docs/potential_issues.md
+++ b/docs/potential_issues.md
@@ -41,5 +41,3 @@
 - [ ] Container registry for external collaborators: where do external contributors host their alternative stage implementations? Maybe their own GHCR or Docker Hub, with the workflow engine pulling from there.
 - [ ] How to expose the workflow engine to external users.
 - [ ] How to validate that externally submitted containers are not a security threat.
-- [ ] Parallelization strategy: when a stage's internal loop can be parallelized across threads or compute nodes, should Snakemake handle the distribution or should the stage software manage it internally?
-	- [ ] Consider an intermediate orchestration layer between Snakemake and the stage software that handles parallelization.

--- a/inputs/quick_run/config.yaml
+++ b/inputs/quick_run/config.yaml
@@ -4,8 +4,13 @@
 # Independent of the input_dir/output_dir folder name; describes the physics case.
 run_name: HSX_vacuum_ns201_quickrun
 
-# Container runtime device. One of: cpu, gpu.
-device: cpu
+# Container runtime GPU pool. One of:
+# null: run every stage on CPU images with no GPU access.
+# "all": run GPU images, pinning each concurrent job to one free GPU of the execution host
+# ids e.g. "4,5,6,7": run GPU images with each concurrent job pinned to one free id from the pool.
+gpu_ids: null
+# Concurrent jobs allowed per GPU.
+jobs_per_gpu: 1
 
 
 input_dir: inputs/quick_run
@@ -71,9 +76,6 @@ stage3:
     nx: 4
     solver_tolerance: 1.0e-6
 
-    # Used only when `device: gpu`.
-    gpu_ids: "0"
-
     # --- Toggles ---
     plot: true
     verbose_workers: true
@@ -125,9 +127,6 @@ stage4:
     # dkap_density: 0.5
     # dkap_temperature: 0.5
     # perturb_rel_step: 0.5
-
-    # Used only when `device: gpu`.
-    gpu_ids: "0"
 
     # --- Toggles ---
     plot: true

--- a/src/gpu_slots.py
+++ b/src/gpu_slots.py
@@ -1,0 +1,376 @@
+"""GPU slot allocator wrapping one pipeline job's container launch.
+
+Pins each concurrent job to one free slot so that no two jobs claim the same share of a device. Takes
+an exclusive ``flock`` on one lock file per slot, substitutes the acquired id into the wrapped
+command's ``@GPU_ID@`` tokens, runs the command as a plain argv list with the lock held, and exits
+with its status. Progress lines go to stderr. Run it from the repository root as
+``python -m src.gpu_slots --gpu-ids 4,5 --jobs-per-gpu 2 --lock-dir DIR -- COMMAND...``. The Multi-GPU
+scheduling section of ``docs/mvp-pipeline.md`` covers how the Snakefile drives this and what the run
+config's keys mean.
+
+``--gpu-ids all`` resolves at job start to the entries of ``CUDA_VISIBLE_DEVICES`` when that variable
+is set, taken verbatim as integer indices or GPU UUID names, and to every index ``nvidia-smi`` reports
+otherwise. MIG device names are unsupported, since a slot hands a job one whole GPU.
+
+The filesystem holding the lock directory must grant locks, and one that refuses stops the run. A
+SIGKILLed wrapper orphans its docker client child, so a container can briefly outlive the freed slot;
+Snakemake cancels jobs by signalling the process group, which reaches the docker client too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import random
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from .utils import parse_gpu_pool
+
+GPU_ID_TOKEN = "@GPU_ID@"
+
+
+def _pool_from_visible_devices(raw: str) -> tuple[str, ...]:
+    """Read a set ``CUDA_VISIBLE_DEVICES`` value as the pool it allows this job.
+
+    Parameters
+    ----------
+    raw : str
+        The variable's value, whose comma-separated entries are integer indices or GPU UUID names such as
+        ``"GPU-c64146c9-1234-5678-9abc-def012345678"``.
+
+    Returns
+    -------
+    tuple[str, ...]
+        The entries as written with surrounding whitespace removed, in the order the variable lists them.
+
+    Raises
+    ------
+    RuntimeError
+        If the variable holds no entry, has an empty entry, or repeats one.
+
+    Notes
+    -----
+    A UUID name has no numeric form to normalize to, so entries are kept verbatim and compared as written. Two
+    spellings of one device, such as an index and that device's UUID, therefore pass as distinct entries.
+    """
+    if not raw.strip():
+        raise RuntimeError(
+            "CUDA_VISIBLE_DEVICES is set but empty, so --gpu-ids all resolves to no device at all. Unset it to use "
+            "every GPU nvidia-smi reports on this host, or set it to the ids this run may take, such as \"4,5\"."
+        )
+
+    ids = [entry.strip() for entry in raw.split(",")]
+    if not all(ids):
+        raise RuntimeError(
+            f"CUDA_VISIBLE_DEVICES has an empty entry in {raw!r}, so --gpu-ids all cannot tell which devices this "
+            "run may take. Write its entries as \"4,5\" or as GPU UUID names, with no doubled or trailing comma."
+        )
+
+    # A repeated entry hands the same device two job slots, silently oversubscribing it while the run still looks
+    # evenly spread across the pool.
+    duplicates = sorted({gpu_id for gpu_id in ids if ids.count(gpu_id) > 1})
+    if duplicates:
+        raise RuntimeError(
+            f"CUDA_VISIBLE_DEVICES names device(s) {duplicates} more than once in {raw!r}, which would give one "
+            "device twice its share of the run. List each device once."
+        )
+    return tuple(ids)
+
+
+def _pool_from_nvidia_smi() -> tuple[str, ...]:
+    """Enumerate the execution host's GPU indices with ``nvidia-smi``.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Every index nvidia-smi reports, normalized by ``parse_gpu_pool``, in the order of the query's output.
+
+    Raises
+    ------
+    RuntimeError
+        If nvidia-smi is not on PATH, hangs, exits nonzero, reports no GPU, or reports lines that are not an id list.
+    """
+    query = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
+    try:
+        completed = subprocess.run(query, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            "nvidia-smi gave no answer within 30 seconds while enumerating this host's GPUs for --gpu-ids all, "
+            "which usually means a wedged driver. Repair the driver installation, or name the ids this run may "
+            "take in CUDA_VISIBLE_DEVICES or in the run config's gpu_ids to skip enumeration."
+        ) from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "--gpu-ids all needs nvidia-smi to enumerate this host's GPUs, but no nvidia-smi is on PATH. Set "
+            "CUDA_VISIBLE_DEVICES to the ids this run may take, or set the run config's gpu_ids to an explicit id "
+            "list such as \"4,5,6,7\", or set it to null to run the cpu images."
+        ) from exc
+
+    if completed.returncode != 0:
+        # The stderr of a driver mismatch runs to several lines, so it is collapsed to one bounded fragment that
+        # still names the failure.
+        reported = " ".join(completed.stderr.split())[:200] or "nothing on stderr"
+        raise RuntimeError(
+            f"nvidia-smi exited with status {completed.returncode} while enumerating this host's GPUs for --gpu-ids "
+            f"all, reporting {reported!r}. Repair the driver installation, or name the ids this run may take in "
+            "CUDA_VISIBLE_DEVICES or in the run config's gpu_ids."
+        )
+
+    indices = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    if not indices:
+        raise RuntimeError(
+            "nvidia-smi reported no GPU on this host, so --gpu-ids all resolves to no device at all. Set the run "
+            "config's gpu_ids to null to run the cpu images instead."
+        )
+    try:
+        return parse_gpu_pool(",".join(indices))
+    except ValueError as exc:
+        raise RuntimeError(
+            f"nvidia-smi reported {indices} as this host's GPU indices, which is not a usable id list. Name the ids "
+            "this run may take in CUDA_VISIBLE_DEVICES or in the run config's gpu_ids to skip enumeration."
+        ) from exc
+
+
+def resolve_wrapper_pool(value: str) -> tuple[str, ...]:
+    """Turn the ``--gpu-ids`` flag into the ids this job may be pinned to.
+
+    Parameters
+    ----------
+    value : str
+        The flag as written, either ``"all"`` to resolve the execution host's pool now or a comma-separated id list
+        to take as given.
+
+    Returns
+    -------
+    tuple[str, ...]
+        The ids concurrent jobs are pinned to, in the order their slots are tried.
+
+    Raises
+    ------
+    RuntimeError
+        If ``"all"`` cannot be resolved on this host, which is an environment failure rather than a usage error.
+    ValueError
+        If an explicit id list is unusable.
+    """
+    if value.strip().lower() == "all":
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if visible is None:
+            return _pool_from_nvidia_smi()
+        return _pool_from_visible_devices(visible)
+    return parse_gpu_pool(value)
+
+
+def split_wrapper_argv(argv: list[str]) -> tuple[list[str], list[str]]:
+    """Split arguments at the first literal ``--`` into wrapper flags and the wrapped command.
+
+    Parameters
+    ----------
+    argv : list[str]
+        Arguments after the program name, holding this wrapper's own flags, a ``--`` separator, and the command to
+        run under the acquired slot.
+
+    Returns
+    -------
+    tuple[list[str], list[str]]
+        The wrapper's own flags and the wrapped command's argv.
+
+    Raises
+    ------
+    ValueError
+        If no ``--`` separator is present, or if nothing follows it.
+
+    Notes
+    -----
+    The split is manual rather than delegated to the argument parser, so a flag spelled the same way on both sides
+    always stays on the side it was written. Only the first separator is consumed, leaving any later ``--`` to the
+    wrapped command.
+    """
+    if "--" not in argv:
+        raise ValueError(
+            "gpu_slots needs a '--' separator between its own flags and the command to run, as in "
+            "'--gpu-ids 4,5 --jobs-per-gpu 2 --lock-dir .snakemake/gpu_slots -- docker run ...'."
+        )
+    separator = argv.index("--")
+    command = argv[separator + 1 :]
+    if not command:
+        raise ValueError(
+            "gpu_slots was given nothing after its '--' separator; write the command to run under the acquired slot "
+            "after it, as in '-- docker run ...'."
+        )
+    return argv[:separator], command
+
+
+def slot_names(pool: tuple[str, ...], jobs_per_gpu: int) -> list[tuple[str, str]]:
+    """List every GPU slot as a ``(gpu_id, lock filename)`` pair, in the order slots are tried.
+
+    Parameters
+    ----------
+    pool : tuple[str, ...]
+        Normalized GPU ids that concurrent jobs are pinned to.
+    jobs_per_gpu : int
+        How many concurrent jobs may share one pooled id.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        One pair per slot, ordered by slot index first and id second. Every id's first slot therefore comes before
+        any id's second slot, which spreads concurrent jobs across the whole pool before doubling up on a device.
+    """
+    return [(gpu_id, f"gpu{gpu_id}_slot{index}.lock") for index in range(jobs_per_gpu) for gpu_id in pool]
+
+
+def acquire_slot(
+    lock_dir: Path, pool: tuple[str, ...], jobs_per_gpu: int, poll_interval: float
+) -> tuple[str, str, int]:
+    """Block until one GPU slot is free, then take and hold its lock.
+
+    Parameters
+    ----------
+    lock_dir : Path
+        Existing directory holding one lock file per slot.
+    pool : tuple[str, ...]
+        Normalized GPU ids that concurrent jobs are pinned to.
+    jobs_per_gpu : int
+        How many concurrent jobs may share one pooled id.
+    poll_interval : float
+        Seconds to wait before rescanning the slots after a full pass found none free.
+
+    Returns
+    -------
+    tuple[str, str, int]
+        The acquired GPU id, the name of the lock file taken, and the open file descriptor holding the lock. The
+        caller keeps the descriptor open for as long as the job needs the device and closes it to free the slot.
+
+    Notes
+    -----
+    A wait is reported once rather than every pass, so a job queued behind a long-running one leaves a single line in
+    its log instead of a message per poll.
+    """
+    candidates = slot_names(pool, jobs_per_gpu)
+    reported_wait = False
+    while True:
+        for gpu_id, lock_name in candidates:
+            fd = os.open(lock_dir / lock_name, os.O_CREAT | os.O_RDWR, 0o644)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                # Only a slot held by another job is contention. Any other error means this filesystem hands out no
+                # locks at all, which must not be retried as if a slot were merely busy.
+                os.close(fd)
+                continue
+            except OSError:
+                os.close(fd)
+                raise
+            return gpu_id, lock_name, fd
+
+        if not reported_wait:
+            print(
+                f"[gpu_slots] waiting for a free GPU slot (pool={','.join(pool)}, jobs_per_gpu={jobs_per_gpu})",
+                file=sys.stderr,
+                flush=True,
+            )
+            reported_wait = True
+        # Jobs released together would otherwise rescan the slots in lockstep and keep contending for the same lock
+        # file, so each waiter draws its own unseeded delay to fall out of step with the others.
+        time.sleep(poll_interval + random.uniform(0.0, poll_interval / 4.0))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the parser for the flags written before the ``--`` separator.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Parser for the wrapper's own flags, which never sees the wrapped command's arguments.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m src.gpu_slots",
+        description="Run a command pinned to one free GPU slot from a pool, holding the slot for the command's life.",
+    )
+    parser.add_argument(
+        "--gpu-ids",
+        required=True,
+        help='Comma-separated GPU ids to share out, such as "4,5,6,7", or "all" for the ids this host offers.',
+    )
+    parser.add_argument("--jobs-per-gpu", required=True, type=int, help="Concurrent jobs allowed to share one id.")
+    parser.add_argument("--lock-dir", required=True, type=Path, help="Directory holding one lock file per slot.")
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=1.0,
+        help="Seconds between rescans of the slots while every one of them is taken (default: %(default)s).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Acquire a GPU slot, run the wrapped command pinned to it, and report the command's exit code.
+
+    Parameters
+    ----------
+    argv : list[str] | None
+        Arguments after the program name. ``None`` reads them from ``sys.argv``.
+
+    Returns
+    -------
+    int
+        The wrapped command's exit code, 1 if ``--gpu-ids all`` could not be resolved on this host or the lock
+        directory's filesystem hands out no locks, 127 if the command's executable was not found, or ``128 + N`` if
+        signal N killed it, matching how a shell reports the same outcomes.
+
+    Raises
+    ------
+    ValueError
+        If the ``--`` separator or the command after it is missing, if ``--gpu-ids`` is not a usable id list, or if
+        ``--jobs-per-gpu`` is below 1.
+    """
+    wrapper_args, command = split_wrapper_argv(sys.argv[1:] if argv is None else argv)
+    args = _build_parser().parse_args(wrapper_args)
+
+    # An unresolvable "all" pool says nothing about how the run was written, so it is reported as a plain message
+    # and a failing status rather than as a traceback the user would have to read past.
+    try:
+        pool = resolve_wrapper_pool(args.gpu_ids)
+    except RuntimeError as exc:
+        print(f"[gpu_slots] {exc}", file=sys.stderr, flush=True)
+        return 1
+
+    if args.jobs_per_gpu < 1:
+        raise ValueError(f"--jobs-per-gpu must be at least 1, got {args.jobs_per_gpu}.")
+
+    args.lock_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        gpu_id, lock_name, fd = acquire_slot(args.lock_dir, pool, args.jobs_per_gpu, args.poll_interval)
+    except OSError as exc:
+        print(
+            f"[gpu_slots] cannot lock a slot under {args.lock_dir} ({exc.strerror}), so no job can be pinned to a "
+            "device. Some network filesystems, such as Lustre mounted without flock support, answer every lock this "
+            "way. Run the pipeline from a working copy on a filesystem that grants locks, such as local disk.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    print(f"[gpu_slots] acquired GPU {gpu_id} ({lock_name})", file=sys.stderr, flush=True)
+
+    pinned_command = [arg.replace(GPU_ID_TOKEN, gpu_id) for arg in command]
+    try:
+        completed = subprocess.run(pinned_command)
+    except FileNotFoundError:
+        print(f"[gpu_slots] cannot run {pinned_command[0]!r}; no such executable on PATH.", file=sys.stderr, flush=True)
+        return 127
+    finally:
+        # The slot stays taken until the command has exited, since closing the descriptor releases the lock.
+        os.close(fd)
+
+    if completed.returncode < 0:
+        killing_signal = -completed.returncode
+        return 128 + killing_signal
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ouroboros.py
+++ b/src/ouroboros.py
@@ -11,6 +11,9 @@ The committed inputs under ``input_dir`` are only ever read, never modified.
 An optional ``loop.rerun`` block in the run config flags stages false to freeze them. When a stage is
 frozen the overrides file also carries the flag map and the iteration 1 tree, so the Snakefile reads that
 stage's artifacts from there. With every stage frozen the driver runs a single forward pass and stops.
+
+The ``--gpu-ids`` and ``--jobs-per-gpu`` flags override the run config's matching top-level keys for
+every iteration of one invocation, leaving the config file itself untouched.
 """
 
 from __future__ import annotations
@@ -24,7 +27,7 @@ from pathlib import Path
 
 import yaml
 
-from .utils import LOOP_STAGES, resolve_pipeline_paths, resolve_rerun_flags
+from .utils import LOOP_STAGES, resolve_gpu_settings, resolve_pipeline_paths, resolve_rerun_flags
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +167,7 @@ def run_forward_pass(
     config_path: Path,
     repo_root: Path,
     extra_configfiles: list[Path] | None = None,
+    extra_config: list[str] | None = None,
 ) -> None:
     """
     Run one Snakemake forward pass for an iteration.
@@ -173,6 +177,9 @@ def run_forward_pass(
     extra_configfiles : list[Path], optional
         Config files merged on top of ``config_path`` (e.g. the loop overrides that
         switch Stages 3/4 to prescribed profiles from iteration 2 on).
+    extra_config : list[str], optional
+        Further ``key=value`` entries for the ``--config`` group (e.g. the GPU pool
+        settings this invocation was given), taking precedence over every config file.
     """
     logger.info("Forward pass [%s]: snakemake %s --cores %d", output_dir, target, cores)
     # Extra config files are appended under the single --configfile flag. A second flag
@@ -180,7 +187,7 @@ def run_forward_pass(
     # take precedence in the deep merge, and --config key=value overrides apply last.
     cmd = ["snakemake", target, "--cores", str(cores), "--configfile", str(config_path)]
     cmd += [str(p) for p in (extra_configfiles or [])]
-    cmd += ["--config", f"input_dir={input_dir}", f"output_dir={output_dir}"]
+    cmd += ["--config", f"input_dir={input_dir}", f"output_dir={output_dir}", *(extra_config or [])]
     subprocess.run(cmd, cwd=repo_root, check=True)
 
 
@@ -194,6 +201,11 @@ def main() -> None:
                         help="Number of iterations (independent forward passes) to run (default: 3).")
     parser.add_argument("--cores", type=int, default=4,
                         help="Cores passed to 'snakemake --cores' (default: 4).")
+    parser.add_argument("--gpu-ids", type=str, default=None,
+                        help="Override the config's gpu_ids for every iteration (null, all, or a comma-separated "
+                             "id list).")
+    parser.add_argument("--jobs-per-gpu", type=int, default=None,
+                        help="Override the config's jobs_per_gpu for every iteration.")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
@@ -210,6 +222,23 @@ def main() -> None:
             "config['loop']['reuse_output_dir'] is written by the driver into each iteration's loop_overrides.yaml "
             "and must not appear in the run config, where it would freeze stages already in iteration 1."
         )
+
+    # Validates the effective GPU settings before any iteration tree is created. yaml.safe_load turns "null" into
+    # None and "4" into an integer, while "all" and "4,5" stay strings.
+    effective = dict(config)
+    if args.gpu_ids is not None:
+        effective["gpu_ids"] = yaml.safe_load(args.gpu_ids)
+    if args.jobs_per_gpu is not None:
+        effective["jobs_per_gpu"] = args.jobs_per_gpu
+    resolve_gpu_settings(effective)
+
+    # The flags are forwarded as raw text so snakemake re-parses each value exactly as a config file would.
+    gpu_overrides: list[str] = []
+    if args.gpu_ids is not None:
+        gpu_overrides.append(f"gpu_ids={args.gpu_ids}")
+    if args.jobs_per_gpu is not None:
+        gpu_overrides.append(f"jobs_per_gpu={args.jobs_per_gpu}")
+
     base_out = config["output_dir"]
     base_p = resolve_pipeline_paths(config)
 
@@ -245,7 +274,7 @@ def main() -> None:
         ]
         run_forward_pass(target=iter_p["s5_signal"], input_dir=iter_in, output_dir=iter_out,
                          cores=args.cores, config_path=config_path, repo_root=repo_root,
-                         extra_configfiles=extra_configfiles)
+                         extra_configfiles=extra_configfiles, extra_config=gpu_overrides or None)
 
         prev_p = iter_p  # post-processing wrote both feedback artifacts; they seed iteration n+1
         signal = json.loads(_abs(repo_root, iter_p["s5_signal"]).read_text())

--- a/src/stage3_helper.py
+++ b/src/stage3_helper.py
@@ -108,7 +108,6 @@ def run_one_cmd(
     *,
     docker_prefix: str,
     image: str,
-    stage_cfg: dict,
     output_dir: str,
     device: str,
 ) -> str:
@@ -120,8 +119,6 @@ def run_one_cmd(
         ``docker run ...`` prefix prepared by the Snakefile.
     image : str
         Container image for Stage 3 (e.g. ``ghcr.io/.../stage-3-sfincs-cpu``).
-    stage_cfg : dict
-        The ``config.yaml`` ``stage3.sfincs_jax`` block.
     output_dir : str
         Stage 3 output directory (already ``{run_name}``-substituted).
     device : str
@@ -150,7 +147,6 @@ def collect_cmd(
     image: str,
     stage_cfg: dict,
     output_dir: str,
-    device: str,
 ) -> str:
     """Compose the Stage 3 ``sfincs_jax`` ``collect`` shell command.
 
@@ -164,9 +160,6 @@ def collect_cmd(
         The ``config.yaml`` ``stage3.sfincs_jax`` block.
     output_dir : str
         Stage 3 output directory (already ``{run_name}``-substituted).
-    device : str
-        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature and
-        not used by the reduction step.
 
     Returns
     -------

--- a/src/stage3_helper.py
+++ b/src/stage3_helper.py
@@ -125,7 +125,8 @@ def run_one_cmd(
     output_dir : str
         Stage 3 output directory (already ``{run_name}``-substituted).
     device : str
-        ``"cpu"`` or ``"gpu"``; controls the JAX backend and GPU pinning.
+        ``"cpu"`` or ``"gpu"``; selects the worker's JAX backend. Device
+        assignment lives in ``docker_prefix``.
 
     Returns
     -------
@@ -140,8 +141,6 @@ def run_one_cmd(
         f"--payload {output_dir}/runs/{{wildcards.surf}}/payload.json",
         f"--backend {device}",
     ]
-    if device == "gpu" and stage_cfg.get("gpu_ids") is not None:
-        parts.append(f"--gpu-ids {stage_cfg['gpu_ids']}")
     return " ".join(parts)
 
 

--- a/src/stage4_helper.py
+++ b/src/stage4_helper.py
@@ -71,7 +71,6 @@ def prepare_cmd(
     image: str,
     stage_cfg: dict,
     output_dir: str,
-    device: str,
 ) -> str:
     """Compose the Stage 4 SPECTRAX-GK ``prepare`` shell command.
 
@@ -90,10 +89,6 @@ def prepare_cmd(
         The ``config.yaml`` ``stage4.spectrax_gk`` block.
     output_dir : str
         Stage 4 output directory (already ``{run_name}``-substituted).
-    device : str
-        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature. The
-        prepare step only writes the manifest and runtime TOMLs, and its parser
-        takes no backend flag, so no device flag is emitted.
 
     Returns
     -------
@@ -167,7 +162,6 @@ def collect_cmd(
     image: str,
     stage_cfg: dict,
     output_dir: str,
-    device: str,
 ) -> str:
     """Compose the Stage 4 SPECTRAX-GK ``collect`` shell command.
 
@@ -181,9 +175,6 @@ def collect_cmd(
         The ``config.yaml`` ``stage4.spectrax_gk`` block.
     output_dir : str
         Stage 4 output directory (already ``{run_name}``-substituted).
-    device : str
-        ``"cpu"`` or ``"gpu"``; accepted for a uniform composer signature and
-        not used by the reduction step.
 
     Returns
     -------

--- a/src/stage4_helper.py
+++ b/src/stage4_helper.py
@@ -136,7 +136,9 @@ def run_one_cmd(
     output_dir : str
         Stage 4 output directory (already ``{run_name}``-substituted).
     device : str
-        ``"cpu"`` or ``"gpu"``; controls the JAX backend and GPU pinning.
+        ``"cpu"`` or ``"gpu"``; selects the worker's JAX backend. Device
+        assignment lives in ``docker_prefix``, so no GPU flag is emitted here
+        and the worker pins the device its container exposes.
 
     Returns
     -------
@@ -152,10 +154,6 @@ def run_one_cmd(
         "--run-name {wildcards.surf}",
         f"--backend {device}",
     ]
-    # The raw comma-separated config value is passed through and the worker pins the first id,
-    # matching Stage 3; distributing a multi-GPU list across surfaces is a deferred follow-up.
-    if device == "gpu" and stage_cfg.get("gpu_ids") is not None:
-        parts.append(f"--gpu-ids {stage_cfg['gpu_ids']}")
     # --verbose-worker is a plain store_true with no negative form, so only an explicit config True
     # emits it; False and a missing key both leave the worker at its quiet default.
     if stage_cfg.get("verbose_workers") is True:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,13 +1,17 @@
 """Shared utilities for the driftless-star Snakemake workflow."""
 
 from .config_edit import apply_assignments
+from .gpu import GpuSettings, parse_gpu_pool, resolve_gpu_settings
 from .loop import LOOP_STAGES, resolve_rerun_flags
 from .paths import RESOLVED_COMMON_CONFIG, resolve_pipeline_paths
 
 __all__ = [
+    "GpuSettings",
     "LOOP_STAGES",
     "RESOLVED_COMMON_CONFIG",
     "apply_assignments",
+    "parse_gpu_pool",
+    "resolve_gpu_settings",
     "resolve_pipeline_paths",
     "resolve_rerun_flags",
 ]

--- a/src/utils/gpu.py
+++ b/src/utils/gpu.py
@@ -1,0 +1,198 @@
+"""GPU pool resolution
+
+``resolve_gpu_settings`` turns a run config's top-level ``gpu_ids`` and ``jobs_per_gpu``
+keys into the container image variant to run, the pool of GPU ids concurrent jobs are
+pinned to, and how many jobs may share one id. The Snakefile validates at parse time and
+the closed-loop driver (``src/ouroboros.py``) at startup, so an unusable pool is reported
+before any job starts.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class GpuSettings(NamedTuple):
+    """Resolved GPU pool settings for one run.
+
+    Attributes
+    ----------
+    device : str
+        ``"cpu"`` or ``"gpu"``, selecting the ``-cpu`` or ``-gpu`` container image variant every stage runs in.
+    pool : tuple[str, ...]
+        Normalized GPU ids that concurrent jobs are pinned to, in config order. Empty when running on cpu and when
+        ``"all"`` leaves the ids to be resolved on the execution host at job start.
+    jobs_per_gpu : int
+        How many concurrent jobs may share one pooled id. Always 1 unless a gpu run raises it.
+    """
+
+    device: str
+    pool: tuple[str, ...]
+    jobs_per_gpu: int
+
+
+def parse_gpu_pool(value: str) -> tuple[str, ...]:
+    """Split a comma-separated GPU id list into normalized ids.
+
+    Parameters
+    ----------
+    value : str
+        Comma-separated GPU ids, for example ``"4,5,6,7"``. Whitespace around an id is ignored and leading zeros are
+        dropped, so ``" 04 , 5"`` normalizes to ``("4", "5")``.
+
+    Returns
+    -------
+    tuple[str, ...]
+        The normalized ids, in the order they were written.
+
+    Raises
+    ------
+    ValueError
+        If an entry is empty, is not an integer, or is negative, or if two entries name the same device once
+        normalized.
+    """
+    ids: list[str] = []
+    for entry in value.split(","):
+        token = entry.strip()
+        if not token:
+            raise ValueError(f"config['gpu_ids'] has an empty entry in {value!r}; write ids as \"4,5,6,7\".")
+        try:
+            gpu_id = int(token)
+        except ValueError as exc:
+            raise ValueError(
+                f"config['gpu_ids'] entry {token!r} is not an integer; write ids as \"4,5,6,7\"."
+            ) from exc
+        if gpu_id < 0:
+            raise ValueError(f"config['gpu_ids'] entry {token!r} is negative; GPU ids start at 0.")
+        ids.append(str(gpu_id))
+
+    # A repeated id hands the same device two job slots, silently oversubscribing it while the run still looks
+    # evenly spread across the pool.
+    duplicates = sorted({gpu_id for gpu_id in ids if ids.count(gpu_id) > 1})
+    if duplicates:
+        raise ValueError(f"config['gpu_ids'] names id(s) {duplicates} more than once in {value!r}; list each id once.")
+    return tuple(ids)
+
+
+def _resolve_pool(raw: object) -> tuple[str, tuple[str, ...]]:
+    """Turn a raw ``gpu_ids`` value into the container image variant and the pinned id pool.
+
+    Parameters
+    ----------
+    raw : object
+        Value of the run config's ``gpu_ids`` key, or ``None`` when the key is absent.
+
+    Returns
+    -------
+    tuple[str, tuple[str, ...]]
+        The image variant (``"cpu"`` or ``"gpu"``) and the normalized ids jobs are pinned to. The pool is empty for a
+        cpu run and for an ``"all"`` run, whose ids are resolved on the execution host at job start.
+
+    Raises
+    ------
+    ValueError
+        If the value is a boolean, a negative integer, an empty or unrecognized string, or any other type.
+    """
+    if raw is None:
+        return "cpu", ()
+    # ``True`` would otherwise reach the integer branch and pin every job to id 1, so booleans are rejected first.
+    if isinstance(raw, bool):
+        raise ValueError(f"config['gpu_ids'] must be null, \"all\", or a comma-separated id list, got {raw!r}.")
+    if isinstance(raw, int):
+        if raw < 0:
+            raise ValueError(f"config['gpu_ids'] is negative ({raw}); GPU ids start at 0.")
+        return "gpu", (str(raw),)
+    if isinstance(raw, str):
+        text = raw.strip()
+        lowered = text.lower()
+        if lowered in ("null", "none"):
+            return "cpu", ()
+        if lowered == "all":
+            return "gpu", ()
+        if not text:
+            raise ValueError(
+                "config['gpu_ids'] is empty; use null for cpu, \"all\" for the execution host's own GPUs, or a "
+                "comma-separated id list such as \"4,5,6,7\"."
+            )
+        return "gpu", parse_gpu_pool(text)
+    raise ValueError(
+        f"config['gpu_ids'] must be null, \"all\", or a comma-separated id list, got {type(raw).__name__}. "
+        "Quote a list of ids as a single string, such as \"4,5,6,7\"."
+    )
+
+
+def _resolve_jobs_per_gpu(raw: object, device: str) -> int:
+    """Check a raw ``jobs_per_gpu`` value against the resolved image variant.
+
+    Parameters
+    ----------
+    raw : object
+        Value of the run config's ``jobs_per_gpu`` key, or 1 when the key is absent.
+    device : str
+        Image variant resolved from ``gpu_ids``, either ``"cpu"`` or ``"gpu"``.
+
+    Returns
+    -------
+    int
+        The number of concurrent jobs allowed to share one pooled id.
+
+    Raises
+    ------
+    ValueError
+        If the value is not a whole number of at least 1, or if it is raised above 1 for a cpu run.
+    """
+    # A quoted "2" and a true/false value are rejected rather than coerced, so a typo cannot quietly change how many
+    # jobs land on each device.
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(f"config['jobs_per_gpu'] must be a whole number of at least 1, got {raw!r}.")
+    if raw < 1:
+        raise ValueError(f"config['jobs_per_gpu'] must be at least 1, got {raw}.")
+    if raw != 1 and device == "cpu":
+        raise ValueError(
+            f"config['jobs_per_gpu'] is {raw} but config['gpu_ids'] asks for a cpu run, which has no devices to "
+            "share out. Raise jobs_per_gpu only alongside gpu_ids set to \"all\" or to an id list such as \"4,5,6,7\"."
+        )
+    return raw
+
+
+def resolve_gpu_settings(config: dict) -> GpuSettings:
+    """Turn a run config's ``gpu_ids`` and ``jobs_per_gpu`` keys into resolved GPU pool settings.
+
+    Parameters
+    ----------
+    config : dict
+        Parsed run config. ``gpu_ids`` is null to run the cpu images, ``"all"`` to run the gpu images with each
+        concurrent job pinned to one free GPU of the execution host, or a comma-separated id list such as
+        ``"4,5,6,7"`` to run the gpu images with each concurrent job pinned to one free id from that pool. An
+        ``"all"`` pool is resolved at job start and covers every GPU of the host, or only the ids
+        ``CUDA_VISIBLE_DEVICES`` lists when that variable is set. ``jobs_per_gpu`` defaults to 1 and may only be
+        raised for a gpu run.
+
+    Returns
+    -------
+    GpuSettings
+        The container image variant, the pinned id pool, and the per-id job slot count.
+
+    Raises
+    ------
+    ValueError
+        If the config still carries a ``device`` key, if ``gpu_ids`` has an unusable type or value, or if
+        ``jobs_per_gpu`` is not a whole number of at least 1 or is raised above 1 for a cpu run.
+
+    Notes
+    -----
+    Values passed on the snakemake command line as ``--config gpu_ids=...`` arrive already parsed. A bare integer
+    comes through as an ``int``, while ``null`` and any id list arrive as plain text, because the fallback parser
+    keeps every scalar it does not recognize as a string. Both spellings of each mode are therefore accepted.
+    """
+    if "device" in config:
+        raise ValueError(
+            "config['device'] is not read anymore; set the top-level gpu_ids key instead, where null runs the cpu "
+            "images, \"all\" runs the gpu images with each concurrent job pinned to one free GPU of the execution "
+            "host, and a comma-separated id list such as \"4,5,6,7\" runs the gpu images with each concurrent job "
+            "pinned to one free id from that pool."
+        )
+
+    device, pool = _resolve_pool(config.get("gpu_ids"))
+    jobs_per_gpu = _resolve_jobs_per_gpu(config.get("jobs_per_gpu", 1), device)
+    return GpuSettings(device=device, pool=pool, jobs_per_gpu=jobs_per_gpu)

--- a/tests/e2e/test_dry_run_dag.py
+++ b/tests/e2e/test_dry_run_dag.py
@@ -126,15 +126,14 @@ def test_loop_overrides_switch_stage_prepares_to_prescribed(tmp_path: Path) -> N
     assert "--profiles-source analytical" not in output, output
 
 
-# The Snakefile validates the `device` config at parse time, before any job runs. This dry-runs with `device=bogus` and
-# asserts the run fails (non-zero exit) with a message saying device must be 'cpu' or 'gpu', confirming a bad value is
-# caught early rather than deep into an execution.
-def test_invalid_device_fails_at_parse(tmp_path: Path) -> None:
-    result = _dry_run(tmp_path, targets=[], config_overrides=["device=bogus"])
+# The Snakefile validates the GPU pool config at parse time, before any job runs. The retired `device` key must be
+# rejected (non-zero exit) with a migration hint naming the gpu_ids replacement, confirming an out-of-date config is
+# caught early rather than silently planning a CPU run.
+def test_device_key_fails_at_parse_with_migration_hint(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["device=gpu"])
     output = result.stdout + result.stderr
     assert result.returncode != 0, output
-    # The Snakefile's parse-time device guard rejects anything but cpu/gpu.
-    assert "must be 'cpu' or 'gpu'" in output, output
+    assert "gpu_ids" in output, output
 
 
 # A perturbed fd_gradients sibling run-directory must be schedulable by stage4_run_one exactly like a baseline

--- a/tests/e2e/test_dry_run_gpu.py
+++ b/tests/e2e/test_dry_run_gpu.py
@@ -1,0 +1,92 @@
+"""Dry-run tests of the GPU wiring the Snakefile plans into every container launch.
+
+``snakemake -n -p`` resolves the GPU pool config and formats every stage's shell
+command without starting a container, so the three modes can be told apart from the
+planned text alone on a machine with no GPU and no Docker.
+
+What is pinned here is the boundary between the modes. A cpu run must plan no device
+flag at all, while both GPU modes must route every single container launch through the
+allocator, because one unwrapped launch would take a device the allocator believes is
+free. The two GPU modes differ only in where the pool comes from. An explicit list is
+planned as ids, and "all" is planned as the word itself, since the host's own ids are
+resolved by the allocator when the job starts. The malformed cases pin that the pool is
+resolved at parse time, so a typo costs nothing rather than failing hours into a run.
+
+The ``_dry_run`` helper is shared with the DAG tests, which documents the isolation it
+applies to keep every write under tmp.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e.test_dry_run_dag import _dry_run
+
+# Exactly how the Snakefile spells the allocator in front of a wrapped launch, for a pool named as ids and for one left
+# to the execution host. The lock directory is a repo-relative path because every job already runs from the repo root,
+# so all of a run's jobs share one set of slot locks. The "all" spelling carries a jobs_per_gpu of 1 because the run
+# that uses it overrides only gpu_ids and the committed config sets that key to 1.
+SLOT_PREFIX = "python -m src.gpu_slots --gpu-ids 4,5 --jobs-per-gpu 2 --lock-dir .snakemake/gpu_slots -- "
+ALL_SLOT_PREFIX = "python -m src.gpu_slots --gpu-ids all --jobs-per-gpu 1 --lock-dir .snakemake/gpu_slots -- "
+
+
+# The committed config runs on cpu, so the default plan must carry no device flag and no allocator, and must select the
+# cpu image variant for every stage. Passing gpu_ids=null on the command line is the same request written the other way,
+# and snakemake's config parser keeps it as the plain text "null", so this pins that both spellings plan the same run.
+def test_null_pool_plans_cpu_images_with_no_device_flag(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["gpu_ids=null"], printshellcmds=True)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "--gpus" not in output, output
+    assert "src.gpu_slots" not in output, output
+    assert "stage-1-vmec-cpu" in output, output
+
+
+# Naming the host instead of a pool still pins every job to one device, so an "all" run must be wrapped exactly like an
+# explicit pool, with the word carried through to the allocator and the id token left for it to substitute. The plan
+# must never hand a container the whole machine, which is what the retired --gpus all flag did and what would let two
+# jobs share a device the allocator believes it gave to one of them.
+def test_all_plans_wrapped_containers_pinned_to_one_device(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["gpu_ids=all"], printshellcmds=True)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert ALL_SLOT_PREFIX in output, output
+    assert "--gpus device=@GPU_ID@" in output, output
+    assert "stage-1-vmec-gpu" in output, output
+    assert "--gpus all" not in output, output
+    assert output.count("docker run") > 0, output
+    assert output.count("docker run") == output.count("src.gpu_slots"), output
+
+
+# With an explicit pool the guarantee is that no container can reach a device without going through the allocator, so
+# the count of planned launches and the count of allocator invocations must match exactly. A single unwrapped launch
+# would see a device the allocator has already handed to another job. The token is left unsubstituted in the plan
+# because the id is only known once a slot is acquired at run time.
+def test_pinned_pool_wraps_every_planned_container(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["gpu_ids=4,5", "jobs_per_gpu=2"], printshellcmds=True)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert SLOT_PREFIX in output, output
+    assert "--gpus device=@GPU_ID@" in output, output
+    assert "stage-1-vmec-gpu" in output, output
+    assert output.count("docker run") > 0, output
+    assert output.count("docker run") == output.count("src.gpu_slots"), output
+
+
+# A mistyped id must be caught while the DAG is being built, before any job runs, and the message must name the entry
+# that could not be read so a long pool with one bad id is actionable.
+def test_malformed_pool_fails_at_parse_naming_the_entry(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["gpu_ids=bogus"])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "bogus" in output, output
+
+
+# Raising jobs_per_gpu without naming ids describes an oversubscription of nothing, which is almost always a forgotten
+# gpu_ids rather than a deliberate choice. The message must name both keys so the user knows which one to add.
+def test_jobs_per_gpu_without_a_pool_fails_at_parse(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["jobs_per_gpu=2"])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "jobs_per_gpu" in output, output
+    assert "gpu_ids" in output, output

--- a/tests/orchestration/test_gpu.py
+++ b/tests/orchestration/test_gpu.py
@@ -1,0 +1,110 @@
+"""Tests for ``src.utils.gpu``.
+
+``resolve_gpu_settings`` turns a run config's ``gpu_ids`` and ``jobs_per_gpu`` keys
+into the container image variant every stage runs in, the pool of device ids
+concurrent jobs are pinned to, and how many jobs may share one id. A pool misread
+here would run the whole pipeline on the wrong image variant, crowd every job onto
+one device, or pin jobs to a device that is not there, so these tests pin the exact
+settings each accepted spelling resolves to and the rejection of the values a typo
+produces.
+
+Both spellings of every mode are covered because a config file and a snakemake
+``--config gpu_ids=...`` override deliver the same mode differently. A bare integer
+arrives as an ``int`` while ``null`` and every id list arrive as plain text.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.utils import GpuSettings, parse_gpu_pool, resolve_gpu_settings
+
+CPU = GpuSettings(device="cpu", pool=(), jobs_per_gpu=1)
+
+
+# Every config a user is allowed to write, paired with the settings it must resolve to. The three modes are cpu (no
+# gpu_ids), the execution host's own devices enumerated at job start ("all"), and an explicit pool named here. Both gpu
+# modes pin each job to one id, so "all" resolves to an empty pool only because its ids are not knowable until the job
+# runs on the host. The whitespace, leading-zero and quoted-integer cases pin the normalization that makes " 04 , 5" and
+# "4,5" the same pool, so a lock file name cannot depend on how the ids were spelled.
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, CPU),
+        ({"gpu_ids": None}, CPU),
+        ({"gpu_ids": "null"}, CPU),
+        ({"gpu_ids": "None"}, CPU),
+        ({"gpu_ids": "all"}, GpuSettings("gpu", (), 1)),
+        ({"gpu_ids": "ALL"}, GpuSettings("gpu", (), 1)),
+        ({"gpu_ids": "4,5,6,7"}, GpuSettings("gpu", ("4", "5", "6", "7"), 1)),
+        ({"gpu_ids": " 4 , 5 "}, GpuSettings("gpu", ("4", "5"), 1)),
+        ({"gpu_ids": "07,8"}, GpuSettings("gpu", ("7", "8"), 1)),
+        ({"gpu_ids": 4}, GpuSettings("gpu", ("4",), 1)),
+        ({"gpu_ids": 0}, GpuSettings("gpu", ("0",), 1)),
+        ({"gpu_ids": "0"}, GpuSettings("gpu", ("0",), 1)),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": 2}, GpuSettings("gpu", ("4", "5"), 2)),
+        ({"gpu_ids": "all", "jobs_per_gpu": 2}, GpuSettings("gpu", (), 2)),
+    ],
+)
+def test_accepted_configs_resolve_to_expected_settings(config: dict, expected: GpuSettings) -> None:
+    assert resolve_gpu_settings(config) == expected
+
+
+# Each rejected config is paired with a fragment of the message it must raise, so a rewording that drops the offending
+# key or value from the message fails here. The device cases catch a config written before the key was replaced, which
+# would otherwise plan a cpu run while the user believes they asked for GPUs. The gpu_ids cases catch a mistyped list,
+# a negative id, a repeat that would silently double up on one device, and the types a YAML list or a bare true would
+# deliver. The jobs_per_gpu cases catch values that are not whole numbers of at least 1, and the last three catch
+# raising the count for a cpu run, which has no device to share out at all and is almost always a forgotten gpu_ids.
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"device": "cpu"}, "gpu_ids"),
+        ({"device": "gpu"}, "gpu_ids"),
+        ({"gpu_ids": ""}, re.escape("config['gpu_ids'] is empty")),
+        ({"gpu_ids": "all,1"}, re.escape("entry 'all' is not an integer")),
+        ({"gpu_ids": "a,b"}, re.escape("entry 'a' is not an integer")),
+        ({"gpu_ids": "-1"}, re.escape("entry '-1' is negative")),
+        ({"gpu_ids": -1}, re.escape("config['gpu_ids'] is negative (-1)")),
+        ({"gpu_ids": "4,,5"}, re.escape("has an empty entry in '4,,5'")),
+        ({"gpu_ids": "4,4"}, re.escape("names id(s) ['4'] more than once")),
+        ({"gpu_ids": "04,4"}, re.escape("names id(s) ['4'] more than once")),
+        ({"gpu_ids": True}, re.escape("got True")),
+        ({"gpu_ids": 4.5}, re.escape("got float")),
+        ({"gpu_ids": [4, 5]}, re.escape("got list")),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": 0}, re.escape("config['jobs_per_gpu'] must be at least 1, got 0")),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": -1}, re.escape("config['jobs_per_gpu'] must be at least 1, got -1")),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": "2"}, re.escape("whole number of at least 1, got '2'")),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": 1.5}, re.escape("whole number of at least 1, got 1.5")),
+        ({"gpu_ids": "4,5", "jobs_per_gpu": True}, re.escape("whole number of at least 1, got True")),
+        ({"jobs_per_gpu": 2}, re.escape("config['jobs_per_gpu'] is 2 but config['gpu_ids'] asks for a cpu run")),
+        ({"gpu_ids": None, "jobs_per_gpu": 2}, re.escape("is 2 but config['gpu_ids'] asks for a cpu run")),
+        ({"gpu_ids": "null", "jobs_per_gpu": 3}, re.escape("is 3 but config['gpu_ids'] asks for a cpu run")),
+    ],
+)
+def test_rejected_configs_raise_naming_the_offending_key(config: dict, expected: str) -> None:
+    with pytest.raises(ValueError, match=expected):
+        resolve_gpu_settings(config)
+
+
+# The pool order is the order slots are tried, so it must survive parsing unsorted. A user who lists the ids they were
+# allocated in an unusual order still gets exactly those ids.
+def test_parse_gpu_pool_preserves_the_written_order() -> None:
+    assert parse_gpu_pool("7,0,3") == ("7", "0", "3")
+
+
+# The parser is also reached directly by the slot allocator's --gpu-ids flag, where the user sees only its message. Each
+# case must name the entry that is wrong rather than only the whole list, so a long pool with one typo is actionable.
+@pytest.mark.parametrize(
+    ("value", "offender"),
+    [
+        ("4,x,5", "'x'"),
+        ("4,-2", "'-2'"),
+        ("4,5,4", "['4']"),
+    ],
+)
+def test_parse_gpu_pool_errors_name_the_offending_entry(value: str, offender: str) -> None:
+    with pytest.raises(ValueError, match=re.escape(offender)):
+        parse_gpu_pool(value)

--- a/tests/orchestration/test_gpu_slots.py
+++ b/tests/orchestration/test_gpu_slots.py
@@ -1,0 +1,573 @@
+"""Tests for ``src.gpu_slots`` (the GPU slot allocator wrapping each container launch).
+
+The allocator is the only thing keeping two concurrently scheduled jobs off the same
+share of a device, and it enforces that through an exclusive ``flock`` per slot rather
+than through bookkeeping the pipeline can inspect. The argument splitting, pool
+resolution and slot naming are checked in-process, while everything about mutual
+exclusion is checked by launching real wrappers as subprocesses, because a lock taken
+inside one interpreter would be re-entrant and would prove nothing.
+
+Resolving ``--gpu-ids all`` reads the host the job landed on, so every test that touches
+it sets ``CUDA_VISIBLE_DEVICES`` and ``PATH`` itself, pointing ``PATH`` at a directory
+holding only a fake ``nvidia-smi``. The answers are therefore the same on a workstation
+with GPUs and on CI with none.
+
+The wrapped payloads are plain Python scripts that record the id they were pinned to
+and the wall-clock window they held it for. Comparing those windows is what pins the
+exclusion guarantee, and every recorded window sits strictly inside its wrapper's
+lock-held window, so overlapping records would mean overlapping locks.
+
+Every subprocess wait carries a timeout, so a regression that deadlocks the allocator
+fails the suite instead of hanging it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import fcntl
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from src.gpu_slots import GPU_ID_TOKEN, acquire_slot, main, resolve_wrapper_pool, slot_names, split_wrapper_argv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# Generous enough that a loaded machine never trips it, short enough that a deadlocked allocator fails quickly.
+WRAPPER_TIMEOUT = 60.0
+# Long enough that several waves of jobs are forced to queue behind each other, short enough to keep the suite quick.
+HOLD_SECONDS = 0.5
+
+# Records the id substituted into its argv and the window it held the slot for. time.monotonic() counts from boot on
+# Linux and macOS, so the values are comparable between the workers.
+RECORD_INTERVAL_PAYLOAD = """
+import sys
+import time
+from pathlib import Path
+
+gpu_id, record = sys.argv[1], sys.argv[2]
+start = time.monotonic()
+time.sleep({hold})
+Path(record).write_text(f"{{gpu_id}} {{start}} {{time.monotonic()}}\\n")
+""".format(hold=HOLD_SECONDS)
+
+# Holds its slot until killed, publishing its pid so the test can reap it after the wrapper above it is SIGKILLed.
+HOLD_UNTIL_KILLED_PAYLOAD = """
+import os
+import sys
+import time
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(str(os.getpid()))
+time.sleep(600)
+"""
+
+
+def _wrapper_argv(
+    lock_dir: Path, gpu_ids: str, jobs_per_gpu: int, command: list[str], poll_interval: float | None = None
+) -> list[str]:
+    """Build the argv that runs one command under the allocator.
+
+    Parameters
+    ----------
+    lock_dir : Path
+        Directory the allocator creates its per-slot lock files in.
+    gpu_ids : str
+        Pool passed to ``--gpu-ids``, either a comma-separated id list or ``"all"``.
+    jobs_per_gpu : int
+        Concurrent jobs allowed to share one id.
+    command : list[str]
+        Command to run under the acquired slot, placed after the ``--`` separator.
+    poll_interval : float, optional
+        Seconds between rescans while every slot is taken. ``None`` leaves the allocator's own default.
+
+    Returns
+    -------
+    list[str]
+        Full argv, invoking the allocator as a module so it runs exactly as the Snakefile spells it.
+    """
+    argv = [
+        sys.executable, "-m", "src.gpu_slots",
+        "--gpu-ids", gpu_ids,
+        "--jobs-per-gpu", str(jobs_per_gpu),
+        "--lock-dir", str(lock_dir),
+    ]
+    if poll_interval is not None:
+        argv += ["--poll-interval", str(poll_interval)]
+    return [*argv, "--", *command]
+
+
+def _nvidia_smi_shim(tmp_path: Path, body: str) -> Path:
+    """Write a fake ``nvidia-smi`` and return the directory to use as the whole PATH.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Directory the shim's bin directory is created under.
+    body : str
+        Shell body standing in for the real query, printing what the tool would print and exiting with the status the
+        test is reproducing.
+
+    Returns
+    -------
+    Path
+        Directory holding the shim. Tests set PATH to exactly this directory, so a real nvidia-smi installed on the
+        host cannot be reached and the answer does not depend on the machine the suite runs on.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "nvidia-smi"
+    shim.write_text(f"#!/bin/sh\n{body}\n")
+    shim.chmod(0o755)
+    return bin_dir
+
+
+def _read_records(records: list[Path]) -> list[tuple[str, float, float]]:
+    """Parse the ``<gpu id> <start> <end>`` line each worker wrote.
+
+    Parameters
+    ----------
+    records : list[Path]
+        One record file per worker.
+
+    Returns
+    -------
+    list[tuple[str, float, float]]
+        The id each worker was pinned to and the window it held its slot for.
+    """
+    parsed = []
+    for record in records:
+        gpu_id, start, end = record.read_text().split()
+        parsed.append((gpu_id, float(start), float(end)))
+    return parsed
+
+
+def _max_overlap(windows: list[tuple[float, float]]) -> int:
+    """Count the largest number of windows that were open at the same instant.
+
+    Parameters
+    ----------
+    windows : list[tuple[float, float]]
+        Start and end times, in any order.
+
+    Returns
+    -------
+    int
+        The peak simultaneous count. Windows that merely touch at an endpoint do not count as overlapping, because a
+        released slot is immediately available to the next waiter.
+    """
+    events = [(start, 1) for start, _ in windows] + [(end, -1) for _, end in windows]
+    events.sort()
+    peak = 0
+    open_now = 0
+    for _, delta in events:
+        open_now += delta
+        peak = max(peak, open_now)
+    return peak
+
+
+def _run_workers(tmp_path: Path, gpu_ids: str, jobs_per_gpu: int, workers: int) -> list[tuple[str, float, float]]:
+    """Launch ``workers`` wrappers at once over one pool and return what each one recorded.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Directory holding the payload script, the lock files, and the per-worker records.
+    gpu_ids : str
+        Comma-separated pool every wrapper shares.
+    jobs_per_gpu : int
+        Concurrent jobs allowed to share one id.
+    workers : int
+        Number of wrappers to launch, normally more than the pool has slots so some must queue.
+
+    Returns
+    -------
+    list[tuple[str, float, float]]
+        One ``(gpu id, start, end)`` triple per worker.
+    """
+    payload = tmp_path / "record_interval.py"
+    payload.write_text(RECORD_INTERVAL_PAYLOAD)
+    records = [tmp_path / f"worker_{index}.txt" for index in range(workers)]
+    # A short poll interval keeps a freed slot from sitting idle for most of the test's runtime.
+    procs = [
+        subprocess.Popen(
+            _wrapper_argv(tmp_path / "locks", gpu_ids, jobs_per_gpu,
+                          [sys.executable, str(payload), GPU_ID_TOKEN, str(record)], poll_interval=0.05),
+            cwd=REPO_ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        for record in records
+    ]
+    try:
+        for proc in procs:
+            assert proc.wait(timeout=WRAPPER_TIMEOUT) == 0
+    finally:
+        for proc in procs:
+            proc.kill()
+    return _read_records(records)
+
+
+def _wait_for_text(log: Path, needle: str, timeout: float = WRAPPER_TIMEOUT) -> None:
+    """Block until ``needle`` appears in ``log``, failing the test if it never does.
+
+    Parameters
+    ----------
+    log : Path
+        File the wrapper's stderr is redirected to.
+    needle : str
+        Text to wait for. The allocator flushes each of its messages, so a match means the event has happened.
+    timeout : float
+        Seconds to wait before failing.
+
+    Raises
+    ------
+    AssertionError
+        If the text has not appeared within ``timeout``.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in log.read_text():
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"{needle!r} never appeared in {log}:\n{log.read_text()}")
+
+
+def _flock_refusing_every_lock(limit: int = 10) -> Callable[[int, int], None]:
+    """Build a stand-in for ``fcntl.flock`` that reports a filesystem granting no locks at all.
+
+    Parameters
+    ----------
+    limit : int
+        Attempts to allow before the stand-in fails the test outright. The allocator has to let the first refusal
+        out, so a retry means a failure that was not contention was mistaken for a busy slot. Bounding the attempts
+        turns that regression into a prompt failure instead of the endless wait it would be in a real run.
+
+    Returns
+    -------
+    Callable[[int, int], None]
+        Replacement for ``fcntl.flock`` that always raises ``ENOTSUP``, which is how a network mount without lock
+        support answers.
+    """
+    attempts = {"n": 0}
+
+    def refuse(fd: int, operation: int) -> None:
+        attempts["n"] += 1
+        if attempts["n"] > limit:
+            raise AssertionError("the allocator retried a lock failure that was not contention")
+        raise OSError(errno.ENOTSUP, "Operation not supported")
+
+    return refuse
+
+
+def _kill_recorded_pid(pid_file: Path) -> None:
+    """Kill the process whose pid was written to ``pid_file``, if it is still running.
+
+    Parameters
+    ----------
+    pid_file : Path
+        File a payload wrote its own pid into. A missing file means the payload never got that far.
+    """
+    with contextlib.suppress(FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
+        os.kill(int(pid_file.read_text()), signal.SIGKILL)
+
+
+# The wrapper's own flags and the command it runs are both plain argv, so the split has to be positional. This pins the
+# happy path and the two shapes that leave the allocator with nothing to run.
+def test_split_wrapper_argv_splits_at_the_separator() -> None:
+    assert split_wrapper_argv(["--gpu-ids", "4,5", "--", "docker", "run"]) == (["--gpu-ids", "4,5"], ["docker", "run"])
+
+
+# Only the first separator belongs to the allocator. A wrapped command that takes its own '--' must receive it intact,
+# which is what lets a pipeline job pass flags through to the program inside its container.
+def test_split_wrapper_argv_keeps_a_later_separator_with_the_command() -> None:
+    wrapper, command = split_wrapper_argv(["--lock-dir", "d", "--", "docker", "run", "img", "--", "--flag"])
+    assert wrapper == ["--lock-dir", "d"]
+    assert command == ["docker", "run", "img", "--", "--flag"]
+
+
+# Without a separator the allocator cannot tell its own flags from the command, and with nothing after one there is no
+# command to hold the slot for. Both are caller mistakes that must fail loudly rather than acquire a slot for nothing.
+@pytest.mark.parametrize("argv", [["--gpu-ids", "4,5", "docker", "run"], ["--gpu-ids", "4,5", "--"]])
+def test_split_wrapper_argv_rejects_a_missing_command(argv: list[str]) -> None:
+    with pytest.raises(ValueError, match="'--'"):
+        split_wrapper_argv(argv)
+
+
+# A set CUDA_VISIBLE_DEVICES is how a shared host hands one user their share of it, and exporting it is the supported
+# way to hold "all" to that share. Its entries are taken verbatim because they may be GPU UUID names with no numeric
+# form to normalize to, and because the docker client accepts either spelling as written. The written order is kept,
+# since it is the order slots are tried.
+@pytest.mark.parametrize(
+    ("visible", "expected"),
+    [
+        ("4, 5", ("4", "5")),
+        ("1,0", ("1", "0")),
+        ("07", ("07",)),
+        ("GPU-abc,GPU-def", ("GPU-abc", "GPU-def")),
+    ],
+)
+def test_all_reads_a_set_visible_devices_verbatim(
+    monkeypatch: pytest.MonkeyPatch, visible: str, expected: tuple[str, ...]
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible)
+    assert resolve_wrapper_pool("all") == expected
+
+
+# The Snakefile always writes the flag as "all", but a hand-run wrapper may capitalize it or leave a stray space around
+# it. Either would otherwise be read as an id list and rejected as unparseable.
+@pytest.mark.parametrize("spelling", ["all", "ALL", " all "])
+def test_all_is_recognized_however_it_is_written(monkeypatch: pytest.MonkeyPatch, spelling: str) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+    assert resolve_wrapper_pool(spelling) == ("4", "5")
+
+
+# A variable that names no usable pool must stop the job rather than quietly resolve to something else, since falling
+# back to every GPU of the host would take devices this run was never allowed. The duplicate case is the one that would
+# otherwise hand a single device two slots while the run still looks evenly spread across the pool.
+@pytest.mark.parametrize(
+    ("visible", "expected"),
+    [
+        ("", "CUDA_VISIBLE_DEVICES is set but empty"),
+        ("   ", "CUDA_VISIBLE_DEVICES is set but empty"),
+        ("4,,5", "has an empty entry in '4,,5'"),
+        ("4,", "has an empty entry"),
+        ("4,4", "names device(s) ['4'] more than once"),
+    ],
+)
+def test_all_rejects_a_visible_devices_value_that_names_no_usable_pool(
+    monkeypatch: pytest.MonkeyPatch, visible: str, expected: str
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible)
+    with pytest.raises(RuntimeError, match=re.escape(expected)):
+        resolve_wrapper_pool("all")
+
+
+# With the variable unset, "all" means every GPU the host reports, which is read from nvidia-smi at job start rather
+# than at parse time so one config can be run on hosts with different device counts. The reported indices go through the
+# same normalization an explicit pool does, so a padded index and a plain one name one slot and not two.
+def test_all_enumerates_the_host_when_visible_devices_is_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv("PATH", str(_nvidia_smi_shim(tmp_path, "echo 0\necho 01")))
+
+    assert resolve_wrapper_pool("all") == ("0", "1")
+
+
+# Enumeration failures are environment failures rather than mistakes in how the run was written, so each one has to be
+# reported as such instead of resolving to a pool the job would then run on. The cases are a driver that reports no
+# device, a query that answers with prose, and a driver mismatch that exits nonzero.
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("exit 0", "reported no GPU on this host"),
+        ("echo 'No devices were found'", "not a usable id list"),
+        ("echo 'Driver/library version mismatch' >&2\nexit 9", "exited with status 9"),
+    ],
+)
+def test_all_reports_an_unusable_nvidia_smi_as_an_environment_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str, expected: str
+) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv("PATH", str(_nvidia_smi_shim(tmp_path, body)))
+
+    with pytest.raises(RuntimeError, match=re.escape(expected)):
+        resolve_wrapper_pool("all")
+
+
+# A host with no nvidia-smi at all is the case a user hits by asking for GPUs on a machine that has none, so the message
+# has to name the missing tool rather than surface as a bare file-not-found from deep inside the allocator.
+def test_all_reports_a_missing_nvidia_smi(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    empty_bin = tmp_path / "empty_bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+
+    with pytest.raises(RuntimeError, match="nvidia-smi"):
+        resolve_wrapper_pool("all")
+
+
+# Ids named in the run config are the run's own allocation, so they must be used as written even on a host whose
+# CUDA_VISIBLE_DEVICES says otherwise. Reading the variable here would silently move the run onto devices it was not
+# given, and would make one config resolve to different pools on different login shells.
+def test_an_explicit_pool_ignores_visible_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "9")
+    assert resolve_wrapper_pool("0,1") == ("0", "1")
+
+
+# Slots are tried in the returned order, so every id's first slot must come before any id's second. That ordering is
+# what spreads concurrent jobs across the whole pool before doubling up on a device that is already busy.
+def test_slot_names_spread_across_the_pool_before_doubling_up() -> None:
+    assert slot_names(("4", "5"), 2) == [
+        ("4", "gpu4_slot0.lock"),
+        ("5", "gpu5_slot0.lock"),
+        ("4", "gpu4_slot1.lock"),
+        ("5", "gpu5_slot1.lock"),
+    ]
+
+
+# The whole point of the wrapper is that the command it runs sees a real id in place of the token and that the command's
+# exit status reaches Snakemake unchanged. This runs one wrapper end to end and checks the substituted id came from the
+# pool, that a non-zero payload status is passed through rather than swallowed, and that the acquired device is reported
+# on stderr where the rule's tee pipe records it.
+def test_wrapper_substitutes_the_token_and_passes_the_exit_code_through(tmp_path: Path) -> None:
+    command = [sys.executable, "-c", "import sys; print(sys.argv[1]); raise SystemExit(3)", GPU_ID_TOKEN]
+    result = subprocess.run(
+        _wrapper_argv(tmp_path / "locks", "4,5", 1, command),
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=WRAPPER_TIMEOUT,
+    )
+    assert result.stdout.strip() in ("4", "5"), result
+    assert result.returncode == 3, result
+    assert "acquired GPU" in result.stderr, result
+
+
+# A missing executable and a killed command are reported the way a shell reports them, so a job that dies inside its
+# container is not mistaken for a clean run. The signal case also exercises the release path, since the slot must be
+# freed even though the command never returned normally.
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (["driftless-star-no-such-executable"], 127),
+        ([sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"], 143),
+    ],
+)
+def test_wrapper_reports_shell_style_failure_codes(tmp_path: Path, command: list[str], expected: int) -> None:
+    result = subprocess.run(
+        _wrapper_argv(tmp_path / "locks", "4", 1, command),
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=WRAPPER_TIMEOUT,
+    )
+    assert result.returncode == expected, result
+
+
+# The Snakefile plans "all" as the word itself, so the resolution, the slot files it implies and the substituted id all
+# have to work through the real command line and not only through the resolver. The wrapper is given a two-id share of
+# the host in its own environment, and the id its command prints must be one of those two rather than the word.
+def test_all_reaches_the_wrapped_command_as_a_real_id(tmp_path: Path) -> None:
+    command = [sys.executable, "-c", "import sys; print(sys.argv[1]); raise SystemExit(3)", GPU_ID_TOKEN]
+    result = subprocess.run(
+        _wrapper_argv(tmp_path / "locks", "all", 1, command),
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=WRAPPER_TIMEOUT,
+        env={**os.environ, "CUDA_VISIBLE_DEVICES": "0,1"},
+    )
+    assert result.stdout.strip() in ("0", "1"), result
+    assert result.returncode == 3, result
+    assert "acquired GPU" in result.stderr, result
+
+
+# A host that cannot be resolved says nothing about how the run was written, so the wrapper reports it as a plain line
+# on the stderr the job's tee pipe records and fails, instead of raising a traceback the user has to read past. The
+# command must not run at all, since running it unpinned would put it on whichever devices the container defaults to.
+def test_an_unresolvable_all_pool_fails_before_running_the_command(tmp_path: Path) -> None:
+    marker = tmp_path / "payload_ran.txt"
+    command = [sys.executable, "-c", "import sys; from pathlib import Path; Path(sys.argv[1]).write_text('ran')",
+               str(marker)]
+    result = subprocess.run(
+        _wrapper_argv(tmp_path / "locks", "all", 1, command),
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=WRAPPER_TIMEOUT,
+        env={**os.environ, "CUDA_VISIBLE_DEVICES": ""},
+    )
+    assert result.returncode == 1, result
+    assert "[gpu_slots]" in result.stderr, result
+    assert "Traceback" not in result.stderr, result
+    assert not marker.exists(), result
+
+
+# Six jobs over a two-id pool with one slot each is the case the allocator exists for. Every job must run, both devices
+# must be used rather than one being starved, and no two jobs may ever have held the same id at the same time, which is
+# what pins the exclusion the pipeline relies on to keep two containers off one device.
+def test_one_slot_per_id_serializes_jobs_on_each_device(tmp_path: Path) -> None:
+    parsed = _run_workers(tmp_path, gpu_ids="0,1", jobs_per_gpu=1, workers=6)
+
+    assert len(parsed) == 6
+    assert {gpu_id for gpu_id, _, _ in parsed} == {"0", "1"}
+    for gpu_id in ("0", "1"):
+        windows = [(start, end) for held, start, end in parsed if held == gpu_id]
+        assert _max_overlap(windows) <= 1, parsed
+    assert _max_overlap([(start, end) for _, start, end in parsed]) <= 2, parsed
+
+
+# Raising jobs_per_gpu is how a user packs several small jobs onto one device, so the ceiling must rise exactly with it
+# and no further. Two ids at two jobs each may run four jobs at once, but never a fifth and never three on one device.
+def test_jobs_per_gpu_raises_the_ceiling_by_exactly_that_factor(tmp_path: Path) -> None:
+    parsed = _run_workers(tmp_path, gpu_ids="0,1", jobs_per_gpu=2, workers=6)
+
+    assert len(parsed) == 6
+    for gpu_id in ("0", "1"):
+        windows = [(start, end) for held, start, end in parsed if held == gpu_id]
+        assert _max_overlap(windows) <= 2, parsed
+    assert _max_overlap([(start, end) for _, start, end in parsed]) <= 4, parsed
+
+
+# A cancelled or crashed job must not strand its device for the rest of the run. The kernel drops a flock when the
+# holding process dies, so this SIGKILLs a wrapper that is holding the only slot of a one-id pool and requires the job
+# queued behind it to acquire and finish. The wrapper is killed rather than asked to exit, which is the case no
+# user-space cleanup could handle. Its payload is orphaned by that kill and is reaped through the pid it published,
+# since the payload never inherits the lock and so cannot keep the slot taken.
+def test_a_killed_wrapper_frees_its_slot_for_the_next_job(tmp_path: Path) -> None:
+    payload = tmp_path / "hold_until_killed.py"
+    payload.write_text(HOLD_UNTIL_KILLED_PAYLOAD)
+    pid_file = tmp_path / "holder.pid"
+    holder_log = tmp_path / "holder.err"
+    waiter_log = tmp_path / "waiter.err"
+    lock_dir = tmp_path / "locks"
+
+    with holder_log.open("wb") as holder_stderr, waiter_log.open("wb") as waiter_stderr:
+        holder = subprocess.Popen(
+            _wrapper_argv(lock_dir, "0", 1, [sys.executable, str(payload), str(pid_file)], poll_interval=0.05),
+            cwd=REPO_ROOT, stdout=subprocess.DEVNULL, stderr=holder_stderr,
+        )
+        waiter = None
+        try:
+            _wait_for_text(holder_log, "acquired GPU")
+            waiter = subprocess.Popen(
+                _wrapper_argv(lock_dir, "0", 1, [sys.executable, "-c", "pass"], poll_interval=0.05),
+                cwd=REPO_ROOT, stdout=subprocess.DEVNULL, stderr=waiter_stderr,
+            )
+            # The queued job must report the wait before the holder dies, proving the slot really was taken and that
+            # the acquisition below is a release rather than a race the waiter won on its first pass.
+            _wait_for_text(waiter_log, "waiting for a free GPU slot")
+            holder.kill()
+            holder.wait(timeout=WRAPPER_TIMEOUT)
+            assert waiter.wait(timeout=WRAPPER_TIMEOUT) == 0, waiter_log.read_text()
+        finally:
+            holder.kill()
+            if waiter is not None:
+                waiter.kill()
+            _kill_recorded_pid(pid_file)
+
+    assert "acquired GPU 0" in waiter_log.read_text()
+
+
+# Only a slot another job already holds is contention. A filesystem that grants no locks at all refuses every attempt
+# with a different error, and counting that as contention would leave the job polling for a slot it can never take,
+# which is an endless wait rather than a failure anyone can see. The scan therefore has to let such an error out on
+# the first attempt.
+def test_a_filesystem_granting_no_locks_stops_the_scan(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(fcntl, "flock", _flock_refusing_every_lock())
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+
+    with pytest.raises(OSError, match="Operation not supported"):
+        acquire_slot(lock_dir, ("4", "5"), 1, poll_interval=0.01)
+
+
+# The wrapper reports that filesystem the way it reports an unresolvable pool, as one [gpu_slots] line naming the lock
+# directory and a failing status rather than a traceback. The command must not run, since running it unpinned would
+# put it on whichever devices the container defaults to, which is exactly what the allocator exists to prevent.
+def test_a_filesystem_granting_no_locks_fails_before_running_the_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(fcntl, "flock", _flock_refusing_every_lock())
+    marker = tmp_path / "payload_ran.txt"
+    command = [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).write_text('ran')"]
+    argv = ["--gpu-ids", "4", "--jobs-per-gpu", "1", "--lock-dir", str(tmp_path / "locks"), "--", *command]
+
+    assert main(argv) == 1
+    assert "[gpu_slots]" in capsys.readouterr().err
+    assert not marker.exists()

--- a/tests/orchestration/test_ouroboros_gpu.py
+++ b/tests/orchestration/test_ouroboros_gpu.py
@@ -1,0 +1,159 @@
+"""Tests for the GPU pool flags of ``src.ouroboros`` (the closed-loop driver).
+
+``--gpu-ids`` and ``--jobs-per-gpu`` let one invocation place its containers without
+editing the committed run config, so the flags have to reach every iteration and have
+to be validated before the loop starts building iteration trees. These tests pin both
+halves of that, plus the requirement that an invocation which passes neither flag
+produces the command line it always did.
+
+The isolation tricks are the ones documented in ``tests/orchestration/test_ouroboros.py``,
+whose ``_write_config`` helper is reused here. Paths stay under tmp and the two
+file-touching collaborators are faked, so the control flow runs with no solver and no
+Snakemake.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+import src.ouroboros as ouroboros
+from tests.orchestration.test_ouroboros import _write_config
+
+# The argv a forward pass builds before any GPU flag is added. Overrides passed as --config entries have to come last,
+# after the dir overrides, because snakemake's --config takes every following token until the next flag.
+BASE_ARGV = [
+    "snakemake", "out/converge_status.json", "--cores", "4",
+    "--configfile", "cfg.yaml",
+    "--config", "input_dir=in", "output_dir=out",
+]
+
+
+def _captured_argv(monkeypatch: pytest.MonkeyPatch, **kwargs) -> list[str]:
+    """Run one forward pass against a fake ``subprocess.run`` and return the argv it was handed.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace ``subprocess.run`` so no Snakemake starts.
+    **kwargs
+        Extra keyword arguments for ``run_forward_pass``, on top of the fixed target, dirs, cores, config and root.
+
+    Returns
+    -------
+    list[str]
+        The command the driver would have run.
+    """
+    captured: dict = {}
+
+    def fake_subprocess_run(cmd, **kw):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(ouroboros.subprocess, "run", fake_subprocess_run)
+    ouroboros.run_forward_pass(
+        target="out/converge_status.json",
+        input_dir="in",
+        output_dir="out",
+        cores=4,
+        config_path=Path("cfg.yaml"),
+        repo_root=Path("/repo"),
+        **kwargs,
+    )
+    return captured["cmd"]
+
+
+def _write_config_with_device(tmp_path: Path) -> Path:
+    """Write a run config that still carries the retired top-level ``device`` key.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Directory the config and its input/output dirs live under.
+
+    Returns
+    -------
+    Path
+        The written config file.
+    """
+    config_path = _write_config(tmp_path)
+    config = yaml.safe_load(config_path.read_text())
+    config["device"] = "gpu"
+    config_path.write_text(yaml.safe_dump(config))
+    return config_path
+
+
+# The GPU settings must reach snakemake as --config entries so they beat the run config file and every overrides file
+# the loop layers on top of it. This pins them landing at the very end of the --config group, as raw key=value text that
+# snakemake re-parses exactly as it would the same values written in a config file.
+def test_extra_config_lands_at_the_end_of_the_config_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    cmd = _captured_argv(monkeypatch, extra_config=["gpu_ids=4,5", "jobs_per_gpu=2"])
+
+    assert cmd == [*BASE_ARGV, "gpu_ids=4,5", "jobs_per_gpu=2"]
+
+
+# An invocation that passes neither flag must run the command line it ran before the flags existed, so adding them
+# cannot have changed any established run. Passing None explicitly and leaving the argument out must both do that.
+def test_no_extra_config_leaves_the_command_line_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _captured_argv(monkeypatch, extra_config=None) == BASE_ARGV
+    assert _captured_argv(monkeypatch) == BASE_ARGV
+
+
+# The flags describe the machine the whole invocation runs on, not one pass of it, so every iteration must be given the
+# same placement. This records what each forward pass received across two iterations and requires both to carry the
+# flags verbatim, since an iteration that dropped them would fall back to the config file's cpu setting mid-run.
+def test_flags_reach_every_iteration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setattr(ouroboros, "_seed_iteration_inputs", lambda **kw: None)
+
+    forwarded: list = []
+
+    def fake_run(*, target, extra_config=None, **kw):
+        forwarded.append(extra_config)
+        signal = Path(target)
+        signal.parent.mkdir(parents=True, exist_ok=True)
+        signal.write_text(json.dumps({}))  # neither halt nor converged -> keep looping
+
+    monkeypatch.setattr(ouroboros, "run_forward_pass", fake_run)
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path), "--max-iters", "2",
+                                     "--gpu-ids", "4,5", "--jobs-per-gpu", "2"])
+    ouroboros.main()
+
+    assert forwarded == [["gpu_ids=4,5", "jobs_per_gpu=2"], ["gpu_ids=4,5", "jobs_per_gpu=2"]]
+
+
+# Raising jobs_per_gpu for a cpu run oversubscribes nothing, because a cpu run has no device to share out. The driver
+# resolves the settings from an overlaid copy of the config right after reading it, so the combination is rejected
+# before the first iteration tree is created and the user loses no work to a flag typo. The flags are checked as the
+# config values they become, so "null" has to reach the same guard the config file's own null would.
+def test_cpu_run_with_a_raised_job_count_is_rejected_before_any_iteration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setattr(ouroboros, "_seed_iteration_inputs", lambda **kw: None)
+    monkeypatch.setattr(ouroboros, "run_forward_pass", lambda **kw: None)
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path),
+                                     "--gpu-ids", "null", "--jobs-per-gpu", "2"])
+
+    with pytest.raises(ValueError, match=re.escape("config['jobs_per_gpu'] is 2 but config['gpu_ids'] asks")):
+        ouroboros.main()
+
+    assert not (tmp_path / "out" / "loop").exists()
+
+
+# A run config written before the key was replaced would otherwise run the whole loop on cpu images while the user
+# believes they asked for GPUs. The driver applies the same guard the Snakefile does, at startup, and its message names
+# the replacement key so the config can be migrated.
+def test_retired_device_key_is_rejected_at_startup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = _write_config_with_device(tmp_path)
+    monkeypatch.setattr(ouroboros, "_seed_iteration_inputs", lambda **kw: None)
+    monkeypatch.setattr(ouroboros, "run_forward_pass", lambda **kw: None)
+    monkeypatch.setattr("sys.argv", ["ouroboros", "--config", str(config_path)])
+
+    with pytest.raises(ValueError, match="gpu_ids"):
+        ouroboros.main()
+
+    assert not (tmp_path / "out" / "loop").exists()

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -5,9 +5,9 @@ config block into the three shell commands that the Snakefile's per-phase Stage 
 rules run. The exact strings are the contract with those rules, so this pins them:
 the static base flags (including the literal ``{input.*}`` and ``{wildcards.surf}``
 placeholders Snakemake substitutes at run time), the not-None-only optional flags
-on ``prepare``, the tri-state booleans, the gpu-only ``--gpu-ids`` flag on
-``run-one``, and the absence of scan-level parallelism flags now that surface
-concurrency belongs to ``snakemake --cores``.
+on ``prepare``, the tri-state booleans, and the absence of scan-level parallelism
+and GPU flags now that surface concurrency belongs to ``snakemake --cores`` and
+device assignment to the docker prefix.
 """
 
 from __future__ import annotations
@@ -29,8 +29,8 @@ _scan = load_stage_module(_STAGE3_SCRIPT)
 
 # Every prepare-phase optional key with a quick-run-like value, used both to exercise
 # each flag individually and to prove that a fully-populated config never leaks
-# scan-level parallelism flags. max_parallel is a retired key that older configs may
-# still carry; it must be ignored by every composer.
+# scan-level parallelism flags. max_parallel and gpu_ids are retired keys that older
+# configs may still carry; every composer must ignore them.
 _PREPARE_OPTIONALS: list[tuple[str, str, object]] = [
     ("profiles_source",    "--profiles-source",    "prescribed"),  # the loop's iteration-2+ value, not the default
     ("neopax_result",      "--neopax-result",      "outputs/quick_run/stage5_transport/transport_solution.h5"),
@@ -148,11 +148,12 @@ def test_collect_plot_tristate() -> None:
     assert "--plot" not in absent and "--no-plot" not in absent
 
 
-# GPU pinning applies only to the worker phase: --gpu-ids appears only when the device is gpu AND the config sets
-# gpu_ids. A cpu device suppresses it even when gpu_ids is configured, and a gpu device without gpu_ids emits nothing.
-def test_run_one_gpu_ids_only_on_gpu() -> None:
+# Device assignment lives in the docker run prefix, so the worker command itself carries no GPU flag in either
+# mode. Even a config still holding the retired gpu_ids key must never make run-one emit --gpu-ids; the worker
+# then pins the one device its container exposes.
+def test_run_one_never_emits_gpu_ids() -> None:
     cfg = {"gpu_ids": "0,1"}
-    assert "--gpu-ids 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
     assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu")
     assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu")
 
@@ -166,13 +167,15 @@ def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
     assert args.func.__name__ == "cmd_prepare"
 
 
-# A drift guard for the worker phase: the composed run-one command (gpu variant, so --gpu-ids is included) must parse
-# with the real stage script and dispatch to cmd_run_one, and the payload path must land on the run-one --payload
-# argument rather than on any flat-parser attribute.
+# A drift guard for the worker phase: the composed run-one command (gpu variant) must parse with the real stage script
+# and dispatch to cmd_run_one, and the payload path must land on the run-one --payload argument rather than on any
+# flat-parser attribute. gpu_ids staying at the parser's own "0" default proves the composer sent no id list, so the
+# worker pins device ordinal 0, the one device a pinned container exposes.
 def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
     args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
     assert args.func.__name__ == "cmd_run_one"
     assert args.payload == "outputs/quick_run/stage3_neoclassical/runs/rho_001_r0p1000/payload.json"
+    assert args.gpu_ids == "0"
 
 
 # A drift guard for the reduction phase. The flat (no-subcommand) parser defines its own --output-dir and --plot

--- a/tests/orchestration/test_stage3_helper_cmd.py
+++ b/tests/orchestration/test_stage3_helper_cmd.py
@@ -13,6 +13,7 @@ device assignment to the docker prefix.
 from __future__ import annotations
 
 import argparse
+import inspect
 import re
 from collections.abc import Callable
 
@@ -55,7 +56,11 @@ _FULL_CFG: dict = {key: value for key, _, value in _PREPARE_OPTIONALS} | {
 
 
 def compose(composer: Callable[..., str], **overrides) -> str:
-    """Build a command with quick-run-like defaults, overriding only what a test varies."""
+    """Build a command with quick-run-like defaults, overriding only what a test varies.
+
+    Each composer takes exactly the arguments its phase uses, so the shared defaults are narrowed to the ones the
+    called composer accepts.
+    """
     base = dict(
         docker_prefix="docker run --rm",
         image="ghcr.io/driftless-star/driftless-star:stage-3-sfincs-cpu",
@@ -64,7 +69,8 @@ def compose(composer: Callable[..., str], **overrides) -> str:
         device="cpu",
     )
     base.update(overrides)
-    return composer(**base)
+    accepted = inspect.signature(composer).parameters
+    return composer(**{name: value for name, value in base.items() if name in accepted})
 
 
 def parse_with_stage_script(command: str) -> argparse.Namespace:
@@ -148,14 +154,13 @@ def test_collect_plot_tristate() -> None:
     assert "--plot" not in absent and "--no-plot" not in absent
 
 
-# Device assignment lives in the docker run prefix, so the worker command itself carries no GPU flag in either
-# mode. Even a config still holding the retired gpu_ids key must never make run-one emit --gpu-ids; the worker
-# then pins the one device its container exposes.
+# Device assignment lives in the docker run prefix, so the worker command itself carries no GPU flag in either mode
+# and the worker pins the one device its container exposes. The worker phase reads no stage config at all, so a
+# retired gpu_ids key left in a config file has no path to this command.
 def test_run_one_never_emits_gpu_ids() -> None:
-    cfg = {"gpu_ids": "0,1"}
-    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
-    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu")
-    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, device="cpu")
+    assert "stage_cfg" not in inspect.signature(run_one_cmd).parameters
 
 
 # A drift guard. The exact-string tests only check the composer against itself; this checks it against the real stage
@@ -172,7 +177,7 @@ def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
 # flat-parser attribute. gpu_ids staying at the parser's own "0" default proves the composer sent no id list, so the
 # worker pins device ordinal 0, the one device a pinned container exposes.
 def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
-    args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
+    args = parse_with_stage_script(compose(run_one_cmd, device="gpu"))
     assert args.func.__name__ == "cmd_run_one"
     assert args.payload == "outputs/quick_run/stage3_neoclassical/runs/rho_001_r0p1000/payload.json"
     assert args.gpu_ids == "0"

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -7,9 +7,9 @@ the static base flags (the ``--vmec-file-override`` and ``--boozer-file-override
 geometry inputs plus the literal ``{input.*}`` and ``{wildcards.surf}`` placeholders
 Snakemake substitutes at run time), the not-None-only optional flags on ``prepare``
 (where ``t_max`` is emitted as ``--t-final``) and ``collect``, the tri-state and
-on-only booleans, the gpu-only ``--gpu-ids`` flag on ``run-one``, and the
-absence of scan-level parallelism flags now that surface concurrency belongs to
-``snakemake --cores``.
+on-only booleans, and the absence of scan-level parallelism and GPU flags now
+that surface concurrency belongs to ``snakemake --cores`` and device assignment
+to the docker prefix.
 """
 
 from __future__ import annotations
@@ -55,8 +55,8 @@ _PREPARE_OPTIONALS: list[tuple[str, str, object]] = [
     ("perturb_rel_step",              "--perturb-rel-step",              0.5),
 ]
 
-# max_parallel and collect_even_if_failures are retired keys that older configs may
-# still carry; every composer must ignore them.
+# max_parallel, collect_even_if_failures, and gpu_ids are retired keys that older
+# configs may still carry; every composer must ignore them.
 _FULL_CFG: dict = {key: value for key, _, value in _PREPARE_OPTIONALS} | {
     "average_window": 1.0,
     "gpu_ids": "0,1",
@@ -181,15 +181,14 @@ def test_run_one_verbose_worker_on_only() -> None:
     assert "--no-verbose-worker" not in compose(run_one_cmd, stage_cfg={"verbose_workers": False})
 
 
-# GPU pinning applies only to the worker phase: --gpu-ids passes the raw gpu_ids config string through and the worker
-# pins the first id (distributing a multi-GPU list across surfaces is deferred). It appears only when the device is
-# gpu AND the config sets gpu_ids: cpu suppresses it even when gpu_ids is configured, and gpu without gpu_ids emits
-# nothing. Token membership so --gpu-ids is matched exactly.
-def test_run_one_gpu_ids_only_on_gpu() -> None:
+# Device assignment lives in the docker run prefix, so the worker command itself carries no GPU flag. Even a config
+# still holding the retired gpu_ids key must never make run-one emit --gpu-ids; the worker then pins the one device
+# its container exposes.
+def test_run_one_never_emits_gpu_ids() -> None:
     cfg = {"gpu_ids": "0,1"}
-    assert "--gpu-ids 0,1" in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
-    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu").split()
-    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu").split()
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="gpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg=cfg, device="cpu")
+    assert "--gpu-ids" not in compose(run_one_cmd, stage_cfg={}, device="gpu")
 
 
 # A drift guard. The exact-string tests only check the composer against itself; this checks it against the real stage
@@ -202,14 +201,15 @@ def test_prepare_flags_parse_and_dispatch_to_cmd_prepare() -> None:
     assert args.t_max == 10.0
 
 
-# A drift guard for the worker phase: the composed run-one command (gpu variant with verbose_workers on, so --gpu-ids
-# and --verbose-worker are included) must parse with the real stage script and dispatch to cmd_run_one, with the
-# substituted surface name landing on the run-one --run-name argument.
+# A drift guard for the worker phase: the composed run-one command (gpu variant with verbose_workers on, so
+# --verbose-worker is included) must parse with the real stage script and dispatch to cmd_run_one, with the
+# substituted surface name landing on the run-one --run-name argument. gpu_ids staying at the parser's None default
+# proves the worker self-pins the device its container exposes instead of receiving an id list.
 def test_run_one_flags_parse_and_dispatch_to_cmd_run_one() -> None:
     args = parse_with_stage_script(compose(run_one_cmd, stage_cfg=_FULL_CFG, device="gpu"))
     assert args.func.__name__ == "cmd_run_one"
     assert args.run_name == "rho_001_r0p1000"
-    assert args.gpu_ids == "0,1"
+    assert args.gpu_ids is None
 
 
 # A drift guard for the reduction phase: the composed collect command must parse with the real stage script, dispatch

--- a/tests/orchestration/test_stage4_helper_cmd.py
+++ b/tests/orchestration/test_stage4_helper_cmd.py
@@ -15,6 +15,7 @@ to the docker prefix.
 from __future__ import annotations
 
 import argparse
+import inspect
 import re
 from collections.abc import Callable
 
@@ -69,7 +70,11 @@ _FULL_CFG: dict = {key: value for key, _, value in _PREPARE_OPTIONALS} | {
 
 
 def compose(composer: Callable[..., str], **overrides) -> str:
-    """Build a command with quick-run-like defaults, overriding only what a test varies."""
+    """Build a command with quick-run-like defaults, overriding only what a test varies.
+
+    Each composer takes exactly the arguments its phase uses, so the shared defaults are narrowed to the ones the
+    called composer accepts.
+    """
     base = dict(
         docker_prefix="docker run --rm",
         image="ghcr.io/driftless-star/driftless-star:stage-4-spectrax-cpu",
@@ -78,7 +83,8 @@ def compose(composer: Callable[..., str], **overrides) -> str:
         device="cpu",
     )
     base.update(overrides)
-    return composer(**base)
+    accepted = inspect.signature(composer).parameters
+    return composer(**{name: value for name, value in base.items() if name in accepted})
 
 
 def parse_with_stage_script(command: str) -> argparse.Namespace:


### PR DESCRIPTION

Resolves #117

## Summary

* `src/utils/gpu.py` (new, exported through `src/utils/__init__.py`): `parse_gpu_pool` and `resolve_gpu_settings` turn the top-level `gpu_ids` and `jobs_per_gpu` keys into a `(device, pool, jobs_per_gpu)` triple. `null` selects the CPU images, `"all"` and an explicit id list select the GPU images. Duplicate or non-integer ids, a `jobs_per_gpu` above 1 on a CPU run, and a leftover `device` key all raise `ValueError` before any job starts. The Snakefile and `ouroboros` both call it, so the keys are interpreted identically wherever they arrive from.
* `src/gpu_slots.py` (new): the slot allocator, run as `python -m src.gpu_slots --gpu-ids ... --jobs-per-gpu N --lock-dir DIR -- COMMAND...`. It takes a non-blocking `flock` on one lock file per slot, retries with jittered backoff until one is free, substitutes the acquired id into the wrapped command's `@GPU_ID@` tokens, and runs the command with the lock held so the slot frees when the container exits. `--gpu-ids all` resolves at job start to the entries of `CUDA_VISIBLE_DEVICES` when set, else to every index `nvidia-smi` reports; every resolution or lock failure prints one `[gpu_slots]` line and exits 1.
* `Snakefile`: a GPU run wraps every `docker run` with the allocator and passes `--gpus device=@GPU_ID@` instead of `--gpus all`, with locks under `.snakemake/gpu_slots`. CPU runs are unchanged.
* `src/ouroboros.py`: `--gpu-ids` and `--jobs-per-gpu` override the matching config keys for every iteration of one invocation, leaving the config file untouched. They are validated once before any iteration tree is created, then forwarded as raw text on snakemake's `--config` so each value is parsed exactly as a config file would parse it.
* `inputs/quick_run/config.yaml`: `device` is replaced by the two new keys, and the per-stage `gpu_ids` entries under `stage3` and `stage4` are dropped now that assignment happens outside the worker. Documented in a new "Multi-GPU scheduling" section of `docs/mvp-pipeline.md`, with pointers from `docs/guide.md` and `docs/container-images.md`; the parallelization item in `docs/potential_issues.md` is now answered and removed.
* Two items beyond the feature itself: the README gained "Run the closed loop" and "Run on GPUs" sections, since it documented neither, and the stage composers lost parameters they do not use (`stage_cfg` from Stage 3 `run_one_cmd`, made unused here, plus `device` from Stage 3 `collect_cmd` and Stage 4 `prepare_cmd` / `collect_cmd`, unused since before this branch).
* Tests ride in this PR rather than following as a separate one: `tests/orchestration/test_gpu.py`, `test_gpu_slots.py` and `test_ouroboros_gpu.py`, `tests/e2e/test_dry_run_gpu.py`, and updates to three committed test files.

## Design Decisions

### A wrapper lock rather than a Snakemake resource

A `resources` entry can cap how many GPU jobs run at once, but it cannot tell a job which device it got, and the loop driver runs each iteration as its own snakemake process. One lock file per slot gives both: the acquired id is substituted into the docker command, and the hold ends with the wrapper process, so a killed or crashed job frees its slot with no bookkeeping to reconcile.

### "all" enumerates and pins

`--gpus all` no longer exists anywhere. Keeping an unpinned mode would have kept the failure this PR fixes, so `"all"` now resolves to a concrete pool and pins exactly like an explicit list. Resolution happens in the wrapper on the execution host at job start, not at parse time, so a machine with no GPUs still parses the Snakefile and dry-runs a GPU config. `nvidia-smi` ignores `CUDA_VISIBLE_DEVICES`, so honoring that variable is deliberate, and it is the supported way to hold `"all"` to your share of a shared host.



---

**Tested:**

* [x] Full local suite passes: `pixi run -e test test` reports 363 passed plus 4 doctests.
* [x] Dry-run matrix on this branch: `gpu_ids: "all"` with `jobs_per_gpu: 2` plans 7 of 7 containers wrapped with `--gpu-ids all --jobs-per-gpu 2` and zero occurrences of `--gpus all`; the CPU and explicit-list plans and every rejection case behave as expected.
* [x] Live pinned run on olvi-1 (rootless docker, `CUDA_VISIBLE_DEVICES=4,5,6,7`, `gpu_ids: "all"`, `jobs_per_gpu 2`) completed 60 of 60 steps with exit 0. All 60 acquire lines fell inside the pool (17/16/14/13 across GPUs 4 through 7), none outside it, with 10 jobs observed waiting for a slot. A concurrent `nvidia-smi` recorder over 148 samples measured a per-GPU maximum of exactly 2 on each pool device and a global maximum of exactly 8, and GPUs 0 through 3, busy with another user's training throughout, were never touched.
* [x] Live loop on olvi-1: `ouroboros --max-iters 1 --cores 8 --gpu-ids all --jobs-per-gpu 2` completed 62 of 62 steps with exit 0 and converged at iteration 1, with all 62 acquire lines inside the pool.
* [x] Enforcement boundary on plasma-workstation (rootful docker, `gpu_ids: 0`, `jobs_per_gpu 2`): 8 of 8 steps done, a maximum of 2 concurrent jobs on GPU 0, and zero new pids on GPU 1.
* [x] Failure paths on the real host: an empty `CUDA_VISIBLE_DEVICES` exits 1 with `[gpu_slots] CUDA_VISIBLE_DEVICES is set but empty`, and UUID entries pass through and pin correctly.
* [x] Interruption is safe: a full pinned run survived `docker kill` on a mid-run container and resumed to exit 0 over 56 of 56 steps through Stage 5.