### PR TITLE
feat: Support rootless Docker daemons via a docker_user config key

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -4,7 +4,13 @@ import json
 import posixpath
 
 from src import stage3_helper, stage4_helper, stage5_helper
-from src.utils import resolve_gpu_settings, resolve_pipeline_paths, resolve_rerun_flags, RESOLVED_COMMON_CONFIG
+from src.utils import (
+    resolve_docker_user,
+    resolve_gpu_settings,
+    resolve_pipeline_paths,
+    resolve_rerun_flags,
+    RESOLVED_COMMON_CONFIG,
+)
 
 # Require an explicit run config
 if not config:
@@ -52,11 +58,11 @@ STAGE3_JAX_IMG = f"ghcr.io/driftless-star/driftless-star:stage-3-sfincs-{DEVICE}
 STAGE4_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-4-spectrax-{DEVICE}"
 STAGE5_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-5-neopax-{DEVICE}"
 
-# --user: make bind-mounted writes host-owned (Linux docker otherwise writes as root).
+# --user: detects the daemon and runs as the invoking user on rootful Docker, so bind-mounted writes stay host-owned.
 # -e HOME=/tmp: pixi activation needs a writable HOME after dropping root.
 DOCKER_PREFIX = (
     f'{SLOT_PREFIX}docker run --rm --pull=missing {GPU_FLAG}'
-    '--user "$(id -u):$(id -g)" '
+    f'{resolve_docker_user(config)}'
     '-e HOME=/tmp '
     '-v "$PWD:/work" -w /work'
 )

--- a/Snakefile
+++ b/Snakefile
@@ -58,7 +58,7 @@ STAGE3_JAX_IMG = f"ghcr.io/driftless-star/driftless-star:stage-3-sfincs-{DEVICE}
 STAGE4_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-4-spectrax-{DEVICE}"
 STAGE5_IMG     = f"ghcr.io/driftless-star/driftless-star:stage-5-neopax-{DEVICE}"
 
-# --user: detects the daemon and runs as the invoking user on rootful Docker, so bind-mounted writes stay host-owned.
+# --user: detects the runtime and picks the uid whose writes land host-owned, the invoking user or container root.
 # -e HOME=/tmp: pixi activation needs a writable HOME after dropping root.
 DOCKER_PREFIX = (
     f'{SLOT_PREFIX}docker run --rm --pull=missing {GPU_FLAG}'

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -261,7 +261,7 @@ Automates the MVP forward pass end-to-end: `Stage 1 -> {Stage 2, Stage 3, Stage 
 
 | Direction | Format              | Location                                                                                                                                                           |
 | --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `gpu_ids`, `jobs_per_gpu`, `input_dir`, `output_dir`, `filenames`, `convergence`, `loop`, `stage3`, `stage4`)    |
+| **In**    | YAML config         | `inputs/quick_run/config.yaml` (keys: `run_name`, `gpu_ids`, `jobs_per_gpu`, `docker_user`, `input_dir`, `output_dir`, `filenames`, `convergence`, `loop`, `stage3`, `stage4`)    |
 | **In**    | Workflow definition | `Snakefile`                                                                                                                                                        |
 | **In**    | Per-stage inputs    | `inputs/quick_run/` (all stage inputs, flat)                                                                                                                       |
 | **Out**   | Stage 2 NetCDF      | `outputs/quick_run/stage2_boozer/boozmn_HSX_vacuum_ns201_quickrun.nc`                                                                                              |
@@ -383,6 +383,22 @@ jobs_per_gpu: 1
 **On the command line.** `--config gpu_ids=4,5,6,7 jobs_per_gpu=2` overrides the file for one invocation, and CPU mode is either `gpu_ids=null` or an empty `gpu_ids=`. Snakemake parses the CLI value itself, and the validator accepts both the `"null"` string and `None` that this produces. The [closed-loop driver](#closing-the-loop) takes the same two settings as `--gpu-ids` / `--jobs-per-gpu`.
 
 **Limitations.** Concurrent pipeline invocations share slot accounting only when they are launched from the same working copy, since the lock files live under that copy's `.snakemake/gpu_slots/`, and only when they agree on `jobs_per_gpu`. Two users running from their own copies therefore allocate independently, and under `gpu_ids: "all"` both pools resolve to every GPU of the host, so each device runs twice the jobs asked for while both runs' `[gpu_slots] acquired` lines still report one job per device. Give each user a disjoint `CUDA_VISIBLE_DEVICES` share so their pools cannot overlap. The slot allocator also needs a POSIX host, since `fcntl.flock` has no Windows implementation, so GPU mode requires WSL2 rather than Git Bash; CPU mode wraps no job and is unaffected. Runtime Apptainer support is a planned follow-up; its per-device mechanism would be the `CUDA_VISIBLE_DEVICES` environment variable, since `apptainer --nv` has no per-device flag.
+
+### Container user (rootful vs rootless Docker)
+
+Every stage's `docker run` bind-mounts the repo at `/work`, so the container's user decides who owns the files a stage writes back into your working tree. The optional top-level `docker_user` key selects that user:
+
+```yaml
+docker_user: auto   # auto (default) | host | root
+```
+
+- **`host`** adds `--user "$(id -u):$(id -g)"`, so a container writes as you instead of as root. This is what a **rootful** daemon needs.
+- **`root`** omits the flag and leaves the image's own user (root) in place. This is what a **rootless** daemon needs: it already maps your host user onto the container's root, so it gives you host-owned outputs for free, and passing `--user` anyway drops the container to an unprivileged subuid that cannot read `/work` at all. The stage then fails on its own inputs, typically reporting a misleading "file not found" for a file that is plainly there.
+- **`auto`** (the default) reads `docker info` once at parse time and picks `root` for a rootless daemon and `host` otherwise. Because the daemon is a property of the execution host rather than of a run, committed run configs carry no `docker_user` key and work on both. If Docker cannot be reached at all, say a dry run on a machine with no Docker, `auto` falls back to `host` rather than failing.
+
+Pin a mode only when you know the host. Setting `root` on a **rootful** daemon runs the container as real host root over the bind-mounted repo, so a stage can write root-owned files or overwrite paths your own account could not. `auto` never selects that combination, since it resolves to `root` only when the daemon reports itself rootless.
+
+Override it per invocation with `--config docker_user=root`. The value is validated by `resolve_docker_user` (`src/utils/docker.py`) at Snakefile parse time, so a typo fails before any job runs. Check which daemon you have with `docker info -f '{{.SecurityOptions}}'`; a rootless one lists `name=rootless`.
 
 ### Visualizing the file-flow graph
 

--- a/docs/mvp-pipeline.md
+++ b/docs/mvp-pipeline.md
@@ -384,7 +384,7 @@ jobs_per_gpu: 1
 
 **Limitations.** Concurrent pipeline invocations share slot accounting only when they are launched from the same working copy, since the lock files live under that copy's `.snakemake/gpu_slots/`, and only when they agree on `jobs_per_gpu`. Two users running from their own copies therefore allocate independently, and under `gpu_ids: "all"` both pools resolve to every GPU of the host, so each device runs twice the jobs asked for while both runs' `[gpu_slots] acquired` lines still report one job per device. Give each user a disjoint `CUDA_VISIBLE_DEVICES` share so their pools cannot overlap. The slot allocator also needs a POSIX host, since `fcntl.flock` has no Windows implementation, so GPU mode requires WSL2 rather than Git Bash; CPU mode wraps no job and is unaffected. Runtime Apptainer support is a planned follow-up; its per-device mechanism would be the `CUDA_VISIBLE_DEVICES` environment variable, since `apptainer --nv` has no per-device flag.
 
-### Container user (rootful vs rootless Docker)
+### Container user (rootful and rootless runtimes)
 
 Every stage's `docker run` bind-mounts the repo at `/work`, so the container's user decides who owns the files a stage writes back into your working tree. The optional top-level `docker_user` key selects that user:
 
@@ -393,12 +393,16 @@ docker_user: auto   # auto (default) | host | root
 ```
 
 - **`host`** adds `--user "$(id -u):$(id -g)"`, so a container writes as you instead of as root. This is what a **rootful** daemon needs.
-- **`root`** omits the flag and leaves the image's own user (root) in place. This is what a **rootless** daemon needs: it already maps your host user onto the container's root, so it gives you host-owned outputs for free, and passing `--user` anyway drops the container to an unprivileged subuid that cannot read `/work` at all. The stage then fails on its own inputs, typically reporting a misleading "file not found" for a file that is plainly there.
-- **`auto`** (the default) reads `docker info` once at parse time and picks `root` for a rootless daemon and `host` otherwise. Because the daemon is a property of the execution host rather than of a run, committed run configs carry no `docker_user` key and work on both. If Docker cannot be reached at all, say a dry run on a machine with no Docker, `auto` falls back to `host` rather than failing.
+- **`root`** adds `--user 0:0`, so the container runs as container root. This is what a **rootless** runtime needs, because it already maps your host user onto container uid 0 and hands you host-owned outputs for free. Passing the host uid there instead drops the container to an unprivileged subuid that cannot read `/work` at all, and the stage then fails on its own inputs, typically reporting a misleading "file not found" for a file that is plainly there. Naming uid 0 rather than omitting the flag keeps the resolved user the same if a stage image ever declares its own `USER`.
+- **`auto`** (the default) reads one `docker info` document at parse time and picks `root` for a rootless runtime and `host` otherwise. It understands both Docker, which reports the mapping in `SecurityOptions`, and Podman, which reports it under `host.security.rootless`, so a rootless podman aliased to `docker` resolves correctly. Because the runtime is a property of the execution host rather than of a run, committed run configs carry no `docker_user` key and work on both. If the runtime cannot be reached at all, say a dry run on a machine with no Docker, `auto` falls back to `host` rather than failing.
 
-Pin a mode only when you know the host. Setting `root` on a **rootful** daemon runs the container as real host root over the bind-mounted repo, so a stage can write root-owned files or overwrite paths your own account could not. `auto` never selects that combination, since it resolves to `root` only when the daemon reports itself rootless.
+Pin a mode only when you know the host. Setting `root` on a **rootful** daemon runs the container as real host root over the bind-mounted repo, so a stage can write root-owned files or overwrite paths your own account could not. `auto` never selects that combination, since it resolves to `root` only when the runtime reports itself rootless. Inspect your own with `docker info --format '{{json .}}'`.
 
-Override it per invocation with `--config docker_user=root`. The value is validated by `resolve_docker_user` (`src/utils/docker.py`) at Snakefile parse time, so a typo fails before any job runs. Check which daemon you have with `docker info -f '{{.SecurityOptions}}'`; a rootless one lists `name=rootless`.
+**Unsupported: rootful Docker with [user-namespace remapping](https://docs.docker.com/engine/security/userns-remap/).** That mode maps container uids onto subordinate host uids, so neither container root nor your own uid owns the bind mount and no automatic choice is correct. `auto` detects it and fails at parse time rather than planning a run whose outputs nobody can read. Pin `host` or `root` to proceed and accept the ownership that follows.
+
+Detection describes the machine that runs `snakemake`, not any machine that later runs a job. That matches the current local execution model; a future cluster executor dispatching to remote hosts would need the mode pinned per run instead.
+
+Override it per invocation with `--config docker_user=root`. The value is validated by `resolve_docker_user` (`src/utils/docker.py`) at Snakefile parse time, so a typo fails before any job runs.
 
 ### Visualizing the file-flow graph
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,7 @@
 """Shared utilities for the driftless-star Snakemake workflow."""
 
 from .config_edit import apply_assignments
+from .docker import resolve_docker_user
 from .gpu import GpuSettings, parse_gpu_pool, resolve_gpu_settings
 from .loop import LOOP_STAGES, resolve_rerun_flags
 from .paths import RESOLVED_COMMON_CONFIG, resolve_pipeline_paths
@@ -11,6 +12,7 @@ __all__ = [
     "RESOLVED_COMMON_CONFIG",
     "apply_assignments",
     "parse_gpu_pool",
+    "resolve_docker_user",
     "resolve_gpu_settings",
     "resolve_pipeline_paths",
     "resolve_rerun_flags",

--- a/src/utils/docker.py
+++ b/src/utils/docker.py
@@ -1,17 +1,18 @@
 """Container user resolution
 
-``resolve_docker_user`` decides whether every stage's ``docker run`` carries
-``--user "$(id -u):$(id -g)"``. The flag exists so that a container's writes into the
-bind-mounted repo land host-owned rather than root-owned, which is what a *rootful*
-daemon needs. A *rootless* daemon already maps the invoking host user onto uid 0 inside
-its own user namespace, so it gives that ownership for free, and passing the flag there
-is actively harmful, since the container becomes an unprivileged subuid that cannot read
-the bind mount at all. The stage then reports the resulting ``EACCES`` as whatever its
-argument parser makes of an unreadable path, typically a misleading "file not found".
+``resolve_docker_user`` decides which ``--user`` flag every stage's ``docker run`` carries. A
+rootful daemon needs ``--user "$(id -u):$(id -g)"`` so a container's writes into the bind-mounted
+repo land host-owned rather than root-owned. A rootless runtime already maps the invoking host
+user onto container uid 0, so it needs ``--user 0:0`` instead, and passing the host uid there
+leaves the container as an unprivileged subuid that cannot read the bind mount at all. The stage
+then reports the resulting ``EACCES`` as whatever its argument parser makes of an unreadable path,
+typically a misleading "file not found".
 
-Which daemon is in use is a property of the execution host, not of a run, so the default
-``"auto"`` detects it instead of asking committed run configs to carry a host detail. The
-Snakefile resolves this once at parse time.
+Which runtime is in use is a property of the execution host, not of a run, so the default
+``"auto"`` probes it instead of asking committed run configs to carry a host detail. One
+``docker info`` document serves both the Docker and Podman schemas, since a rootless podman
+aliased to ``docker`` is a supported runtime. The Snakefile resolves this once at parse time, so
+the answer describes the host that plans the jobs rather than any host that later runs one.
 """
 
 from __future__ import annotations
@@ -19,16 +20,16 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
-# Placed between the device flag and -e HOME=/tmp in the Snakefile's prefix, so it carries its own trailing space and
-# drops out cleanly when empty.
+# Both carry their own trailing space, since they sit between the device flag and -e HOME=/tmp in the Snakefile prefix.
 HOST_USER_FLAG = '--user "$(id -u):$(id -g)" '
+ROOT_USER_FLAG = "--user 0:0 "
 
-# `docker info` spelling for a rootless daemon.
+# `docker info` spellings for a rootless daemon and for rootful user-namespace remapping.
 _ROOTLESS_MARKER = "name=rootless"
+_USERNS_MARKER = "name=userns"
 
 # Local daemon round trip, ~65 ms. The timeout only guards a wedged daemon, where failing open to the rootful default
 # is better than hanging every snakemake invocation.
@@ -37,63 +38,67 @@ _PROBE_TIMEOUT_S = 10.0
 _MODES = ("auto", "host", "root")
 
 
-def _probe_rootless() -> bool:
-    """Ask the Docker daemon whether it is running rootless.
+def _probe_daemon() -> str:
+    """Ask the container runtime how it maps the invoking user onto container uids.
 
     Returns
     -------
-    bool
-        True only when the daemon reports the rootless security option. Any failure to reach or read the daemon
-        returns False, which resolves ``"auto"`` to the rootful default and so preserves the historical command.
+    str
+        ``"rootless"`` when the runtime maps the caller onto container uid 0, ``"userns"`` for a rootful Docker daemon
+        with user-namespace remapping, ``"rootful"`` for a plain rootful daemon, and ``"unknown"`` when the runtime
+        cannot be reached or its answer cannot be read.
 
     Notes
     -----
-    Failure is deliberately not fatal. The Snakefile calls this at parse time, and a dry run planning commands on a
-    machine with no Docker at all is a supported workflow.
+    Docker reports the mapping in a ``SecurityOptions`` list and Podman under ``host.security.rootless``, so one
+    document answers for both. Failure is deliberately not fatal and resolves to the rootful default, because the
+    Snakefile calls this at parse time and a dry run planning commands on a machine with no runtime at all is
+    supported.
     """
     try:
         completed = subprocess.run(
-            ["docker", "info", "-f", "{{json .SecurityOptions}}"],
+            ["docker", "info", "--format", "{{json .}}"],
             capture_output=True,
             text=True,
             timeout=_PROBE_TIMEOUT_S,
             check=False,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        logger.debug("Could not run `docker info` to detect a rootless daemon (%s); assuming rootful.", exc)
-        return False
+        logger.debug("Could not run `docker info` to detect the container runtime (%s); assuming rootful.", exc)
+        return "unknown"
 
     if completed.returncode != 0:
         logger.debug(
-            "`docker info` exited %d while detecting a rootless daemon (%s); assuming rootful.",
+            "`docker info` exited %d while detecting the container runtime (%s); assuming rootful.",
             completed.returncode,
             completed.stderr.strip(),
         )
-        return False
+        return "unknown"
 
     try:
-        options = json.loads(completed.stdout)
+        info = json.loads(completed.stdout)
     except ValueError as exc:
-        logger.debug("Could not parse `docker info` security options (%s); assuming rootful.", exc)
-        return False
+        logger.debug("Could not parse the `docker info` document (%s); assuming rootful.", exc)
+        return "unknown"
 
-    if not isinstance(options, list):
-        logger.debug("`docker info` reported no security options list (%r); assuming rootful.", options)
-        return False
+    if not isinstance(info, dict):
+        logger.debug("`docker info` reported %r rather than a document; assuming rootful.", info)
+        return "unknown"
 
-    return _ROOTLESS_MARKER in options
+    options = info.get("SecurityOptions")
+    if isinstance(options, list):
+        if _ROOTLESS_MARKER in options:
+            return "rootless"
+        return "userns" if _USERNS_MARKER in options else "rootful"
 
+    host = info.get("host")
+    security = host.get("security") if isinstance(host, dict) else None
+    rootless = security.get("rootless") if isinstance(security, dict) else None
+    if isinstance(rootless, bool):
+        return "rootless" if rootless else "rootful"
 
-@lru_cache(maxsize=1)
-def daemon_is_rootless() -> bool:
-    """Return whether the Docker daemon is rootless, probing it at most once per process.
-
-    Returns
-    -------
-    bool
-        True when the daemon reports the rootless security option, False otherwise or when it cannot be reached.
-    """
-    return _probe_rootless()
+    logger.debug("`docker info` carried no recognised user mapping; assuming rootful.")
+    return "unknown"
 
 
 def resolve_docker_user(config: dict) -> str:
@@ -102,34 +107,41 @@ def resolve_docker_user(config: dict) -> str:
     Parameters
     ----------
     config : dict
-        Parsed run config. ``docker_user`` is ``"auto"`` (the default) to match the execution host's daemon,
-        ``"host"`` to always run the container as the invoking user, or ``"root"`` to always leave the image's own
-        user in place.
+        Parsed run config. ``docker_user`` is ``"auto"`` (the default) to match the execution host's runtime,
+        ``"host"`` to always run the container as the invoking user, or ``"root"`` to always run it as container root.
 
     Returns
     -------
     str
-        Either ``'--user "$(id -u):$(id -g)" '`` or the empty string, ready to be concatenated into the prefix.
+        Either ``'--user "$(id -u):$(id -g)" '`` or ``'--user 0:0 '``, ready to be concatenated into the prefix.
 
     Raises
     ------
     ValueError
-        If ``docker_user`` is not one of ``"auto"``, ``"host"`` or ``"root"``.
+        If ``docker_user`` is not one of ``"auto"``, ``"host"`` or ``"root"``, or if ``"auto"`` finds a rootful daemon
+        with user-namespace remapping, where neither mode gives the invoking user ownership of the bind mount.
 
     Notes
     -----
-    ``"root"`` omits the flag rather than passing ``--user 0:0`` because ``stages/Dockerfile`` declares no ``USER``,
-    so the image's default user is already root and the two spellings are equivalent.
+    ``"root"`` names container uid 0 explicitly rather than omitting the flag, so the resolved user stays the same if
+    a stage image ever declares a non-root ``USER``. Under a rootless runtime that uid is the invoking host user.
     """
     value = config.get("docker_user", "auto")
     if not isinstance(value, str) or value.strip().lower() not in _MODES:
         raise ValueError(
             f"config['docker_user'] is {value!r}; write one of {', '.join(repr(m) for m in _MODES)}. "
-            '"auto" matches the execution host\'s daemon, "host" always runs the container as the invoking user, '
-            'and "root" always leaves the image\'s own user in place.'
+            '"auto" matches the execution host\'s runtime, "host" always runs the container as the invoking user, '
+            'and "root" always runs it as container root.'
         )
 
     mode = value.strip().lower()
     if mode == "auto":
-        mode = "root" if daemon_is_rootless() else "host"
-    return HOST_USER_FLAG if mode == "host" else ""
+        daemon = _probe_daemon()
+        if daemon == "userns":
+            raise ValueError(
+                "The Docker daemon remaps container users onto subordinate host uids, so neither container root nor "
+                'the invoking uid owns the bind-mounted repo. Set docker_user to "host" or "root" to pin one and '
+                "accept the file ownership that follows."
+            )
+        mode = "root" if daemon == "rootless" else "host"
+    return HOST_USER_FLAG if mode == "host" else ROOT_USER_FLAG

--- a/src/utils/docker.py
+++ b/src/utils/docker.py
@@ -1,0 +1,135 @@
+"""Container user resolution
+
+``resolve_docker_user`` decides whether every stage's ``docker run`` carries
+``--user "$(id -u):$(id -g)"``. The flag exists so that a container's writes into the
+bind-mounted repo land host-owned rather than root-owned, which is what a *rootful*
+daemon needs. A *rootless* daemon already maps the invoking host user onto uid 0 inside
+its own user namespace, so it gives that ownership for free, and passing the flag there
+is actively harmful, since the container becomes an unprivileged subuid that cannot read
+the bind mount at all. The stage then reports the resulting ``EACCES`` as whatever its
+argument parser makes of an unreadable path, typically a misleading "file not found".
+
+Which daemon is in use is a property of the execution host, not of a run, so the default
+``"auto"`` detects it instead of asking committed run configs to carry a host detail. The
+Snakefile resolves this once at parse time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+# Placed between the device flag and -e HOME=/tmp in the Snakefile's prefix, so it carries its own trailing space and
+# drops out cleanly when empty.
+HOST_USER_FLAG = '--user "$(id -u):$(id -g)" '
+
+# `docker info` spelling for a rootless daemon.
+_ROOTLESS_MARKER = "name=rootless"
+
+# Local daemon round trip, ~65 ms. The timeout only guards a wedged daemon, where failing open to the rootful default
+# is better than hanging every snakemake invocation.
+_PROBE_TIMEOUT_S = 10.0
+
+_MODES = ("auto", "host", "root")
+
+
+def _probe_rootless() -> bool:
+    """Ask the Docker daemon whether it is running rootless.
+
+    Returns
+    -------
+    bool
+        True only when the daemon reports the rootless security option. Any failure to reach or read the daemon
+        returns False, which resolves ``"auto"`` to the rootful default and so preserves the historical command.
+
+    Notes
+    -----
+    Failure is deliberately not fatal. The Snakefile calls this at parse time, and a dry run planning commands on a
+    machine with no Docker at all is a supported workflow.
+    """
+    try:
+        completed = subprocess.run(
+            ["docker", "info", "-f", "{{json .SecurityOptions}}"],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Could not run `docker info` to detect a rootless daemon (%s); assuming rootful.", exc)
+        return False
+
+    if completed.returncode != 0:
+        logger.debug(
+            "`docker info` exited %d while detecting a rootless daemon (%s); assuming rootful.",
+            completed.returncode,
+            completed.stderr.strip(),
+        )
+        return False
+
+    try:
+        options = json.loads(completed.stdout)
+    except ValueError as exc:
+        logger.debug("Could not parse `docker info` security options (%s); assuming rootful.", exc)
+        return False
+
+    if not isinstance(options, list):
+        logger.debug("`docker info` reported no security options list (%r); assuming rootful.", options)
+        return False
+
+    return _ROOTLESS_MARKER in options
+
+
+@lru_cache(maxsize=1)
+def daemon_is_rootless() -> bool:
+    """Return whether the Docker daemon is rootless, probing it at most once per process.
+
+    Returns
+    -------
+    bool
+        True when the daemon reports the rootless security option, False otherwise or when it cannot be reached.
+    """
+    return _probe_rootless()
+
+
+def resolve_docker_user(config: dict) -> str:
+    """Turn a run config's ``docker_user`` key into the ``--user`` fragment of the docker run prefix.
+
+    Parameters
+    ----------
+    config : dict
+        Parsed run config. ``docker_user`` is ``"auto"`` (the default) to match the execution host's daemon,
+        ``"host"`` to always run the container as the invoking user, or ``"root"`` to always leave the image's own
+        user in place.
+
+    Returns
+    -------
+    str
+        Either ``'--user "$(id -u):$(id -g)" '`` or the empty string, ready to be concatenated into the prefix.
+
+    Raises
+    ------
+    ValueError
+        If ``docker_user`` is not one of ``"auto"``, ``"host"`` or ``"root"``.
+
+    Notes
+    -----
+    ``"root"`` omits the flag rather than passing ``--user 0:0`` because ``stages/Dockerfile`` declares no ``USER``,
+    so the image's default user is already root and the two spellings are equivalent.
+    """
+    value = config.get("docker_user", "auto")
+    if not isinstance(value, str) or value.strip().lower() not in _MODES:
+        raise ValueError(
+            f"config['docker_user'] is {value!r}; write one of {', '.join(repr(m) for m in _MODES)}. "
+            '"auto" matches the execution host\'s daemon, "host" always runs the container as the invoking user, '
+            'and "root" always leaves the image\'s own user in place.'
+        )
+
+    mode = value.strip().lower()
+    if mode == "auto":
+        mode = "root" if daemon_is_rootless() else "host"
+    return HOST_USER_FLAG if mode == "host" else ""

--- a/tests/e2e/test_dry_run_docker_user.py
+++ b/tests/e2e/test_dry_run_docker_user.py
@@ -1,0 +1,56 @@
+"""Dry-run tests of the container user the Snakefile plans into every launch.
+
+``snakemake -n -p`` formats every stage's shell command without starting a container, so
+the ``docker_user`` modes can be told apart from the planned text alone on a machine with
+no Docker.
+
+What is pinned here is that the mode reaches every launch, not just the first. The flag
+decides whether a container can read the bind-mounted repo at all on a rootless daemon,
+so a single launch built from a stale hardcoded prefix would fail the run while the plan
+looked correct. Only the explicit modes are asserted on, since the default ``"auto"``
+resolves against the daemon of whichever machine runs the suite.
+
+The ``_dry_run`` helper is shared with the DAG tests, which documents the isolation it
+applies to keep every write under tmp.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e.test_dry_run_dag import _dry_run
+
+# Snakefile spelling for running the container as the invoking user. The shell substitution is planned literally and
+# evaluated when the job runs, so it appears verbatim in the plan.
+HOST_USER_FLAG = '--user "$(id -u):$(id -g)"'
+
+
+# A rootful daemon needs every launch to drop to the invoking user, or the run leaves root-owned files scattered
+# through the user's working tree. Counting against planned launches catches a rule that was given a prefix built
+# before the mode was resolved.
+def test_host_mode_plans_the_user_flag_on_every_launch(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["docker_user=host"], printshellcmds=True)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert output.count("docker run") > 0, output
+    assert output.count(HOST_USER_FLAG) == output.count("docker run"), output
+
+
+# A rootless daemon already maps the invoking user onto the container's root, and passing the flag anyway leaves the
+# container as an unprivileged subuid that cannot read /work. Not one launch may carry it.
+def test_root_mode_plans_no_user_flag_at_all(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["docker_user=root"], printshellcmds=True)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert output.count("docker run") > 0, output
+    assert "--user" not in output, output
+
+
+# A mistyped mode must be caught while the DAG is being built, before any job runs, and the message must name the
+# value, so the failure is actionable rather than surfacing hours later as an unreadable bind mount.
+def test_malformed_mode_fails_at_parse_naming_the_value(tmp_path: Path) -> None:
+    result = _dry_run(tmp_path, targets=[], config_overrides=["docker_user=rootless"])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "docker_user" in output, output
+    assert "rootless" in output, output

--- a/tests/e2e/test_dry_run_docker_user.py
+++ b/tests/e2e/test_dry_run_docker_user.py
@@ -20,9 +20,10 @@ from pathlib import Path
 
 from tests.e2e.test_dry_run_dag import _dry_run
 
-# Snakefile spelling for running the container as the invoking user. The shell substitution is planned literally and
-# evaluated when the job runs, so it appears verbatim in the plan.
+# Snakefile spellings for the two container users. The host substitution is planned literally and evaluated when the
+# job runs, so it appears verbatim in the plan.
 HOST_USER_FLAG = '--user "$(id -u):$(id -g)"'
+ROOT_USER_FLAG = "--user 0:0"
 
 
 # A rootful daemon needs every launch to drop to the invoking user, or the run leaves root-owned files scattered
@@ -36,14 +37,17 @@ def test_host_mode_plans_the_user_flag_on_every_launch(tmp_path: Path) -> None:
     assert output.count(HOST_USER_FLAG) == output.count("docker run"), output
 
 
-# A rootless daemon already maps the invoking user onto the container's root, and passing the flag anyway leaves the
-# container as an unprivileged subuid that cannot read /work. Not one launch may carry it.
-def test_root_mode_plans_no_user_flag_at_all(tmp_path: Path) -> None:
+# A rootless runtime already maps the invoking user onto container uid 0, and passing the host uid anyway leaves the
+# container as an unprivileged subuid that cannot read /work. Naming uid 0 explicitly rather than omitting the flag
+# keeps the resolved user the same if a stage image ever declares its own USER, so every launch must carry it and none
+# may carry the host spelling.
+def test_root_mode_plans_the_root_flag_on_every_launch(tmp_path: Path) -> None:
     result = _dry_run(tmp_path, targets=[], config_overrides=["docker_user=root"], printshellcmds=True)
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
     assert output.count("docker run") > 0, output
-    assert "--user" not in output, output
+    assert output.count(ROOT_USER_FLAG) == output.count("docker run"), output
+    assert HOST_USER_FLAG not in output, output
 
 
 # A mistyped mode must be caught while the DAG is being built, before any job runs, and the message must name the

--- a/tests/orchestration/test_docker.py
+++ b/tests/orchestration/test_docker.py
@@ -1,0 +1,134 @@
+"""Tests for ``src.utils.docker``.
+
+``resolve_docker_user`` decides whether every stage's container launch carries
+``--user "$(id -u):$(id -g)"``. Getting this wrong does not degrade a run, it stops one
+outright. Passing the flag to a rootless daemon runs the container as an unprivileged
+subuid that cannot read the bind-mounted repo, and the stage reports the resulting
+``EACCES`` as a misleading "file not found" from its own argument parser. Omitting it on
+a rootful daemon leaves every output file root-owned in the user's working tree.
+
+The probe is therefore pinned in both directions, and so is its failure behavior. A dry
+run planning commands on a machine with no Docker is a supported workflow, so an
+unreachable daemon must fall back to the rootful flag rather than raise, which also keeps
+the planned text identical to what it was before detection existed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+import pytest
+
+from src.utils import resolve_docker_user
+from src.utils.docker import HOST_USER_FLAG, _probe_rootless, daemon_is_rootless
+
+ROOTLESS_OPTIONS = ["name=seccomp,profile=builtin", "name=rootless"]
+ROOTFUL_OPTIONS = ["name=seccomp,profile=builtin", "name=cgroupns"]
+
+
+# The probe is cached for the lifetime of a process, so a test that leaves a result behind would decide the outcome of
+# whichever test ran next.
+@pytest.fixture(autouse=True)
+def _clear_probe_cache() -> None:
+    daemon_is_rootless.cache_clear()
+    yield
+    daemon_is_rootless.cache_clear()
+
+
+def _fake_docker_info(monkeypatch: pytest.MonkeyPatch, stdout: str = "", returncode: int = 0) -> None:
+    """Stand in for the `docker info` call with a fixed result."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=["docker"], returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+def _raising_docker_info(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Stand in for the `docker info` call with a failure to invoke it at all."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+# An explicit mode must not consult the daemon at all, so that a user who knows their host can pin the behavior and a
+# machine with no Docker can still plan commands. The probe is replaced with one that fails the test if it is reached.
+@pytest.mark.parametrize(("mode", "expected"), [("host", HOST_USER_FLAG), ("root", "")])
+def test_explicit_mode_is_used_without_probing_the_daemon(
+    monkeypatch: pytest.MonkeyPatch, mode: str, expected: str
+) -> None:
+    _raising_docker_info(monkeypatch, AssertionError("the daemon must not be probed for an explicit mode"))
+    assert resolve_docker_user({"docker_user": mode}) == expected
+
+
+# Case is normalized the way gpu_ids already normalizes "ALL", so a config written in either case resolves the same.
+@pytest.mark.parametrize("mode", ["HOST", " host ", "Root", " ROOT "])
+def test_explicit_mode_ignores_case_and_surrounding_space(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    _raising_docker_info(monkeypatch, AssertionError("the daemon must not be probed for an explicit mode"))
+    expected = HOST_USER_FLAG if mode.strip().lower() == "host" else ""
+    assert resolve_docker_user({"docker_user": mode}) == expected
+
+
+# The two daemons this exists to tell apart. A rootless daemon already maps the invoking user onto the container's
+# root, so the flag must disappear; a rootful one needs it to keep outputs out of root ownership. An absent key must
+# behave exactly like "auto", because no committed run config carries the key and every one of them must still work.
+@pytest.mark.parametrize("config", [{}, {"docker_user": "auto"}])
+@pytest.mark.parametrize(
+    ("options", "expected"), [(ROOTLESS_OPTIONS, ""), (ROOTFUL_OPTIONS, HOST_USER_FLAG)]
+)
+def test_auto_follows_the_daemon(
+    monkeypatch: pytest.MonkeyPatch, config: dict, options: list[str], expected: str
+) -> None:
+    _fake_docker_info(monkeypatch, stdout=json.dumps(options))
+    assert resolve_docker_user(config) == expected
+
+
+# Every way the probe can fail must resolve to the rootful flag rather than raise. That is the behavior the Snakefile
+# had before detection existed, so a machine with no Docker plans exactly the command it always did, and a wedged or
+# unreadable daemon costs a suboptimal flag instead of a broken parse.
+@pytest.mark.parametrize(
+    ("name", "apply"),
+    [
+        ("docker not installed", lambda mp: _raising_docker_info(mp, FileNotFoundError("docker"))),
+        ("daemon unreachable", lambda mp: _fake_docker_info(mp, stdout="", returncode=1)),
+        ("probe timed out", lambda mp: _raising_docker_info(mp, subprocess.TimeoutExpired("docker", 10.0))),
+        ("output not json", lambda mp: _fake_docker_info(mp, stdout="not json at all")),
+        ("options not a list", lambda mp: _fake_docker_info(mp, stdout="null")),
+        ("empty output", lambda mp: _fake_docker_info(mp, stdout="")),
+    ],
+)
+def test_unreadable_daemon_falls_back_to_the_rootful_flag(
+    monkeypatch: pytest.MonkeyPatch, name: str, apply: object
+) -> None:
+    apply(monkeypatch)
+    assert _probe_rootless() is False
+    assert resolve_docker_user({"docker_user": "auto"}) == HOST_USER_FLAG
+
+
+# The Snakefile resolves this at parse time and the closed loop re-invokes snakemake once per iteration, so the probe
+# must cost one daemon round trip per process rather than one per resolve.
+def test_daemon_is_probed_at_most_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def counting_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        nonlocal calls
+        calls += 1
+        return subprocess.CompletedProcess(
+            args=["docker"], returncode=0, stdout=json.dumps(ROOTLESS_OPTIONS), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+    assert [resolve_docker_user({}) for _ in range(5)] == [""] * 5
+    assert calls == 1
+
+
+# A typo must name the offending value, because the alternative is a silently rootful run whose only symptom is
+# root-owned outputs, or a silently rootless one that cannot read its inputs.
+@pytest.mark.parametrize("value", ["hosts", "rootless", "", "none", True, None, 0, ["host"]])
+def test_unknown_mode_is_rejected_naming_the_value(value: object) -> None:
+    with pytest.raises(ValueError, match=re.escape(f"config['docker_user'] is {value!r}")):
+        resolve_docker_user({"docker_user": value})

--- a/tests/orchestration/test_docker.py
+++ b/tests/orchestration/test_docker.py
@@ -1,16 +1,16 @@
 """Tests for ``src.utils.docker``.
 
-``resolve_docker_user`` decides whether every stage's container launch carries
-``--user "$(id -u):$(id -g)"``. Getting this wrong does not degrade a run, it stops one
-outright. Passing the flag to a rootless daemon runs the container as an unprivileged
-subuid that cannot read the bind-mounted repo, and the stage reports the resulting
-``EACCES`` as a misleading "file not found" from its own argument parser. Omitting it on
-a rootful daemon leaves every output file root-owned in the user's working tree.
+``resolve_docker_user`` decides which ``--user`` flag every stage's container launch carries.
+Getting this wrong does not degrade a run, it stops one outright. Passing the host uid to a
+rootless runtime runs the container as an unprivileged subuid that cannot read the bind-mounted
+repo, and the stage reports the resulting ``EACCES`` as a misleading "file not found" from its own
+argument parser. Passing container root to a rootful daemon leaves every output file root-owned in
+the user's working tree.
 
-The probe is therefore pinned in both directions, and so is its failure behavior. A dry
-run planning commands on a machine with no Docker is a supported workflow, so an
-unreachable daemon must fall back to the rootful flag rather than raise, which also keeps
-the planned text identical to what it was before detection existed.
+Both runtime schemas are pinned, since the repo supports a rootless podman aliased to ``docker``
+and the two report the mapping in different places. So is the failure behavior. A dry run planning
+commands on a machine with no runtime is a supported workflow, so an unreachable runtime must fall
+back to the rootful flag rather than raise.
 """
 
 from __future__ import annotations
@@ -22,19 +22,14 @@ import subprocess
 import pytest
 
 from src.utils import resolve_docker_user
-from src.utils.docker import HOST_USER_FLAG, _probe_rootless, daemon_is_rootless
+from src.utils.docker import HOST_USER_FLAG, ROOT_USER_FLAG, _probe_daemon
 
-ROOTLESS_OPTIONS = ["name=seccomp,profile=builtin", "name=rootless"]
-ROOTFUL_OPTIONS = ["name=seccomp,profile=builtin", "name=cgroupns"]
-
-
-# The probe is cached for the lifetime of a process, so a test that leaves a result behind would decide the outcome of
-# whichever test ran next.
-@pytest.fixture(autouse=True)
-def _clear_probe_cache() -> None:
-    daemon_is_rootless.cache_clear()
-    yield
-    daemon_is_rootless.cache_clear()
+# Docker reports the user mapping in a SecurityOptions list, Podman under host.security.rootless.
+DOCKER_ROOTLESS = {"SecurityOptions": ["name=seccomp,profile=builtin", "name=rootless"]}
+DOCKER_ROOTFUL = {"SecurityOptions": ["name=seccomp,profile=builtin", "name=cgroupns"]}
+DOCKER_USERNS = {"SecurityOptions": ["name=seccomp,profile=builtin", "name=userns"]}
+PODMAN_ROOTLESS = {"host": {"security": {"rootless": True}}}
+PODMAN_ROOTFUL = {"host": {"security": {"rootless": False}}}
 
 
 def _fake_docker_info(monkeypatch: pytest.MonkeyPatch, stdout: str = "", returncode: int = 0) -> None:
@@ -55,75 +50,71 @@ def _raising_docker_info(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> Non
     monkeypatch.setattr(subprocess, "run", fake_run)
 
 
-# An explicit mode must not consult the daemon at all, so that a user who knows their host can pin the behavior and a
+# An explicit mode must not consult the runtime at all, so that a user who knows their host can pin the behavior and a
 # machine with no Docker can still plan commands. The probe is replaced with one that fails the test if it is reached.
-@pytest.mark.parametrize(("mode", "expected"), [("host", HOST_USER_FLAG), ("root", "")])
-def test_explicit_mode_is_used_without_probing_the_daemon(
+@pytest.mark.parametrize(("mode", "expected"), [("host", HOST_USER_FLAG), ("root", ROOT_USER_FLAG)])
+def test_explicit_mode_is_used_without_probing_the_runtime(
     monkeypatch: pytest.MonkeyPatch, mode: str, expected: str
 ) -> None:
-    _raising_docker_info(monkeypatch, AssertionError("the daemon must not be probed for an explicit mode"))
+    _raising_docker_info(monkeypatch, AssertionError("the runtime must not be probed for an explicit mode"))
     assert resolve_docker_user({"docker_user": mode}) == expected
 
 
 # Case is normalized the way gpu_ids already normalizes "ALL", so a config written in either case resolves the same.
 @pytest.mark.parametrize("mode", ["HOST", " host ", "Root", " ROOT "])
 def test_explicit_mode_ignores_case_and_surrounding_space(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
-    _raising_docker_info(monkeypatch, AssertionError("the daemon must not be probed for an explicit mode"))
-    expected = HOST_USER_FLAG if mode.strip().lower() == "host" else ""
+    _raising_docker_info(monkeypatch, AssertionError("the runtime must not be probed for an explicit mode"))
+    expected = HOST_USER_FLAG if mode.strip().lower() == "host" else ROOT_USER_FLAG
     assert resolve_docker_user({"docker_user": mode}) == expected
 
 
-# The two daemons this exists to tell apart. A rootless daemon already maps the invoking user onto the container's
-# root, so the flag must disappear; a rootful one needs it to keep outputs out of root ownership. An absent key must
-# behave exactly like "auto", because no committed run config carries the key and every one of them must still work.
+# The four runtimes this exists to tell apart. A rootless runtime already maps the invoking user onto container root,
+# so it needs uid 0; a rootful one needs the host uid to keep outputs out of root ownership. Docker and Podman report
+# the same fact in different places, and the repo supports podman aliased to docker. An absent key must behave exactly
+# like "auto", because no committed run config carries the key and every one of them must still work.
 @pytest.mark.parametrize("config", [{}, {"docker_user": "auto"}])
 @pytest.mark.parametrize(
-    ("options", "expected"), [(ROOTLESS_OPTIONS, ""), (ROOTFUL_OPTIONS, HOST_USER_FLAG)]
+    ("info", "expected"),
+    [
+        (DOCKER_ROOTLESS, ROOT_USER_FLAG),
+        (DOCKER_ROOTFUL, HOST_USER_FLAG),
+        (PODMAN_ROOTLESS, ROOT_USER_FLAG),
+        (PODMAN_ROOTFUL, HOST_USER_FLAG),
+    ],
 )
-def test_auto_follows_the_daemon(
-    monkeypatch: pytest.MonkeyPatch, config: dict, options: list[str], expected: str
-) -> None:
-    _fake_docker_info(monkeypatch, stdout=json.dumps(options))
+def test_auto_follows_the_runtime(monkeypatch: pytest.MonkeyPatch, config: dict, info: dict, expected: str) -> None:
+    _fake_docker_info(monkeypatch, stdout=json.dumps(info))
     assert resolve_docker_user(config) == expected
 
 
-# Every way the probe can fail must resolve to the rootful flag rather than raise. That is the behavior the Snakefile
-# had before detection existed, so a machine with no Docker plans exactly the command it always did, and a wedged or
-# unreadable daemon costs a suboptimal flag instead of a broken parse.
+# A rootful daemon with user-namespace remapping maps container uids onto subordinate host uids, so neither container
+# root nor the invoking uid owns the bind mount and no automatic choice is correct. This asserts "auto" refuses at
+# parse time and names the escape hatch rather than planning a run that writes files nobody can read.
+def test_auto_rejects_a_userns_remapped_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_docker_info(monkeypatch, stdout=json.dumps(DOCKER_USERNS))
+    with pytest.raises(ValueError, match="subordinate host uids"):
+        resolve_docker_user({})
+
+
+# Every way the probe can fail must resolve to the rootful flag rather than raise, one case per branch. That is the
+# behavior the Snakefile had before detection existed, so a machine with no runtime plans exactly the command it
+# always did, and a wedged or unreadable runtime costs a suboptimal flag instead of a broken parse.
 @pytest.mark.parametrize(
     ("name", "apply"),
     [
-        ("docker not installed", lambda mp: _raising_docker_info(mp, FileNotFoundError("docker"))),
-        ("daemon unreachable", lambda mp: _fake_docker_info(mp, stdout="", returncode=1)),
-        ("probe timed out", lambda mp: _raising_docker_info(mp, subprocess.TimeoutExpired("docker", 10.0))),
+        ("runtime not installed", lambda mp: _raising_docker_info(mp, FileNotFoundError("docker"))),
+        ("runtime unreachable", lambda mp: _fake_docker_info(mp, stdout="", returncode=1)),
         ("output not json", lambda mp: _fake_docker_info(mp, stdout="not json at all")),
-        ("options not a list", lambda mp: _fake_docker_info(mp, stdout="null")),
-        ("empty output", lambda mp: _fake_docker_info(mp, stdout="")),
+        ("document is not an object", lambda mp: _fake_docker_info(mp, stdout="null")),
+        ("neither schema present", lambda mp: _fake_docker_info(mp, stdout=json.dumps({"ServerVersion": "27.0"}))),
     ],
 )
-def test_unreadable_daemon_falls_back_to_the_rootful_flag(
+def test_unreadable_runtime_falls_back_to_the_host_flag(
     monkeypatch: pytest.MonkeyPatch, name: str, apply: object
 ) -> None:
     apply(monkeypatch)
-    assert _probe_rootless() is False
+    assert _probe_daemon() == "unknown"
     assert resolve_docker_user({"docker_user": "auto"}) == HOST_USER_FLAG
-
-
-# The Snakefile resolves this at parse time and the closed loop re-invokes snakemake once per iteration, so the probe
-# must cost one daemon round trip per process rather than one per resolve.
-def test_daemon_is_probed_at_most_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = 0
-
-    def counting_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
-        nonlocal calls
-        calls += 1
-        return subprocess.CompletedProcess(
-            args=["docker"], returncode=0, stdout=json.dumps(ROOTLESS_OPTIONS), stderr=""
-        )
-
-    monkeypatch.setattr(subprocess, "run", counting_run)
-    assert [resolve_docker_user({}) for _ in range(5)] == [""] * 5
-    assert calls == 1
 
 
 # A typo must name the offending value, because the alternative is a silently rootful run whose only symptom is


### PR DESCRIPTION
Resolves #122

## Summary

* `src/utils/docker.py` (new, exported through `src/utils/__init__.py`): `resolve_docker_user` turns the top-level `docker_user` key into the `--user` fragment of the docker run prefix. `host` emits `--user "$(id -u):$(id -g)"`, `root` emits `--user 0:0`, and `auto` picks between them from the runtime. `_probe_daemon` reads one `docker info --format '{{json .}}'` document and classifies it as rootless, rootful, userns-remapped, or unknown. The value is normalized for case and surrounding space, and anything outside the three modes raises `ValueError` before any job starts.
* `Snakefile`: `DOCKER_PREFIX` calls `resolve_docker_user(config)` instead of hardcoding the flag, so the mode is resolved once at parse time and reaches every stage launch rather than only the first. The comment block collapses to a single purpose line, since the rootless rationale now lives in the module docstring.
* `docs/mvp-pipeline.md`: a new "Container user (rootful and rootless runtimes)" section covers the three modes, the two runtime schemas, the per-invocation `--config docker_user=root` override, the consequence of pinning `root` on a rootful host, userns-remap as unsupported, and the fact that detection describes the planning host. `docker_user` joins the config key list.
* Tests ride in this PR rather than following as a separate one: `tests/orchestration/test_docker.py` covers both runtimes in both directions, the absent key, case and whitespace normalization, one case per probe-failure branch, userns refusal, and malformed value rejection; `tests/e2e/test_dry_run_docker_user.py` asserts the planned command text per mode. 31 cases.

## Design Decisions

### Detecting the runtime rather than asking the config to declare it

Which runtime is running is a property of the execution host, not of a run. Making `docker_user` mandatory would push a host detail into committed run configs, so the same config would stop working when moved between machines. `auto` is therefore the default, and every committed config carries no key at all. Explicit `host` and `root` remain for pinning a known host, and neither consults the runtime.

### One document, both schemas

`docs/mvp-pipeline.md` supports a rootless podman aliased to `docker`, and podman reports rootlessness under `host.security.rootless` rather than in Docker's `SecurityOptions` list. A Docker-only probe would fail to parse under podman, fall back to `host`, and hand a rootless runtime the exact flag this PR exists to remove. Requesting the whole `docker info` document and reading whichever schema is present covers both from a single call.

### Naming container uid 0 explicitly

`root` emits `--user 0:0` rather than omitting the flag. Omitting would depend on the base image defaulting to root, which is upstream metadata this repo does not control, since `stages/Dockerfile` declares no `USER` of its own. Naming the uid keeps the resolved user stable if that ever changes, and under a rootless runtime uid 0 is the invoking host user, so it does not reintroduce the original defect.

### Refusing userns-remap rather than guessing

A rootful daemon with user-namespace remapping maps container uids onto subordinate host uids, so neither container root nor the invoking uid owns the bind mount. No automatic choice is correct, so `auto` raises at parse time and names the escape hatch instead of planning a run whose outputs nobody can read. Pinning `host` or `root` proceeds with the ownership that follows.

### Failure resolves to the rootful flag

Every way the probe can fail, meaning the runtime not installed, unreachable, unparseable, or answering in neither schema, resolves `auto` to `host`. That reproduces exactly the command the Snakefile planned before detection existed, so a dry run on a machine with no runtime still works, which is a supported workflow. Failing toward the more restrictive container user also means the worst case is a broken run on a rootless host rather than an unexpected privilege.

---

**Tested:**

* [x] Full local suite, rebased onto `main` at `818e909`: 406 passed, 0 failed. That is main's 375 plus the 31 new cases, and no pre-existing failure remains at the merge base.
* [x] The new probe classifies a real rootful daemon as `rootful` and resolves `auto` to the host flag, so the schema change is exercised against a live runtime rather than fixtures alone.
* [x] A real `snakemake -n -p --config docker_user=root` plans `docker run --rm --pull=missing --user 0:0 ...` on every launch.
* [x] The e2e tests count flag occurrences against `docker run` occurrences rather than asserting mere presence, so a rule built from a prefix constructed before the mode was resolved is caught rather than passing with a correct-looking plan.
* [x] Scope confirmed at 6 files changed, 364 insertions, 4 deletions, covering one new module, its export, the `DOCKER_PREFIX` construction, the docs section, and two test files. No existing test file is modified.

**Not verified:**

* The Podman branch is tested against a synthetic document matching the documented schema. Podman is not installed on the development machine, so it has never run against a real podman.
* The `name=userns` marker comes from Docker's documentation rather than observation, since no userns-remapped daemon was available. If that string is wrong, `auto` classifies such a daemon as `rootful` and behaves exactly as the code did before this PR, so the failure mode is no worse than today.
