### PR TITLE
fix: Fix the Stage 3 Er parabola test against the zero-scale fixture

### DIFF
--- a/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
+++ b/tests/stage3-neoclassical/test_sfincs_scan_helpers.py
@@ -175,13 +175,24 @@ def test_snapshot_grid_defaults_rho_edge(module: ModuleType) -> None:
 
 
 # The radial electric field is the parabola er0_scale * x * (er0_peak_rho - x) in normalised x. It crosses zero at
-# x = er0_peak_rho, so this also asserts the outermost point (x = 1 > 0.8) comes out negative.
+# x = er0_peak_rho, so this also asserts the outermost point (x = 1 > 0.8) comes out negative. The shared fixture pins
+# er0_scale = 0.0, so a non-zero scale is set here.
 @pytest.mark.parametrize("module", SNAPSHOT_MODULES)
 def test_snapshot_er_is_neopax_parabola(module: ModuleType) -> None:
-    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    cfg = _w7x_like_profiles()
+    cfg["profiles"]["er0_scale"] = 100.0
+    snap = module._build_standard_analytical_snapshot(cfg, n_species=2, n_radial=5)
     x = np.linspace(0.0, 1.0, 5)
     assert_allclose(snap.er, 100.0 * x * (0.8 - x), rtol=1e-12)
     assert snap.er[-1] < 0.0  # x = 1 > er0_peak_rho = 0.8
+
+
+# The T3D reference case runs with no radial electric field, so the fixture's er0_scale = 0.0 must flatten the parabola
+# to exactly zero at every radius. atol = 0.0 pins exact zeros rather than merely small values.
+@pytest.mark.parametrize("module", SNAPSHOT_MODULES)
+def test_snapshot_er_is_zero_when_scale_is_zero(module: ModuleType) -> None:
+    snap = module._build_standard_analytical_snapshot(_w7x_like_profiles(), n_species=2, n_radial=5)
+    assert_allclose(snap.er, np.zeros(5), atol=0.0)
 
 
 # --- _build_prescribed_snapshot ---


### PR DESCRIPTION
`test_snapshot_er_is_neopax_parabola` fails on `main` for both parametrized modules, so the suite is currently 371 passed with 2 failed.

The `_w7x_like_profiles()` fixture sets `er0_scale = 0.0`, following @eduardolneto's suggestion on #120 to match the T3D reference case, which runs with no radial electric field. The parabola test asserts against `100.0 * x * (0.8 - x)`, the builder's *default* scale, which the fixture overrides. With a zero scale the builder correctly returns all zeros, so the assertion cannot pass. `assert snap.er[-1] < 0.0` fails for the same reason.

The builder is correct throughout. Only the test disagreed with its own fixture.

### Change

The fixture keeps `er0_scale = 0.0`. The parabola test sets its own scale instead, following the `del cfg["geometry"]["rho_edge"]` pattern already used a few lines above it.

```python
cfg = _w7x_like_profiles()
cfg["profiles"]["er0_scale"] = 100.0
```

A second test pins the zero-scale case, which nothing covered once the parabola test stopped reading the fixture's value. `atol = 0.0` requires exact zeros rather than small ones, so a future change leaving a residual Er fails instead of passing quietly.