### PR TITLE
Fix: stage3 analytical profiles

### DIFF
--- a/stages/stage3-neoclassical/sfincs_jax_radial_scan.py
+++ b/stages/stage3-neoclassical/sfincs_jax_radial_scan.py
@@ -196,14 +196,18 @@ def _build_standard_analytical_snapshot(
     n_radial: int,
 ) -> TransportSnapshot:
     profile_cfg = cfg.get("profiles", {})
-    rho = np.linspace(0.0, 1.0, int(n_radial), dtype=np.float64)
+    rho_edge = float(cfg.get("geometry", {}).get("rho_edge", 1.0))
+    rho = np.linspace(0.0, rho_edge, int(n_radial), dtype=np.float64)
+    x = rho / max(float(rho[-1]) if rho.size else 1.0, 1.0e-30)
 
-    n0 = float(profile_cfg.get("n0", profile_cfg.get("ni0", profile_cfg.get("ne0", 4.21))))
-    n_edge = float(profile_cfg.get("n_edge", profile_cfg.get("nib", profile_cfg.get("neb", 0.6))))
-    t0 = float(profile_cfg.get("T0", profile_cfg.get("ti0", profile_cfg.get("te0", 17.8))))
-    t_edge = float(profile_cfg.get("T_edge", profile_cfg.get("tib", profile_cfg.get("teb", 0.7))))
-    density_shape_power = float(profile_cfg.get("density_shape_power", 2.0))
-    temperature_shape_power = float(profile_cfg.get("temperature_shape_power", 2.0))
+    n0 = _match_species_factors(profile_cfg.get("n0", profile_cfg.get("ni0", profile_cfg.get("ne0", 4.21))), n_species, default=4.21)
+    n_edge = _match_species_factors(profile_cfg.get("n_edge", profile_cfg.get("nib", profile_cfg.get("neb", 0.6))), n_species, default=0.6)
+    t0 = _match_species_factors(profile_cfg.get("T0", profile_cfg.get("ti0", profile_cfg.get("te0", 17.8))), n_species, default=17.8)
+    t_edge = _match_species_factors(profile_cfg.get("T_edge", profile_cfg.get("tib", profile_cfg.get("teb", 0.7))), n_species, default=0.7)
+    density_shape_power = _match_species_factors(profile_cfg.get("density_shape_power", 2.0), n_species, default=2.0)
+    density_shape_alpha = _match_species_factors(profile_cfg.get("density_shape_alpha", 1.0), n_species, default=1.0)
+    temperature_shape_power = _match_species_factors(profile_cfg.get("temperature_shape_power", 2.0), n_species, default=2.0)
+    temperature_shape_alpha = _match_species_factors(profile_cfg.get("temperature_shape_alpha", 1.0), n_species, default=1.0)
 
     c_density = profile_cfg.get("c_density")
     if c_density is None and n_species == 3:
@@ -216,22 +220,22 @@ def _build_standard_analytical_snapshot(
     density_global_scale = _match_species_factors(profile_cfg.get("n_scale", 1.0), n_species, default=1.0)
     temperature_global_scale = _match_species_factors(profile_cfg.get("T_scale", 1.0), n_species, default=1.0)
 
-    density_base = n_edge + (n0 - n_edge) * (1.0 - rho**density_shape_power)
-    temperature_base = t_edge + (t0 - t_edge) * (1.0 - rho**temperature_shape_power)
-    density = density_species_scale[:, None] * density_global_scale[:, None] * density_base[None, :]
-    temperature = (
-        temperature_species_scale[:, None]
-        * temperature_global_scale[:, None]
-        * temperature_base[None, :]
-    )
+    density = np.zeros((n_species, rho.size), dtype=np.float64)
+    temperature = np.zeros((n_species, rho.size), dtype=np.float64)
+    for i in range(n_species):
+        density_shape = (1.0 - x**density_shape_power[i]) ** density_shape_alpha[i]
+        temperature_shape = (1.0 - x**temperature_shape_power[i]) ** temperature_shape_alpha[i]
+        density_base = n_edge[i] + (n0[i] - n_edge[i]) * density_shape
+        temperature_base = t_edge[i] + (t0[i] - t_edge[i]) * temperature_shape
+        density[i, :] = density_species_scale[i] * density_global_scale[i] * density_base
+        temperature[i, :] = temperature_species_scale[i] * temperature_global_scale[i] * temperature_base
 
     er0_scale = float(profile_cfg.get("er0_scale", 100.0))
     er0_peak_rho = float(profile_cfg.get("er0_peak_rho", 0.8))
-    width = max(0.05, 0.35 * max(er0_peak_rho, 1.0 - er0_peak_rho, 0.15))
-    er = er0_scale * rho * np.exp(-0.5 * ((rho - er0_peak_rho) / width) ** 2)
+    er = er0_scale * x * (er0_peak_rho - x)
 
     return TransportSnapshot(
-        rho=rho,
+        rho=np.asarray(rho, dtype=np.float64),
         density=np.asarray(density, dtype=np.float64),
         temperature=np.asarray(temperature, dtype=np.float64),
         er=np.asarray(er, dtype=np.float64),

--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -110,6 +110,80 @@ def test_snapshot_species_density_ratios(module: ModuleType) -> None:
     assert_allclose(snap.density[2], 0.4 * snap.density[0], rtol=1e-12)
 
 
+def _w7x_like_profiles() -> dict:
+    """A 2-species [profiles] block in the per-species-array form used by inputs/w7-x_t3d_like."""
+    return {
+        "geometry": {"n_radial": 5, "rho_edge": 0.7},
+        "profiles": {
+            "model": "standard_analytical",
+            "n0": [0.35, 0.35],
+            "n_edge": [0.29, 0.29],
+            "T0": [6.7, 1.0],
+            "T_edge": [0.8, 0.8],
+            "density_shape_power": [2.0, 2.0],
+            "temperature_shape_power": [2.0, 2.0],
+            "temperature_shape_alpha": [2.0, 1.0],
+            "er0_scale": 100.0,
+            "er0_peak_rho": 0.8,
+        },
+    }
+
+
+# Every scalar [profiles] knob is equally accepted as a per-species list. T0 = [6.7, 1.0] with a shared
+# T_edge = 0.8 gives each species its own core temperature meeting at a common edge value, so this asserts the
+# electron and ion columns start at 6.7 and 1.0 respectively and both end at 0.8.
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_accepts_per_species_arrays(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    assert_allclose(snap.temperature[0, 0], 6.7, rtol=1e-12)  # electron core T0
+    assert_allclose(snap.temperature[1, 0], 1.0, rtol=1e-12)  # ion core T0
+    assert_allclose(snap.temperature[:, -1], 0.8, rtol=1e-12)  # shared T_edge
+    assert_allclose(snap.density[:, 0], 0.35, rtol=1e-12)
+    assert_allclose(snap.density[:, -1], 0.29, rtol=1e-12)
+
+
+# temperature_shape_alpha is the outer exponent in edge + (core - edge) * (1 - x**power)**alpha. With
+# alpha = [2.0, 1.0] and equal powers, this asserts each species matches its own analytical curve and that the two
+# normalised shapes come out different.
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_applies_shape_alpha(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    x = np.linspace(0.0, 1.0, 5)
+    for i, (t0, alpha) in enumerate([(6.7, 2.0), (1.0, 1.0)]):
+        expected = 0.8 + (t0 - 0.8) * (1.0 - x**2.0) ** alpha
+        assert_allclose(snap.temperature[i], expected, rtol=1e-12)
+    # Normalised shapes differ between the two species.
+    shape_e = (snap.temperature[0] - 0.8) / (6.7 - 0.8)
+    shape_i = (snap.temperature[1] - 0.8) / (1.0 - 0.8)
+    assert not np.allclose(shape_e, shape_i)
+
+
+# [geometry].rho_edge sets the extent of the radial grid. With rho_edge = 0.7 this asserts the snapshot's rho is
+# linspace(0, 0.7, n) rather than always reaching 1.0; the shape functions are evaluated on x = rho / rho_edge.
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_grid_honours_rho_edge(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    assert_allclose(snap.rho, np.linspace(0.0, 0.7, 5), rtol=1e-12)
+
+
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_grid_defaults_rho_edge(module: ModuleType) -> None:
+    cfg = _w7x_like_profiles()
+    del cfg["geometry"]["rho_edge"]
+    snap = module._build_standard_analytical_snapshot(cfg, n_species=2, n_radial=5)
+    assert_allclose(snap.rho, np.linspace(0.0, 1.0, 5), rtol=1e-12)
+
+
+# The radial electric field is the parabola er0_scale * x * (er0_peak_rho - x) in normalised x. It crosses zero at
+# x = er0_peak_rho, so this also asserts the outermost point (x = 1 > 0.8) comes out negative.
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_er_is_neopax_parabola(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    x = np.linspace(0.0, 1.0, 5)
+    assert_allclose(snap.er, 100.0 * x * (0.8 - x), rtol=1e-12)
+    assert snap.er[-1] < 0.0  # x = 1 > er0_peak_rho = 0.8
+
+
 # --- _build_prescribed_snapshot ---
 
 # Both stage scripts also carry a _build_prescribed_snapshot twin that reads the closed loop's fed-back [profiles]

--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -123,7 +123,7 @@ def _w7x_like_profiles() -> dict:
             "density_shape_power": [2.0, 2.0],
             "temperature_shape_power": [2.0, 2.0],
             "temperature_shape_alpha": [2.0, 1.0],
-            "er0_scale": 100.0,
+            "er0_scale": 0.0,
             "er0_peak_rho": 0.8,
         },
     }


### PR DESCRIPTION
Stage 3's `_build_standard_analytical_snapshot` did not implement the same `[profiles]` contract as its Stage 4 twin, so the shared `common_input.toml` produced different profiles in Stages 3 vs 4/5. This brings Stage 3 in line with Stage 4 (the changed block is now identical to Stage 4's except for the snapshot type names):

- Per-species values: the six profile knobs (`n0`, `n_edge`, `T0`, `T_edge`, `*_shape_power`) go through `_match_species_factors`, so per-species lists work element-wise (previously `float()` raised `TypeError` on any list).
- The radial grid spans the transport domain: `linspace(0, rho_edge, n)` reading `[geometry].rho_edge` (default 1.0), with shape functions evaluated on the normalized coordinate.
- New optional `density_shape_alpha` / `temperature_shape_alpha` outer exponents (default 1.0 recovers old behavior).
- The radial electric field is NEOPAX's parabola `er0_scale * x * (er0_peak_rho - x)` instead of a Gaussian.

**Behavior notes:** Er now changes sign for `x > er0_peak_rho` (the old Gaussian was positive everywhere); under this formula `er0_peak_rho` is the zero crossing, with the extremum at `er0_peak_rho / 2`. Both match Stage 4 and NEOPAX exactly. A few lines exceed 120 chars verbatim from Stage 4 to keep the two implementations textually comparable.

Includes 5 contract tests parametrized over both the Stage 3 and Stage 4 copies of the builder, pinning per-species arrays, `shape_alpha`, the `rho_edge` grid (honored and defaulted), and the Er parabola, so the two implementations cannot drift apart again. With the implementation reverted, all 5 fail on the Stage 3 leg with the original `TypeError`; full suite: 401 passed.

The `w7-x_t3d_like` config tuning (`analytical_n_radii` 51 to 9) and the W7-X SFINCS template that accompanied this work will land with the W7-X configs PR, since that input directory is not on `main`.
